### PR TITLE
[FEAT] Receipt-routing helpers for WhatsApp ingestion

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -164,9 +164,9 @@ const FIXTURE_GROUP_ID: &str = "1";
 fn fixture_groups() -> Vec<(&'static str, GroupContent)> {
     vec![
         (FIXTURE_GROUP_ID, GroupContent {
-            name: "Ajo Circle Alpha".into(),
+            name: "PoolPay Group Alpha".into(),
             status: "active".into(),
-            description: Some("First Ajo savings circle — 6 members, ₦10k monthly".into()),
+            description: Some("First PoolPay savings group — 6 members, ₦10k monthly".into()),
             created_at: "2025-06-15T00:00:00+00:00".into(),
             updated_at: "2025-06-15T00:00:00+00:00".into(),
             deleted_at: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod db;
 pub mod extractor;
 pub mod models;
 pub mod parser;
+pub mod routing;
 pub mod whatsapp;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -31,7 +31,10 @@ pub async fn find_group_by_chat_id(
     Ok(group.filter(|g| g.deleted_at.is_none()))
 }
 
-/// Find the active member in `group_id` whose stored phone matches `phone`.
+/// Find a live (non-soft-deleted) member in `group_id` whose stored phone
+/// matches `phone`. Member `status` is not constrained, so inactive members
+/// still match — callers that need to exclude inactive members must filter
+/// on the returned row themselves.
 ///
 /// Phone comparison is exact; canonicalisation is the caller's job, since
 /// WhatsApp delivers numbers as raw E.164-style digits and admin input is
@@ -57,9 +60,10 @@ pub async fn find_member_by_phone(
 /// Return the single active cycle for `group_id`, if one exists.
 ///
 /// Cycles do not carry `deleted_at`, but only one cycle per group should
-/// hold `status = 'active'` at a time. If the invariant is violated this
-/// returns the first row deterministically — the caller is expected to
-/// surface the inconsistency separately.
+/// hold `status = 'active'` at a time. The query is ordered by
+/// `cycle_number` ascending so that, if the invariant is violated, the
+/// lowest-numbered active cycle is returned deterministically — the
+/// caller is expected to surface the inconsistency separately.
 pub async fn find_active_cycle(
     db: &DbConn,
     group_id: &EntityId,
@@ -67,7 +71,8 @@ pub async fn find_active_cycle(
     let rows: Vec<DbCycle> = db
         .query(
             "SELECT * FROM cycle \
-             WHERE group_id = $gid AND status = 'active' LIMIT 1",
+             WHERE group_id = $gid AND status = 'active' \
+             ORDER BY cycle_number ASC LIMIT 1",
         )
         .bind(("gid", group_id.clone()))
         .await?

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,98 @@
+//! Receipt-routing helpers used by the WhatsApp ingestion pipeline.
+//!
+//! These functions translate facts about an incoming WhatsApp message
+//! (chat id, sender phone, message id) into the PoolPay entities the
+//! pipeline needs (group, member, active cycle, prior receipt). They are
+//! pure DB lookups — no Green API or HTTP dependencies — so the pipeline
+//! can be assembled and tested in isolation.
+
+use crate::api::models::{AppError, DbCycle, DbGroup, DbGroupLink, DbMember, DbReceipt, EntityId};
+use crate::db::DbConn;
+
+/// Resolve an incoming WhatsApp `chat_id` to its linked PoolPay group.
+///
+/// Returns `None` when no live link exists for the chat, the link points
+/// at a non-existent group, or the linked group has been soft-deleted.
+pub async fn find_group_by_chat_id(
+    db: &DbConn,
+    chat_id: &str,
+) -> Result<Option<DbGroup>, AppError> {
+    let links: Vec<DbGroupLink> = db
+        .query("SELECT * FROM group_link WHERE chat_id = $cid AND deleted_at IS NONE LIMIT 1")
+        .bind(("cid", chat_id.to_string()))
+        .await?
+        .take(0)?;
+
+    let Some(link) = links.into_iter().next() else {
+        return Ok(None);
+    };
+
+    let group: Option<DbGroup> = db.select(("group", link.group_id.as_str())).await?;
+    Ok(group.filter(|g| g.deleted_at.is_none()))
+}
+
+/// Find the active member in `group_id` whose stored phone matches `phone`.
+///
+/// Phone comparison is exact; canonicalisation is the caller's job, since
+/// WhatsApp delivers numbers as raw E.164-style digits and admin input is
+/// already trimmed when stored.
+pub async fn find_member_by_phone(
+    db: &DbConn,
+    group_id: &EntityId,
+    phone: &str,
+) -> Result<Option<DbMember>, AppError> {
+    let rows: Vec<DbMember> = db
+        .query(
+            "SELECT * FROM member \
+             WHERE group_id = $gid AND phone = $phone AND deleted_at IS NONE LIMIT 1",
+        )
+        .bind(("gid", group_id.clone()))
+        .bind(("phone", phone.to_string()))
+        .await?
+        .take(0)?;
+
+    Ok(rows.into_iter().next())
+}
+
+/// Return the single active cycle for `group_id`, if one exists.
+///
+/// Cycles do not carry `deleted_at`, but only one cycle per group should
+/// hold `status = 'active'` at a time. If the invariant is violated this
+/// returns the first row deterministically — the caller is expected to
+/// surface the inconsistency separately.
+pub async fn find_active_cycle(
+    db: &DbConn,
+    group_id: &EntityId,
+) -> Result<Option<DbCycle>, AppError> {
+    let rows: Vec<DbCycle> = db
+        .query(
+            "SELECT * FROM cycle \
+             WHERE group_id = $gid AND status = 'active' LIMIT 1",
+        )
+        .bind(("gid", group_id.clone()))
+        .await?
+        .take(0)?;
+
+    Ok(rows.into_iter().next())
+}
+
+/// Look up a previously ingested receipt by its WhatsApp message id.
+///
+/// Soft-deleted rows are excluded so a re-ingestion after admin cleanup
+/// is not blocked by a tombstone. Confirmed and rejected rows still
+/// count as duplicates: the pipeline should refuse to re-process them.
+pub async fn find_receipt_by_message_id(
+    db: &DbConn,
+    whatsapp_message_id: &str,
+) -> Result<Option<DbReceipt>, AppError> {
+    let rows: Vec<DbReceipt> = db
+        .query(
+            "SELECT * FROM receipt \
+             WHERE whatsapp_message_id = $mid AND deleted_at IS NONE LIMIT 1",
+        )
+        .bind(("mid", whatsapp_message_id.to_string()))
+        .await?
+        .take(0)?;
+
+    Ok(rows.into_iter().next())
+}

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -173,7 +173,7 @@ async fn get_groups_returns_seeded_group() {
     let resp = call(test_app().await, get("/api/groups")).await;
     let groups: Vec<serde_json::Value> = json_body(resp).await;
     assert_eq!(groups.len(), 1);
-    assert_eq!(groups[0]["name"], "Ajo Circle Alpha");
+    assert_eq!(groups[0]["name"], "PoolPay Group Alpha");
 }
 
 #[tokio::test]

--- a/tests/routing_integration.rs
+++ b/tests/routing_integration.rs
@@ -48,7 +48,7 @@ async fn group_by_chat_id_returns_group_when_linked() {
     seed_link(&db, FIXTURE_CHAT_ID, FIXTURE_GROUP_ID).await;
     let g = find_group_by_chat_id(&db, FIXTURE_CHAT_ID).await.unwrap();
     let g = g.expect("expected group lookup to succeed");
-    assert_eq!(g.name, "Ajo Circle Alpha");
+    assert_eq!(g.name, "PoolPay Group Alpha");
 }
 
 #[tokio::test]

--- a/tests/routing_integration.rs
+++ b/tests/routing_integration.rs
@@ -20,7 +20,7 @@ async fn fresh_db() -> DbConn {
 
 async fn seed_link(db: &DbConn, chat_id: &str, group_id: &str) {
     let now = now_iso();
-    let _: Option<DbGroupLink> = db
+    let created: Option<DbGroupLink> = db
         .create("group_link")
         .content(GroupLinkContent {
             chat_id: chat_id.into(),
@@ -31,6 +31,7 @@ async fn seed_link(db: &DbConn, chat_id: &str, group_id: &str) {
         })
         .await
         .expect("seed link failed");
+    assert!(created.is_some(), "group_link insert returned None");
 }
 
 // ── find_group_by_chat_id ────────────────────────────────────────────────────
@@ -103,9 +104,9 @@ async fn member_by_phone_returns_none_for_unknown_phone() {
 }
 
 #[tokio::test]
-async fn member_by_phone_scoped_to_group() {
-    // Same phone but a different group id must return None even though the
-    // member exists in another group.
+async fn member_by_phone_returns_none_for_unknown_group() {
+    // A phone that matches a fixture member must not resolve when the
+    // supplied group_id does not exist — the query is group-scoped.
     let db = fresh_db().await;
     let other: EntityId = "does-not-exist".into();
     let m = find_member_by_phone(&db, &other, "2348101234567")

--- a/tests/routing_integration.rs
+++ b/tests/routing_integration.rs
@@ -1,0 +1,165 @@
+//! Integration tests for the receipt-routing helpers.
+//!
+//! These tests exercise `src/routing.rs` directly against a fresh
+//! in-memory SurrealDB seeded with the standard fixtures. They do not
+//! go through the Axum router, so they isolate query behaviour from
+//! handler/auth concerns.
+
+use poolpay::api::models::{DbGroupLink, EntityId, GroupLinkContent, now_iso};
+use poolpay::db::{self, DbConn};
+use poolpay::routing::{
+    find_active_cycle, find_group_by_chat_id, find_member_by_phone, find_receipt_by_message_id,
+};
+
+const FIXTURE_GROUP_ID: &str = "1";
+const FIXTURE_CHAT_ID: &str = "2349000000001@g.us";
+
+async fn fresh_db() -> DbConn {
+    db::init_memory().await.expect("failed to init test DB")
+}
+
+async fn seed_link(db: &DbConn, chat_id: &str, group_id: &str) {
+    let now = now_iso();
+    let _: Option<DbGroupLink> = db
+        .create("group_link")
+        .content(GroupLinkContent {
+            chat_id: chat_id.into(),
+            group_id: group_id.into(),
+            created_at: now.clone(),
+            updated_at: now,
+            deleted_at: None,
+        })
+        .await
+        .expect("seed link failed");
+}
+
+// ── find_group_by_chat_id ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn group_by_chat_id_returns_none_when_no_link() {
+    let db = fresh_db().await;
+    let g = find_group_by_chat_id(&db, FIXTURE_CHAT_ID).await.unwrap();
+    assert!(g.is_none());
+}
+
+#[tokio::test]
+async fn group_by_chat_id_returns_group_when_linked() {
+    let db = fresh_db().await;
+    seed_link(&db, FIXTURE_CHAT_ID, FIXTURE_GROUP_ID).await;
+    let g = find_group_by_chat_id(&db, FIXTURE_CHAT_ID).await.unwrap();
+    let g = g.expect("expected group lookup to succeed");
+    assert_eq!(g.name, "Ajo Circle Alpha");
+}
+
+#[tokio::test]
+async fn group_by_chat_id_ignores_soft_deleted_link() {
+    let db = fresh_db().await;
+    let now = now_iso();
+    let _: Option<DbGroupLink> = db
+        .create("group_link")
+        .content(GroupLinkContent {
+            chat_id: FIXTURE_CHAT_ID.into(),
+            group_id: FIXTURE_GROUP_ID.into(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            deleted_at: Some(now),
+        })
+        .await
+        .unwrap();
+
+    let g = find_group_by_chat_id(&db, FIXTURE_CHAT_ID).await.unwrap();
+    assert!(g.is_none(), "soft-deleted link must not resolve to a group");
+}
+
+#[tokio::test]
+async fn group_by_chat_id_unknown_chat_returns_none() {
+    let db = fresh_db().await;
+    seed_link(&db, FIXTURE_CHAT_ID, FIXTURE_GROUP_ID).await;
+    let g = find_group_by_chat_id(&db, "1111@g.us").await.unwrap();
+    assert!(g.is_none());
+}
+
+// ── find_member_by_phone ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn member_by_phone_returns_match_in_group() {
+    let db = fresh_db().await;
+    let group_id: EntityId = FIXTURE_GROUP_ID.into();
+    let m = find_member_by_phone(&db, &group_id, "2348101234567")
+        .await
+        .unwrap();
+    let m = m.expect("expected to find Adaeze");
+    assert_eq!(m.name, "Adaeze Okonkwo");
+}
+
+#[tokio::test]
+async fn member_by_phone_returns_none_for_unknown_phone() {
+    let db = fresh_db().await;
+    let group_id: EntityId = FIXTURE_GROUP_ID.into();
+    let m = find_member_by_phone(&db, &group_id, "999")
+        .await
+        .unwrap();
+    assert!(m.is_none());
+}
+
+#[tokio::test]
+async fn member_by_phone_scoped_to_group() {
+    // Same phone but a different group id must return None even though the
+    // member exists in another group.
+    let db = fresh_db().await;
+    let other: EntityId = "does-not-exist".into();
+    let m = find_member_by_phone(&db, &other, "2348101234567")
+        .await
+        .unwrap();
+    assert!(m.is_none());
+}
+
+// ── find_active_cycle ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn active_cycle_returns_the_active_one() {
+    let db = fresh_db().await;
+    let group_id: EntityId = FIXTURE_GROUP_ID.into();
+    let c = find_active_cycle(&db, &group_id).await.unwrap();
+    let c = c.expect("expected one active cycle");
+    assert_eq!(c.status, "active");
+}
+
+#[tokio::test]
+async fn active_cycle_returns_none_for_unknown_group() {
+    let db = fresh_db().await;
+    let other: EntityId = "no-such-group".into();
+    let c = find_active_cycle(&db, &other).await.unwrap();
+    assert!(c.is_none());
+}
+
+// ── find_receipt_by_message_id ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn receipt_by_message_id_returns_existing_receipt() {
+    let db = fresh_db().await;
+    let r = find_receipt_by_message_id(&db, "3EB0C123ABCD4567EF89")
+        .await
+        .unwrap();
+    let r = r.expect("expected fixture receipt 1");
+    assert_eq!(r.status, "pending");
+}
+
+#[tokio::test]
+async fn receipt_by_message_id_returns_none_for_unknown_id() {
+    let db = fresh_db().await;
+    let r = find_receipt_by_message_id(&db, "no-such-message")
+        .await
+        .unwrap();
+    assert!(r.is_none());
+}
+
+#[tokio::test]
+async fn receipt_by_message_id_excludes_soft_deleted() {
+    // Fixture receipt 2 has deleted_at set.
+    let db = fresh_db().await;
+    let r = find_receipt_by_message_id(&db, "3EB0C9876FEDC543210")
+        .await
+        .unwrap();
+    assert!(r.is_none(), "soft-deleted receipt must not be returned");
+}


### PR DESCRIPTION
## Summary
- New `src/routing.rs` module with four pure DB lookups the future WhatsApp ingestion pipeline will compose:
  - `find_group_by_chat_id` — chat id → linked group (live link + live group only)
  - `find_member_by_phone` — `(group, phone)` → member (scoped to group, live only)
  - `find_active_cycle` — group → single active cycle, if any
  - `find_receipt_by_message_id` — message id → existing receipt (excludes soft-deleted; confirmed/rejected still count as duplicates)
- No HTTP, Green API, or OCR coupling, so the pipeline can be assembled incrementally and tested in isolation.

## Why incrementally
Plan 2's ingestion path is large (chat→group, sender→member, active cycle, dedup, OCR, amount compare, INSERT, quoted reply). Landing the lookup primitives first keeps each PR focused and reviewable; the next PR will wire these into the existing Green API loop.

## Test plan
- [x] `cargo test` — 153 passed (was 141; +12 new in `tests/routing_integration.rs` covering happy paths, soft-delete exclusion, cross-group isolation, unknown keys)