### PR TITLE
[FEAT] Add WhatsApp link admin CRUD endpoints

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -699,10 +699,10 @@ pub async fn delete_whatsapp_link(
     let existing =
         existing.ok_or_else(|| AppError::NotFound(format!("whatsapp link {id} does not exist")))?;
 
+    // Idempotent: if already soft-deleted, return 204 without mutating.
+    // Matches the semantics of `delete_group` / `delete_member`.
     if existing.deleted_at.is_some() {
-        return Err(AppError::NotFound(format!(
-            "whatsapp link {id} does not exist"
-        )));
+        return Ok(StatusCode::NO_CONTENT);
     }
 
     let now = now_iso();

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -9,9 +9,10 @@ use tracing::error;
 use super::auth::AdminToken;
 use crate::api::models::{
     AppError, CreateCycleRequest, CreateGroupRequest, CreateMemberRequest, CreatePaymentRequest,
-    Cycle, CycleContent, DbCycle, DbGroup, DbMember, DbPayment, EntityId, Group, GroupContent,
-    Member, MemberContent, Payment, PaymentContent, UpdateCycleRequest, UpdateGroupRequest,
-    UpdateMemberRequest, now_iso, record_id_to_string,
+    CreateWhatsappLinkRequest, Cycle, CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember,
+    DbPayment, EntityId, Group, GroupContent, GroupLink, GroupLinkContent, Member, MemberContent,
+    Payment, PaymentContent, UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest, now_iso,
+    record_id_to_string,
 };
 use crate::db::{DbConn, reseed};
 
@@ -623,6 +624,96 @@ pub async fn delete_payment(
         };
         let _: Option<DbPayment> = db.upsert(("payment", id.as_str())).content(content).await?;
     }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Admin WhatsApp link handlers ─────────────────────────────────────────────
+
+pub async fn get_whatsapp_links(
+    _auth: AdminToken,
+    State(db): State<DbConn>,
+) -> Result<Json<Vec<GroupLink>>, AppError> {
+    let rows: Vec<DbGroupLink> = db.select("group_link").await?;
+    let links: Vec<GroupLink> = rows
+        .into_iter()
+        .map(GroupLink::from)
+        .filter(|l| l.deleted_at.is_none())
+        .collect();
+    Ok(Json(links))
+}
+
+pub async fn create_whatsapp_link(
+    _auth: AdminToken,
+    State(db): State<DbConn>,
+    Json(body): Json<CreateWhatsappLinkRequest>,
+) -> Result<(StatusCode, Json<GroupLink>), AppError> {
+    body.validate()?;
+
+    let group_id = body.group_id.trim().to_string();
+    let chat_id = body.chat_id.trim().to_string();
+
+    // Verify group exists and is not soft-deleted.
+    let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
+    match &group {
+        None => return Err(AppError::NotFound(format!("group {group_id} does not exist"))),
+        Some(g) if g.deleted_at.is_some() => {
+            return Err(AppError::NotFound(format!("group {group_id} does not exist")));
+        }
+        _ => {}
+    }
+
+    // Enforce 1:1 chat_id uniqueness over live (non-deleted) links.
+    let dupes: Vec<DbGroupLink> = db
+        .query("SELECT * FROM group_link WHERE chat_id = $cid AND deleted_at IS NONE")
+        .bind(("cid", chat_id.clone()))
+        .await?
+        .take(0)?;
+    if !dupes.is_empty() {
+        return Err(AppError::Conflict(
+            "a WhatsApp link already exists for this chatId".into(),
+        ));
+    }
+
+    let now = now_iso();
+    let content = GroupLinkContent {
+        chat_id,
+        group_id,
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+    };
+
+    let created: Option<DbGroupLink> = db.create("group_link").content(content).await?;
+    let created = created.ok_or_else(|| AppError::Internal("whatsapp link was not created".into()))?;
+
+    Ok((StatusCode::CREATED, Json(GroupLink::from(created))))
+}
+
+pub async fn delete_whatsapp_link(
+    _auth: AdminToken,
+    State(db): State<DbConn>,
+    Path(id): Path<EntityId>,
+) -> Result<StatusCode, AppError> {
+    let existing: Option<DbGroupLink> = db.select(("group_link", id.as_str())).await?;
+    let existing =
+        existing.ok_or_else(|| AppError::NotFound(format!("whatsapp link {id} does not exist")))?;
+
+    if existing.deleted_at.is_some() {
+        return Err(AppError::NotFound(format!(
+            "whatsapp link {id} does not exist"
+        )));
+    }
+
+    let now = now_iso();
+    let content = GroupLinkContent {
+        chat_id: existing.chat_id,
+        group_id: existing.group_id,
+        created_at: existing.created_at,
+        updated_at: now.clone(),
+        deleted_at: Some(now),
+    };
+    let _: Option<DbGroupLink> = db.upsert(("group_link", id.as_str())).content(content).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,9 +11,10 @@ use tower_http::cors::CorsLayer;
 
 use crate::db::DbConn;
 use handlers::{
-    create_cycle, create_group, create_member, create_payment, delete_cycle, delete_group,
-    delete_member, delete_payment, get_cycles, get_groups, get_members, get_payments, reset_db,
-    update_cycle, update_group, update_member,
+    create_cycle, create_group, create_member, create_payment, create_whatsapp_link, delete_cycle,
+    delete_group, delete_member, delete_payment, delete_whatsapp_link, get_cycles, get_groups,
+    get_members, get_payments, get_whatsapp_links, reset_db, update_cycle, update_group,
+    update_member,
 };
 
 /// Build the Axum router with all API routes and CORS middleware.
@@ -39,7 +40,11 @@ pub fn router(db: DbConn) -> Router {
         // Admin cycle endpoints
         .route("/api/admin/groups/{gid}/cycles", post(create_cycle))
         .route("/api/admin/cycles/{id}", patch(update_cycle))
-        .route("/api/admin/cycles/{id}", delete(delete_cycle));
+        .route("/api/admin/cycles/{id}", delete(delete_cycle))
+        // Admin WhatsApp link endpoints
+        .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
+        .route("/api/admin/whatsapp-links", post(create_whatsapp_link))
+        .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link));
 
     if std::env::var("APP_ENV").as_deref() != Ok("production") {
         router = router.route("/api/test/reset", post(reset_db));

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -184,6 +184,16 @@ pub struct DbCycle {
 }
 
 #[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbGroupLink {
+    pub id: RecordId,
+    pub chat_id: String,
+    pub group_id: EntityId,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
 pub struct DbPayment {
     pub id: RecordId,
     pub member_id: EntityId,
@@ -296,6 +306,21 @@ pub struct Payment {
     pub deleted_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupLink {
+    pub id: EntityId,
+    #[serde(rename = "chatId")]
+    pub chat_id: String,
+    #[serde(rename = "groupId")]
+    pub group_id: EntityId,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(rename = "deletedAt", skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
 // ── DB-to-API conversions ───────────────────────────────────────────────────
 
 /// Extract the string key from a SurrealDB RecordId.
@@ -385,6 +410,19 @@ impl TryFrom<DbPayment> for Payment {
     }
 }
 
+impl From<DbGroupLink> for GroupLink {
+    fn from(db: DbGroupLink) -> Self {
+        Self {
+            id: record_id_to_string(db.id),
+            chat_id: db.chat_id,
+            group_id: db.group_id,
+            created_at: db.created_at,
+            updated_at: db.updated_at,
+            deleted_at: db.deleted_at,
+        }
+    }
+}
+
 // ── DB-side insert structs (no id — SurrealDB owns the record ID) ───────────
 
 #[derive(Debug, Clone, Serialize, SurrealValue)]
@@ -440,6 +478,15 @@ pub struct PaymentContent {
     pub reference: Option<String>,
     pub confirmed_at: Option<String>,
     pub confirmed_by: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, SurrealValue)]
+pub struct GroupLinkContent {
+    pub chat_id: String,
+    pub group_id: EntityId,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
@@ -727,6 +774,26 @@ impl CreatePaymentRequest {
             return Err(AppError::BadRequest(
                 "paymentDate must be a valid YYYY-MM-DD date".into(),
             ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateWhatsappLinkRequest {
+    #[serde(rename = "chatId")]
+    pub chat_id: String,
+    #[serde(rename = "groupId")]
+    pub group_id: EntityId,
+}
+
+impl CreateWhatsappLinkRequest {
+    pub fn validate(&self) -> Result<(), AppError> {
+        if self.chat_id.trim().is_empty() {
+            return Err(AppError::BadRequest("chatId must not be empty".into()));
+        }
+        if self.group_id.trim().is_empty() {
+            return Err(AppError::BadRequest("groupId must not be empty".into()));
         }
         Ok(())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use surrealdb::engine::local::{Db, RocksDb};
 use tracing::info;
 
 use crate::api::models::{
-    CycleContent, DbCycle, DbGroup, DbMember, DbPayment, GroupContent, MemberContent,
+    CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember, DbPayment, GroupContent, MemberContent,
     PaymentContent,
 };
 
@@ -66,8 +66,14 @@ async fn seed(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     let members: Vec<DbMember> = select_or_empty(db, "member").await?;
     let cycles: Vec<DbCycle> = select_or_empty(db, "cycle").await?;
     let payments: Vec<DbPayment> = select_or_empty(db, "payment").await?;
+    let group_links: Vec<DbGroupLink> = select_or_empty(db, "group_link").await?;
 
-    if !groups.is_empty() || !members.is_empty() || !cycles.is_empty() || !payments.is_empty() {
+    if !groups.is_empty()
+        || !members.is_empty()
+        || !cycles.is_empty()
+        || !payments.is_empty()
+        || !group_links.is_empty()
+    {
         info!("SurrealDB already has data — skipping seed");
         return Ok(());
     }
@@ -93,6 +99,7 @@ pub async fn reseed(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     let _: Vec<DbMember> = db.delete("member").await?;
     let _: Vec<DbCycle> = db.delete("cycle").await?;
     let _: Vec<DbPayment> = db.delete("payment").await?;
+    let _: Vec<DbGroupLink> = db.delete("group_link").await?;
 
     insert_fixtures(db).await?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,6 +18,8 @@ pub async fn init() -> Result<DbConn, surrealdb::Error> {
     let db = Surreal::new::<RocksDb>("./data.surreal").await?;
     db.use_ns("circle").use_db("main").await?;
 
+    define_tables(&db).await?;
+
     if std::env::var("SEED_ON_EMPTY").as_deref() == Ok("true") {
         seed(&db).await?;
     }
@@ -31,8 +33,28 @@ pub async fn init_memory() -> Result<DbConn, surrealdb::Error> {
     use surrealdb::engine::local::Mem;
     let db = Surreal::new::<Mem>(()).await?;
     db.use_ns("circle").use_db("main").await?;
+    define_tables(&db).await?;
     seed(&db).await?;
     Ok(Arc::new(db))
+}
+
+/// Idempotently define every table the application reads from.
+///
+/// In SurrealDB 3, `SELECT` against an undefined table returns an error rather
+/// than an empty result. Tables seeded via `upsert` in `insert_fixtures` are
+/// defined implicitly, but tables that start empty (e.g. `group_link`) must be
+/// declared here so handlers can query them without special-casing.
+async fn define_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
+    db.query(
+        "DEFINE TABLE IF NOT EXISTS group SCHEMALESS;
+         DEFINE TABLE IF NOT EXISTS member SCHEMALESS;
+         DEFINE TABLE IF NOT EXISTS cycle SCHEMALESS;
+         DEFINE TABLE IF NOT EXISTS payment SCHEMALESS;
+         DEFINE TABLE IF NOT EXISTS group_link SCHEMALESS;",
+    )
+    .await?
+    .check()?;
+    Ok(())
 }
 
 /// Seed the database with fixture data.

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -1219,3 +1219,243 @@ async fn conflict_error_has_json_error_field() {
     let body: serde_json::Value = json_body(resp).await;
     assert!(body.get("error").is_some(), "409 must have an 'error' field");
 }
+
+// ── WhatsApp links (admin CRUD) ─────────────────────────────────────────────
+
+fn get_authed(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("authorization", "Bearer test-secret-token")
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_no_auth_returns_401() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        post_json(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000001@g.us", "groupId": "1"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn get_whatsapp_links_no_auth_returns_401() {
+    let app = test_app_with_auth().await;
+    let resp = call(app, get("/api/admin/whatsapp-links")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn delete_whatsapp_link_no_auth_returns_401() {
+    let app = test_app_with_auth().await;
+    let resp = call(app, delete_req("/api/admin/whatsapp-links/xyz")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_returns_201_with_body() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000001@g.us", "groupId": "1"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let link: serde_json::Value = json_body(resp).await;
+    assert!(link.get("id").is_some(), "missing id");
+    assert_eq!(link["chatId"], "2349000000001@g.us");
+    assert_eq!(link["groupId"], "1");
+    assert!(link.get("createdAt").is_some(), "missing createdAt");
+    assert!(link.get("updatedAt").is_some(), "missing updatedAt");
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_missing_group_returns_404() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000001@g.us", "groupId": "999"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_deleted_group_returns_404() {
+    let app = test_app_with_auth().await;
+
+    // Create a group, then soft-delete it.
+    let resp = call(
+        app.clone(),
+        post_json_authed("/api/admin/groups", serde_json::json!({"name": "Doomed"})),
+    )
+    .await;
+    let group: serde_json::Value = json_body(resp).await;
+    let gid = group["id"].as_str().unwrap().to_string();
+    let del = call(
+        app.clone(),
+        delete_req_authed(&format!("/api/admin/groups/{gid}")),
+    )
+    .await;
+    assert_eq!(del.status(), StatusCode::NO_CONTENT);
+
+    let resp = call(
+        app,
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000002@g.us", "groupId": gid}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_duplicate_chat_id_returns_409() {
+    let app = test_app_with_auth().await;
+    let body = serde_json::json!({"chatId": "2349000000003@g.us", "groupId": "1"});
+
+    let first = call(app.clone(), post_json_authed("/api/admin/whatsapp-links", body.clone())).await;
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let second = call(app, post_json_authed("/api/admin/whatsapp-links", body)).await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_empty_chat_id_returns_400() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "   ", "groupId": "1"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_whatsapp_link_empty_group_id_returns_400() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000004@g.us", "groupId": ""}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_whatsapp_links_returns_200_empty_on_fresh_db() {
+    let app = test_app_with_auth().await;
+    let resp = call(app, get_authed("/api/admin/whatsapp-links")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let links: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(links.len(), 0);
+}
+
+#[tokio::test]
+async fn get_whatsapp_links_excludes_soft_deleted() {
+    let app = test_app_with_auth().await;
+
+    let created = call(
+        app.clone(),
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000005@g.us", "groupId": "1"}),
+        ),
+    )
+    .await;
+    let link: serde_json::Value = json_body(created).await;
+    let id = link["id"].as_str().unwrap().to_string();
+
+    let before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get_authed("/api/admin/whatsapp-links")).await).await;
+    assert_eq!(before.len(), 1);
+
+    let del = call(
+        app.clone(),
+        delete_req_authed(&format!("/api/admin/whatsapp-links/{id}")),
+    )
+    .await;
+    assert_eq!(del.status(), StatusCode::NO_CONTENT);
+
+    let after: Vec<serde_json::Value> =
+        json_body(call(app, get_authed("/api/admin/whatsapp-links")).await).await;
+    assert_eq!(after.len(), 0, "soft-deleted links must be excluded");
+}
+
+#[tokio::test]
+async fn delete_whatsapp_link_returns_204() {
+    let app = test_app_with_auth().await;
+    let created = call(
+        app.clone(),
+        post_json_authed(
+            "/api/admin/whatsapp-links",
+            serde_json::json!({"chatId": "2349000000006@g.us", "groupId": "1"}),
+        ),
+    )
+    .await;
+    let link: serde_json::Value = json_body(created).await;
+    let id = link["id"].as_str().unwrap().to_string();
+
+    let resp = call(
+        app,
+        delete_req_authed(&format!("/api/admin/whatsapp-links/{id}")),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn delete_whatsapp_link_nonexistent_returns_404() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        delete_req_authed("/api/admin/whatsapp-links/does-not-exist"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_whatsapp_link_allows_relinking_same_chat_id() {
+    let app = test_app_with_auth().await;
+    let body = serde_json::json!({"chatId": "2349000000007@g.us", "groupId": "1"});
+
+    let first = call(
+        app.clone(),
+        post_json_authed("/api/admin/whatsapp-links", body.clone()),
+    )
+    .await;
+    let link: serde_json::Value = json_body(first).await;
+    let id = link["id"].as_str().unwrap().to_string();
+
+    call(
+        app.clone(),
+        delete_req_authed(&format!("/api/admin/whatsapp-links/{id}")),
+    )
+    .await;
+
+    // Recreate the same chat_id — should succeed because previous row is soft-deleted.
+    let second = call(app, post_json_authed("/api/admin/whatsapp-links", body)).await;
+    assert_eq!(second.status(), StatusCode::CREATED);
+}


### PR DESCRIPTION
## Summary

Thin-slice first PR for **Plan 2 — WhatsApp Integration** ([scoping doc](https://github.com/Sensei3k/poolpay-api) §5). Introduces the `WhatsappLink` entity and three admin routes so the dashboard can map Green API chat IDs onto PoolPay groups.

- New entity `WhatsappLink` via the three-struct pattern (`DbGroupLink` / `GroupLinkContent` / `GroupLink`)
- `GET` / `POST` / `DELETE /api/admin/whatsapp-links[/{id}]` — all admin-gated
- 1:1 `chat_id` uniqueness over live (non-soft-deleted) rows — a link can be removed and the same `chat_id` relinked
- `DEFINE TABLE IF NOT EXISTS` added at startup for all tables (idiomatic fix for SurrealDB 3's "undefined table" SELECT behaviour; replaces per-handler error swallowing)

**Non-goals** (deferred to follow-up PRs per scoping doc): no Receipt table, no pipeline changes, no quoted reply helper, no `parse_amount_to_kobo`, no confirm/reject endpoints.

## Test plan

- [x] `cargo test` — 120/120 green (89 integration incl. 14 new WhatsApp tests, 28 parser, 3 lib)
- [x] `cargo clippy` — no new lints introduced
- [ ] Reviewer: spot-check route shapes against existing admin CRUD patterns (Group/Member/Cycle)
- [ ] Reviewer: confirm `DEFINE TABLE IF NOT EXISTS` approach over the previous implicit-via-upsert behaviour

## Follow-up PRs (planned order)

1. Receipt entity + read-only `GET /api/receipts`
2. `parse_amount_to_kobo()` parser helper
3. `send_quoted_reply()` + receipt-flow module wired into the poll loop
4. Admin `/receipts/{id}/confirm` and `/reject` — completes the loop