### PR TITLE
[DOCS] Drop "Ajo" terminology from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # poolpay
 
-A Rust service that manages Ajo savings circles with a REST API and WhatsApp receipt OCR. Built with Axum, SurrealDB, and Green API.
+A Rust service that manages PoolPay savings groups with a REST API and WhatsApp receipt OCR. Built with Axum, SurrealDB, and Green API.
 
 ## What it does
 
-**REST API** for managing multi-group Ajo circles:
+**REST API** for managing multi-group PoolPay savings groups:
 - CRUD for groups, members, cycles, and payments
 - Admin endpoints secured with bearer token auth
 - Soft delete for groups/members/payments, hard delete for cycles

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -113,7 +113,7 @@ Two concurrent tasks:
 2. **API Server** (port 8080)
    - Public read endpoints for groups, members, cycles, payments
    - Admin write endpoints (bearer token auth) for CRUD operations
-   - Manages multi-group ajo circles with soft delete and version control
+   - Manages multi-group PoolPay savings groups with soft delete and version control
    - Development-only database reset endpoint
 
 See [RUNBOOK.md - Service Architecture](./RUNBOOK.md#service-architecture) for details.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -131,13 +131,13 @@ curl -X POST http://localhost:8080/api/test/reset
 
 All IDs are SurrealDB-generated strings (not integers). The `EntityId` type alias (`String`) is the single point of control for ID representation across the codebase.
 
-**Groups** — Ajo savings circles
+**Groups** — PoolPay savings groups
 ```json
 {
   "id": "abc123",
   "name": "Family Circle",
   "status": "active",
-  "description": "Monthly family ajo",
+  "description": "Monthly family pool",
   "createdAt": "2026-01-01T00:00:00Z",
   "updatedAt": "2026-01-01T00:00:00Z",
   "version": 1


### PR DESCRIPTION
## Summary
- README.md: "Ajo savings circles" → "PoolPay savings groups" (×2)
- docs/RUNBOOK.md: data-model heading + example description
- docs/INDEX.md: API server description

The project rebranded from Ajo to PoolPay; user-facing docs still carried the old term. Code/fixture cleanup of the remaining `src/db.rs` and `tests/` references is bundled into PR #18 (`feat/receipt-routing-helpers`) and lands when that merges.

## Test plan
- [x] Docs-only change, no code or test impact
- [x] `grep -r Ajo` against README/docs returns nothing in the changed files