### PR TITLE
[FEAT] - Add Receipt entity and read-only GET /api/receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ data.surreal/
 # Rust coverage reports
 tarpaulin-report.html
 lcov.info
+
+# Personal brain-sync state (not for sharing)
+.brain-sync

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -10,9 +10,9 @@ use super::auth::AdminToken;
 use crate::api::models::{
     AppError, CreateCycleRequest, CreateGroupRequest, CreateMemberRequest, CreatePaymentRequest,
     CreateWhatsappLinkRequest, Cycle, CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember,
-    DbPayment, EntityId, Group, GroupContent, GroupLink, GroupLinkContent, Member, MemberContent,
-    Payment, PaymentContent, UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest, now_iso,
-    record_id_to_string,
+    DbPayment, DbReceipt, EntityId, Group, GroupContent, GroupLink, GroupLinkContent, Member,
+    MemberContent, Payment, PaymentContent, Receipt, ReceiptStatus, UpdateCycleRequest,
+    UpdateGroupRequest, UpdateMemberRequest, now_iso, record_id_to_string,
 };
 use crate::db::{DbConn, reseed};
 
@@ -28,6 +28,13 @@ pub struct GroupIdQuery {
 pub struct PaymentsQuery {
     #[serde(rename = "cycleId")]
     pub cycle_id: Option<EntityId>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReceiptsQuery {
+    #[serde(rename = "groupId")]
+    pub group_id: Option<EntityId>,
+    pub status: Option<String>,
 }
 
 // ── Public GET handlers ──────────────────────────────────────────────────────
@@ -89,6 +96,32 @@ pub async fn get_payments(
         .into_iter()
         .filter(|p| p.deleted_at.is_none())
         .filter(|p| params.cycle_id.as_ref().map_or(true, |cid| p.cycle_id == *cid))
+        .collect();
+
+    Ok(Json(filtered))
+}
+
+pub async fn get_receipts(
+    State(db): State<DbConn>,
+    Query(params): Query<ReceiptsQuery>,
+) -> Result<Json<Vec<Receipt>>, AppError> {
+    // Validate status filter up-front so an unknown value returns 400 rather
+    // than silently producing an empty list.
+    let status_filter: Option<ReceiptStatus> = match params.status.as_deref() {
+        None => None,
+        Some(s) => Some(s.parse::<ReceiptStatus>().map_err(AppError::BadRequest)?),
+    };
+
+    let rows: Vec<DbReceipt> = db.select("receipt").await?;
+    let receipts: Result<Vec<Receipt>, AppError> =
+        rows.into_iter().map(Receipt::try_from).collect();
+    let receipts = receipts?;
+
+    let filtered: Vec<Receipt> = receipts
+        .into_iter()
+        .filter(|r| r.deleted_at.is_none())
+        .filter(|r| params.group_id.as_ref().is_none_or(|gid| r.group_id == *gid))
+        .filter(|r| status_filter.as_ref().is_none_or(|s| r.status == *s))
         .collect();
 
     Ok(Json(filtered))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,8 +13,8 @@ use crate::db::DbConn;
 use handlers::{
     create_cycle, create_group, create_member, create_payment, create_whatsapp_link, delete_cycle,
     delete_group, delete_member, delete_payment, delete_whatsapp_link, get_cycles, get_groups,
-    get_members, get_payments, get_whatsapp_links, reset_db, update_cycle, update_group,
-    update_member,
+    get_members, get_payments, get_receipts, get_whatsapp_links, reset_db, update_cycle,
+    update_group, update_member,
 };
 
 /// Build the Axum router with all API routes and CORS middleware.
@@ -29,6 +29,7 @@ pub fn router(db: DbConn) -> Router {
         .route("/api/payments", get(get_payments))
         .route("/api/payments", post(create_payment))
         .route("/api/payments/{member_id}/{cycle_id}", delete(delete_payment))
+        .route("/api/receipts", get(get_receipts))
         // Admin group endpoints
         .route("/api/admin/groups", post(create_group))
         .route("/api/admin/groups/{id}", patch(update_group))

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -112,6 +112,26 @@ impl std::str::FromStr for CycleStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReceiptStatus {
+    Pending,
+    Confirmed,
+    Rejected,
+}
+
+impl std::str::FromStr for ReceiptStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "confirmed" => Ok(Self::Confirmed),
+            "rejected" => Ok(Self::Rejected),
+            _ => Err(format!("unknown receipt status: {s}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Currency {
     NGN,
 }
@@ -181,6 +201,28 @@ pub struct DbCycle {
     pub created_at: String,
     pub updated_at: String,
     pub version: i64,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbReceipt {
+    pub id: RecordId,
+    pub whatsapp_message_id: String,
+    pub group_id: EntityId,
+    pub chat_id: String,
+    pub sender_phone: String,
+    pub member_id: Option<EntityId>,
+    pub cycle_id: Option<EntityId>,
+    pub extracted_amount: Option<i64>,
+    pub expected_amount: Option<i64>,
+    pub amount_matches: Option<bool>,
+    pub status: String,
+    pub ocr_text: Option<String>,
+    pub sender_label: Option<String>,
+    pub bank_label: Option<String>,
+    pub received_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize, SurrealValue)]
@@ -307,6 +349,44 @@ pub struct Payment {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Receipt {
+    pub id: EntityId,
+    #[serde(rename = "whatsappMessageId")]
+    pub whatsapp_message_id: String,
+    #[serde(rename = "groupId")]
+    pub group_id: EntityId,
+    #[serde(rename = "chatId")]
+    pub chat_id: String,
+    #[serde(rename = "senderPhone")]
+    pub sender_phone: String,
+    #[serde(rename = "memberId", skip_serializing_if = "Option::is_none")]
+    pub member_id: Option<EntityId>,
+    #[serde(rename = "cycleId", skip_serializing_if = "Option::is_none")]
+    pub cycle_id: Option<EntityId>,
+    #[serde(rename = "extractedAmount", skip_serializing_if = "Option::is_none")]
+    pub extracted_amount: Option<i64>,
+    #[serde(rename = "expectedAmount", skip_serializing_if = "Option::is_none")]
+    pub expected_amount: Option<i64>,
+    #[serde(rename = "amountMatches", skip_serializing_if = "Option::is_none")]
+    pub amount_matches: Option<bool>,
+    pub status: ReceiptStatus,
+    #[serde(rename = "ocrText", skip_serializing_if = "Option::is_none")]
+    pub ocr_text: Option<String>,
+    #[serde(rename = "senderLabel", skip_serializing_if = "Option::is_none")]
+    pub sender_label: Option<String>,
+    #[serde(rename = "bankLabel", skip_serializing_if = "Option::is_none")]
+    pub bank_label: Option<String>,
+    #[serde(rename = "receivedAt")]
+    pub received_at: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(rename = "deletedAt", skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupLink {
     pub id: EntityId,
     #[serde(rename = "chatId")]
@@ -410,6 +490,32 @@ impl TryFrom<DbPayment> for Payment {
     }
 }
 
+impl TryFrom<DbReceipt> for Receipt {
+    type Error = AppError;
+    fn try_from(db: DbReceipt) -> Result<Self, AppError> {
+        Ok(Self {
+            id: record_id_to_string(db.id),
+            whatsapp_message_id: db.whatsapp_message_id,
+            group_id: db.group_id,
+            chat_id: db.chat_id,
+            sender_phone: db.sender_phone,
+            member_id: db.member_id,
+            cycle_id: db.cycle_id,
+            extracted_amount: db.extracted_amount,
+            expected_amount: db.expected_amount,
+            amount_matches: db.amount_matches,
+            status: db.status.parse().map_err(|e: String| AppError::Internal(e))?,
+            ocr_text: db.ocr_text,
+            sender_label: db.sender_label,
+            bank_label: db.bank_label,
+            received_at: db.received_at,
+            created_at: db.created_at,
+            updated_at: db.updated_at,
+            deleted_at: db.deleted_at,
+        })
+    }
+}
+
 impl From<DbGroupLink> for GroupLink {
     fn from(db: DbGroupLink) -> Self {
         Self {
@@ -478,6 +584,27 @@ pub struct PaymentContent {
     pub reference: Option<String>,
     pub confirmed_at: Option<String>,
     pub confirmed_by: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, SurrealValue)]
+pub struct ReceiptContent {
+    pub whatsapp_message_id: String,
+    pub group_id: EntityId,
+    pub chat_id: String,
+    pub sender_phone: String,
+    pub member_id: Option<EntityId>,
+    pub cycle_id: Option<EntityId>,
+    pub extracted_amount: Option<i64>,
+    pub expected_amount: Option<i64>,
+    pub amount_matches: Option<bool>,
+    pub status: String,
+    pub ocr_text: Option<String>,
+    pub sender_label: Option<String>,
+    pub bank_label: Option<String>,
+    pub received_at: String,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,8 +5,8 @@ use surrealdb::engine::local::{Db, RocksDb};
 use tracing::info;
 
 use crate::api::models::{
-    CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember, DbPayment, GroupContent, MemberContent,
-    PaymentContent,
+    CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember, DbPayment, DbReceipt, GroupContent,
+    MemberContent, PaymentContent, ReceiptContent,
 };
 
 /// The shared SurrealDB connection type — passed as Axum state.
@@ -50,7 +50,8 @@ async fn define_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
          DEFINE TABLE IF NOT EXISTS member SCHEMALESS;
          DEFINE TABLE IF NOT EXISTS cycle SCHEMALESS;
          DEFINE TABLE IF NOT EXISTS payment SCHEMALESS;
-         DEFINE TABLE IF NOT EXISTS group_link SCHEMALESS;",
+         DEFINE TABLE IF NOT EXISTS group_link SCHEMALESS;
+         DEFINE TABLE IF NOT EXISTS receipt SCHEMALESS;",
     )
     .await?
     .check()?;
@@ -67,12 +68,14 @@ async fn seed(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     let cycles: Vec<DbCycle> = select_or_empty(db, "cycle").await?;
     let payments: Vec<DbPayment> = select_or_empty(db, "payment").await?;
     let group_links: Vec<DbGroupLink> = select_or_empty(db, "group_link").await?;
+    let receipts: Vec<DbReceipt> = select_or_empty(db, "receipt").await?;
 
     if !groups.is_empty()
         || !members.is_empty()
         || !cycles.is_empty()
         || !payments.is_empty()
         || !group_links.is_empty()
+        || !receipts.is_empty()
     {
         info!("SurrealDB already has data — skipping seed");
         return Ok(());
@@ -80,13 +83,14 @@ async fn seed(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
 
     info!("Seeding SurrealDB with fixture data");
     insert_fixtures(db).await?;
-    let (g, m, c, p) = (
+    let (g, m, c, p, r) = (
         fixture_groups().len(),
         fixture_members().len(),
         fixture_cycles().len(),
         fixture_payments().len(),
+        fixture_receipts().len(),
     );
-    info!("Seed complete: {g} groups, {m} members, {c} cycles, {p} payments");
+    info!("Seed complete: {g} groups, {m} members, {c} cycles, {p} payments, {r} receipts");
     Ok(())
 }
 
@@ -100,16 +104,20 @@ pub async fn reseed(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     let _: Vec<DbCycle> = db.delete("cycle").await?;
     let _: Vec<DbPayment> = db.delete("payment").await?;
     let _: Vec<DbGroupLink> = db.delete("group_link").await?;
+    let _: Vec<DbReceipt> = db.delete("receipt").await?;
 
     insert_fixtures(db).await?;
 
-    let (g, m, c, p) = (
+    let (g, m, c, p, r) = (
         fixture_groups().len(),
         fixture_members().len(),
         fixture_cycles().len(),
         fixture_payments().len(),
+        fixture_receipts().len(),
     );
-    info!("Reseed complete: {g} groups, {m} members, {c} cycles, {p} payments restored");
+    info!(
+        "Reseed complete: {g} groups, {m} members, {c} cycles, {p} payments, {r} receipts restored"
+    );
     Ok(())
 }
 
@@ -126,6 +134,9 @@ async fn insert_fixtures(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     }
     for (id, content) in fixture_payments() {
         let _: Option<DbPayment> = db.upsert(("payment", id)).content(content).await?;
+    }
+    for (id, content) in fixture_receipts() {
+        let _: Option<DbReceipt> = db.upsert(("receipt", id)).content(content).await?;
     }
     Ok(())
 }
@@ -308,5 +319,60 @@ fn fixture_payments() -> Vec<(&'static str, PaymentContent)> {
         ("48", payment("4", "9", "2025-12-06")),
         ("49", payment("5", "9", "2025-12-07")),
         ("50", payment("6", "9", "2025-12-09")),
+    ]
+}
+
+/// Two fixture receipts against the active cycle (9) — one pending (awaiting
+/// admin review) and one soft-deleted (to verify list filtering). The real
+/// pipeline will write these via Green API polling; until then the fixtures
+/// give the dashboard something to render.
+fn fixture_receipts() -> Vec<(&'static str, ReceiptContent)> {
+    let created_at = "2026-03-02T10:30:00+00:00";
+    let group_id = FIXTURE_GROUP_ID.to_string();
+    vec![
+        (
+            "1",
+            ReceiptContent {
+                whatsapp_message_id: "3EB0C123ABCD4567EF89".into(),
+                group_id: group_id.clone(),
+                chat_id: "2349000000001@g.us".into(),
+                sender_phone: "2348101234567".into(),
+                member_id: Some("1".into()),
+                cycle_id: Some("3".into()),
+                extracted_amount: Some(1_000_000),
+                expected_amount: Some(1_000_000),
+                amount_matches: Some(true),
+                status: "pending".into(),
+                ocr_text: Some("NGN 10,000.00\nFrom: Adaeze Okonkwo\nBank: GTBank".into()),
+                sender_label: Some("Adaeze Okonkwo".into()),
+                bank_label: Some("GTBank".into()),
+                received_at: "2026-03-02T10:29:45+00:00".into(),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+            },
+        ),
+        (
+            "2",
+            ReceiptContent {
+                whatsapp_message_id: "3EB0C9876FEDC543210".into(),
+                group_id,
+                chat_id: "2349000000001@g.us".into(),
+                sender_phone: "2347031234567".into(),
+                member_id: Some("2".into()),
+                cycle_id: Some("3".into()),
+                extracted_amount: Some(500_000),
+                expected_amount: Some(1_000_000),
+                amount_matches: Some(false),
+                status: "rejected".into(),
+                ocr_text: Some("NGN 5,000.00\nFrom: Chukwuemeka Eze".into()),
+                sender_label: Some("Chukwuemeka Eze".into()),
+                bank_label: None,
+                received_at: "2026-03-03T14:15:00+00:00".into(),
+                created_at: "2026-03-03T14:15:30+00:00".into(),
+                updated_at: "2026-03-03T16:00:00+00:00".into(),
+                deleted_at: Some("2026-03-03T16:00:00+00:00".into()),
+            },
+        ),
     ]
 }

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -1459,3 +1459,104 @@ async fn delete_whatsapp_link_allows_relinking_same_chat_id() {
     let second = call(app, post_json_authed("/api/admin/whatsapp-links", body)).await;
     assert_eq!(second.status(), StatusCode::CREATED);
 }
+
+// ── GET /api/receipts ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_receipts_returns_200() {
+    let resp = call(test_app().await, get("/api/receipts")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_receipts_no_auth_header_is_public() {
+    // No Authorization header — endpoint must still succeed (public read).
+    let resp = call(test_app().await, get("/api/receipts")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_receipts_returns_seeded_fixtures() {
+    let resp = call(test_app().await, get("/api/receipts")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert!(
+        !receipts.is_empty(),
+        "expected at least one seeded receipt fixture"
+    );
+}
+
+#[tokio::test]
+async fn get_receipts_response_shape() {
+    let resp = call(test_app().await, get("/api/receipts")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    let r = &receipts[0];
+    for field in [
+        "id",
+        "whatsappMessageId",
+        "groupId",
+        "chatId",
+        "senderPhone",
+        "status",
+        "receivedAt",
+        "createdAt",
+        "updatedAt",
+    ] {
+        assert!(r.get(field).is_some(), "missing field: {field}");
+    }
+}
+
+#[tokio::test]
+async fn get_receipts_filter_by_group_id() {
+    let app = test_app().await;
+    let resp = call(app, get("/api/receipts?groupId=1")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert!(receipts.iter().all(|r| r["groupId"] == "1"));
+}
+
+#[tokio::test]
+async fn get_receipts_filter_by_group_id_unknown_returns_empty() {
+    let app = test_app().await;
+    let resp = call(app, get("/api/receipts?groupId=does-not-exist")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(receipts.len(), 0);
+}
+
+#[tokio::test]
+async fn get_receipts_filter_by_status_pending() {
+    let app = test_app().await;
+    let resp = call(app, get("/api/receipts?status=pending")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert!(receipts.iter().all(|r| r["status"] == "pending"));
+}
+
+#[tokio::test]
+async fn get_receipts_invalid_status_returns_400() {
+    let app = test_app().await;
+    let resp = call(app, get("/api/receipts?status=weird")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_receipts_excludes_soft_deleted() {
+    // At least one fixture receipt has deleted_at set — ensure it's filtered out.
+    let app = test_app().await;
+    let resp = call(app, get("/api/receipts")).await;
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert!(
+        receipts.iter().all(|r| r.get("deletedAt").is_none()
+            || r["deletedAt"].is_null()),
+        "soft-deleted receipts must not be returned"
+    );
+}
+
+#[tokio::test]
+async fn reset_restores_receipts_to_fixture_count() {
+    let app = test_app().await;
+    let before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get("/api/receipts")).await).await;
+    let baseline = before.len();
+    call(app.clone(), post_empty("/api/test/reset")).await;
+    let after: Vec<serde_json::Value> =
+        json_body(call(app, get("/api/receipts")).await).await;
+    assert_eq!(after.len(), baseline);
+}


### PR DESCRIPTION
## Summary
- Adds `Receipt` entity (three-struct pattern: `DbReceipt` / `ReceiptContent` / `Receipt`) with `ReceiptStatus` enum (pending/confirmed/rejected).
- Adds public `GET /api/receipts` with optional `groupId` and `status` filters; invalid status returns 400.
- Defines `receipt` table proactively in `db.rs` and seeds 2 fixtures (one pending/matched, one soft-deleted rejected).
- Folds in `.gitignore` rule for personal `.brain-sync` state file.

This is PR 2 of Plan 2 (WhatsApp Integration). The endpoint is read-only; the pipeline that writes receipts lands in PR 4.

## Test plan
- [x] `cargo test` — 130 tests pass (3 lib + 99 integration + 28 parser)
- [x] `cargo clippy --all-targets` clean on new code
- [x] 10 new integration tests covering 200/shape/filters/400/soft-delete/reset