### PR TITLE
[FEAT] WhatsApp receipt ingestion pipeline

### DIFF
--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -1,0 +1,167 @@
+//! Receipt ingestion pipeline.
+//!
+//! Takes the facts from a processed WhatsApp message (chat, sender phone,
+//! message id, OCR text, parsed fields) and produces either a persisted
+//! `receipt` row or a reason the message was dropped. This module owns the
+//! routing decisions; Green API polling and quoted-reply formatting live
+//! elsewhere so the pipeline can be exercised without network I/O.
+
+use tracing::info;
+
+use crate::api::models::{AppError, EntityId, ReceiptContent, now_iso};
+use crate::db::DbConn;
+use crate::models::ParsedReceipt;
+use crate::parser;
+use crate::routing;
+
+/// Tolerance applied when comparing an extracted amount to the cycle's
+/// expected contribution. OCR frequently drops a naira or two on noisy
+/// images, so a 1 NGN (100 kobo) window protects against false rejects
+/// without hiding genuine underpayments.
+const AMOUNT_MATCH_TOLERANCE_KOBO: i64 = 100;
+
+/// Inputs gathered by the polling loop for a single incoming receipt.
+pub struct IngestionInput<'a> {
+    pub chat_id: &'a str,
+    pub sender_phone: &'a str,
+    pub message_id: &'a str,
+    pub ocr_text: &'a str,
+    pub parsed: &'a ParsedReceipt,
+    pub received_at: String,
+}
+
+/// What happened with the ingestion attempt. Carries everything the reply
+/// layer (PR-next) needs to decide which quoted response to send.
+#[derive(Debug, Clone)]
+pub enum IngestionOutcome {
+    /// No group is linked to this chat — nothing to attach the receipt to.
+    NotLinked,
+    /// The same WhatsApp message id was already ingested; treated as a
+    /// duplicate regardless of the prior receipt's status.
+    DuplicateMessage,
+    /// The receipt was persisted. Member, cycle, and amount fields may all
+    /// be absent depending on how much context was resolvable.
+    Ingested(IngestedReceipt),
+}
+
+#[derive(Debug, Clone)]
+pub struct IngestedReceipt {
+    pub receipt_id: String,
+    pub group_id: EntityId,
+    pub member_matched: bool,
+    pub cycle_matched: bool,
+    pub extracted_amount: Option<i64>,
+    pub expected_amount: Option<i64>,
+    pub amount_matches: Option<bool>,
+}
+
+/// Run the ingestion pipeline. Returns an outcome the caller can log or
+/// translate into a WhatsApp reply.
+pub async fn ingest_receipt(
+    db: &DbConn,
+    input: IngestionInput<'_>,
+) -> Result<IngestionOutcome, AppError> {
+    let Some(group) = routing::find_group_by_chat_id(db, input.chat_id).await? else {
+        info!(chat_id = input.chat_id, "Ingestion skipped: chat not linked to a group");
+        return Ok(IngestionOutcome::NotLinked);
+    };
+    let group_id = crate::api::models::record_id_to_string(group.id);
+
+    if routing::find_receipt_by_message_id(db, input.message_id)
+        .await?
+        .is_some()
+    {
+        info!(message_id = input.message_id, "Ingestion skipped: duplicate message id");
+        return Ok(IngestionOutcome::DuplicateMessage);
+    }
+
+    let sender_phone = strip_jid(input.sender_phone).to_string();
+
+    let member_id = routing::find_member_by_phone(db, &group_id, &sender_phone)
+        .await?
+        .map(|m| crate::api::models::record_id_to_string(m.id));
+
+    let cycle = routing::find_active_cycle(db, &group_id).await?;
+    let expected_amount = cycle.as_ref().map(|c| c.contribution_per_member);
+    let cycle_id = cycle.map(|c| crate::api::models::record_id_to_string(c.id));
+
+    let extracted_amount = input
+        .parsed
+        .amount
+        .as_deref()
+        .and_then(parser::parse_amount_to_kobo);
+
+    let amount_matches = match (extracted_amount, expected_amount) {
+        (Some(got), Some(want)) => Some((got - want).abs() <= AMOUNT_MATCH_TOLERANCE_KOBO),
+        _ => None,
+    };
+
+    let now = now_iso();
+    let content = ReceiptContent {
+        whatsapp_message_id: input.message_id.to_string(),
+        group_id: group_id.clone(),
+        chat_id: input.chat_id.to_string(),
+        sender_phone,
+        member_id: member_id.clone(),
+        cycle_id: cycle_id.clone(),
+        extracted_amount,
+        expected_amount,
+        amount_matches,
+        status: "pending".to_string(),
+        ocr_text: Some(input.ocr_text.to_string()),
+        sender_label: input.parsed.sender.clone(),
+        bank_label: input.parsed.bank.clone(),
+        received_at: input.received_at,
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+    };
+
+    // `create` returns the inserted row(s) so we can surface the generated id.
+    let created: Option<crate::api::models::DbReceipt> =
+        db.create("receipt").content(content).await?;
+    let receipt_id = created
+        .map(|r| crate::api::models::record_id_to_string(r.id))
+        .ok_or_else(|| AppError::Internal("Failed to persist receipt".to_string()))?;
+
+    info!(
+        receipt_id = %receipt_id,
+        group_id = %group_id,
+        member_matched = member_id.is_some(),
+        cycle_matched = cycle_id.is_some(),
+        "Receipt ingested"
+    );
+
+    Ok(IngestionOutcome::Ingested(IngestedReceipt {
+        receipt_id,
+        group_id,
+        member_matched: member_id.is_some(),
+        cycle_matched: cycle_id.is_some(),
+        extracted_amount,
+        expected_amount,
+        amount_matches,
+    }))
+}
+
+/// WhatsApp delivers sender/chat ids as JIDs like `2348012345678@c.us`.
+/// Member records store only the digits, so strip everything from `@` onward
+/// before comparing. Inputs without `@` pass through unchanged.
+fn strip_jid(jid: &str) -> &str {
+    jid.split_once('@').map(|(head, _)| head).unwrap_or(jid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_jid_removes_suffix() {
+        assert_eq!(strip_jid("2348012345678@c.us"), "2348012345678");
+        assert_eq!(strip_jid("2348012345678@s.whatsapp.net"), "2348012345678");
+    }
+
+    #[test]
+    fn strip_jid_passes_through_raw_digits() {
+        assert_eq!(strip_jid("2348012345678"), "2348012345678");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod db;
 pub mod extractor;
+pub mod ingestion;
 pub mod models;
 pub mod parser;
 pub mod routing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use poolpay::{api, db, extractor, parser, whatsapp};
+use poolpay::{api, db, extractor, ingestion, parser, whatsapp};
+use poolpay::api::models::now_iso;
 
 use dotenv::dotenv;
 use std::{env, net::SocketAddr};
@@ -113,6 +114,38 @@ async fn main() {
                                             .sender_data
                                             .as_ref()
                                             .and_then(|s| s.chat_id.as_deref());
+                                        let sender_jid = notification
+                                            .body
+                                            .sender_data
+                                            .as_ref()
+                                            .and_then(|s| s.sender.as_deref());
+                                        let message_id = notification.body.id_message.as_deref();
+
+                                        match (chat_id, sender_jid, message_id) {
+                                            (Some(cid), Some(sender), Some(mid)) => {
+                                                let input = ingestion::IngestionInput {
+                                                    chat_id: cid,
+                                                    sender_phone: sender,
+                                                    message_id: mid,
+                                                    ocr_text: &text,
+                                                    parsed: &parsed,
+                                                    received_at: now_iso(),
+                                                };
+                                                match ingestion::ingest_receipt(&surreal_db, input).await {
+                                                    Ok(outcome) => info!(?outcome, "Ingestion outcome"),
+                                                    Err(e) => {
+                                                        error!(error = ?e, "Ingestion failed");
+                                                        processing_ok = false;
+                                                    }
+                                                }
+                                            }
+                                            _ => warn!(
+                                                has_chat_id = chat_id.is_some(),
+                                                has_sender = sender_jid.is_some(),
+                                                has_message_id = message_id.is_some(),
+                                                "Skipping ingestion — notification missing required ids"
+                                            ),
+                                        }
 
                                         if let Some(chat_id) = chat_id {
                                             let sender = parsed.sender.unwrap_or_else(|| "unknown".to_string());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -108,6 +108,52 @@ pub fn parse_receipt(text: &str) -> ParsedReceipt {
     ParsedReceipt { sender, bank, amount }
 }
 
+/// Converts a normalised amount string (as produced by `parse_receipt`) into
+/// an integer kobo value. Returns `None` when the input is not a recognisable
+/// Naira amount.
+///
+/// Accepted shapes: `₦97,800.00`, `₦97,800`, `₦97800.5`. The currency prefix
+/// may be `₦`, `#`, or `NGN` (with optional whitespace). Thousand separators
+/// and spaces are ignored; decimals are truncated to two places of kobo.
+pub fn parse_amount_to_kobo(amount: &str) -> Option<i64> {
+    let trimmed = amount.trim();
+    let without_prefix = trimmed
+        .strip_prefix('₦')
+        .or_else(|| trimmed.strip_prefix('#'))
+        .or_else(|| {
+            trimmed
+                .strip_prefix("NGN")
+                .or_else(|| trimmed.strip_prefix("ngn"))
+                .map(str::trim_start)
+        })?;
+
+    let cleaned: String = without_prefix
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != ',')
+        .collect();
+
+    let (whole, fraction) = match cleaned.split_once('.') {
+        Some((w, f)) => (w, f),
+        None => (cleaned.as_str(), ""),
+    };
+
+    if whole.is_empty() || !whole.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    if !fraction.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let naira: i64 = whole.parse().ok()?;
+    let kobo_fraction: i64 = match fraction.len() {
+        0 => 0,
+        1 => fraction.parse::<i64>().ok()? * 10,
+        _ => fraction[..2].parse().ok()?,
+    };
+
+    naira.checked_mul(100)?.checked_add(kobo_fraction)
+}
+
 /// Logs the fields of a ParsedReceipt.
 pub fn print_parsed(parsed: &ParsedReceipt) {
     info!(

--- a/tests/ingestion_integration.rs
+++ b/tests/ingestion_integration.rs
@@ -1,0 +1,251 @@
+//! Integration tests for the WhatsApp receipt ingestion pipeline.
+//!
+//! Exercises `src/ingestion.rs` end-to-end against an in-memory SurrealDB
+//! seeded with fixtures, avoiding the Axum router and Green API entirely.
+
+use poolpay::api::models::{DbGroupLink, DbReceipt, GroupLinkContent, now_iso};
+use poolpay::db::{self, DbConn};
+use poolpay::ingestion::{IngestionInput, IngestionOutcome, ingest_receipt};
+use poolpay::models::ParsedReceipt;
+
+const FIXTURE_CHAT_ID: &str = "2349000000001@g.us";
+const FIXTURE_GROUP_ID: &str = "1";
+/// Fixture member 1 — matches FIXTURE_GROUP_ID's active cycle 3.
+const FIXTURE_MEMBER_PHONE: &str = "2348101234567";
+const FIXTURE_MEMBER_JID: &str = "2348101234567@c.us";
+
+async fn fresh_db() -> DbConn {
+    db::init_memory().await.expect("failed to init test DB")
+}
+
+async fn link_default_group(db: &DbConn) {
+    let now = now_iso();
+    let _: Option<DbGroupLink> = db
+        .create("group_link")
+        .content(GroupLinkContent {
+            chat_id: FIXTURE_CHAT_ID.into(),
+            group_id: FIXTURE_GROUP_ID.into(),
+            created_at: now.clone(),
+            updated_at: now,
+            deleted_at: None,
+        })
+        .await
+        .expect("seed link failed");
+}
+
+fn parsed(amount: Option<&str>) -> ParsedReceipt {
+    ParsedReceipt {
+        sender: Some("Adaeze Okonkwo".into()),
+        bank: Some("GTBank".into()),
+        amount: amount.map(str::to_string),
+    }
+}
+
+fn input<'a>(
+    chat_id: &'a str,
+    sender: &'a str,
+    message_id: &'a str,
+    parsed: &'a ParsedReceipt,
+) -> IngestionInput<'a> {
+    IngestionInput {
+        chat_id,
+        sender_phone: sender,
+        message_id,
+        ocr_text: "raw OCR text",
+        parsed,
+        received_at: now_iso(),
+    }
+}
+
+async fn ingested(outcome: IngestionOutcome) -> poolpay::ingestion::IngestedReceipt {
+    match outcome {
+        IngestionOutcome::Ingested(r) => r,
+        other => panic!("expected Ingested, got {other:?}"),
+    }
+}
+
+async fn count_receipts(db: &DbConn) -> usize {
+    let rows: Vec<DbReceipt> = db.select("receipt").await.unwrap();
+    rows.len()
+}
+
+#[tokio::test]
+async fn ingest_returns_not_linked_when_chat_unknown() {
+    let db = fresh_db().await;
+    let p = parsed(Some("₦10,000.00"));
+    let before = count_receipts(&db).await;
+
+    let out = ingest_receipt(&db, input("9999@g.us", FIXTURE_MEMBER_JID, "MID1", &p))
+        .await
+        .unwrap();
+
+    assert!(matches!(out, IngestionOutcome::NotLinked));
+    assert_eq!(count_receipts(&db).await, before, "must not insert a row");
+}
+
+#[tokio::test]
+async fn ingest_persists_full_match() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦10,000.00"));
+
+    let out = ingest_receipt(
+        &db,
+        input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-FULL", &p),
+    )
+    .await
+    .unwrap();
+
+    let r = ingested(out).await;
+    assert!(r.member_matched);
+    assert!(r.cycle_matched);
+    assert_eq!(r.extracted_amount, Some(1_000_000));
+    assert_eq!(r.expected_amount, Some(1_000_000));
+    assert_eq!(r.amount_matches, Some(true));
+
+    let rows: Vec<DbReceipt> = db.select("receipt").await.unwrap();
+    let persisted = rows
+        .iter()
+        .find(|r| r.whatsapp_message_id == "MID-FULL")
+        .expect("persisted row missing");
+    assert_eq!(persisted.status, "pending");
+    assert_eq!(persisted.sender_phone, "2348101234567");
+    assert_eq!(persisted.amount_matches, Some(true));
+}
+
+#[tokio::test]
+async fn ingest_flags_amount_mismatch() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦500.00"));
+
+    let r = ingested(
+        ingest_receipt(
+            &db,
+            input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-MISM", &p),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    assert_eq!(r.extracted_amount, Some(50_000));
+    assert_eq!(r.expected_amount, Some(1_000_000));
+    assert_eq!(r.amount_matches, Some(false));
+}
+
+#[tokio::test]
+async fn ingest_tolerates_one_naira_difference() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦9,999.50")); // 999,950 kobo — 50 kobo below 1,000,000
+
+    let r = ingested(
+        ingest_receipt(
+            &db,
+            input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-TOL", &p),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    assert_eq!(r.amount_matches, Some(true), "within 1 NGN must match");
+}
+
+#[tokio::test]
+async fn ingest_leaves_member_empty_when_sender_not_registered() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦10,000.00"));
+
+    let r = ingested(
+        ingest_receipt(
+            &db,
+            input(FIXTURE_CHAT_ID, "2349999999999@c.us", "MID-NM", &p),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    assert!(!r.member_matched);
+    assert!(r.cycle_matched, "active cycle still resolves");
+
+    let rows: Vec<DbReceipt> = db.select("receipt").await.unwrap();
+    let row = rows
+        .iter()
+        .find(|r| r.whatsapp_message_id == "MID-NM")
+        .unwrap();
+    assert!(row.member_id.is_none());
+    assert_eq!(row.sender_phone, "2349999999999");
+}
+
+#[tokio::test]
+async fn ingest_returns_duplicate_for_repeated_message_id() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦10,000.00"));
+
+    let first = ingest_receipt(
+        &db,
+        input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-DUP", &p),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(first, IngestionOutcome::Ingested(_)));
+
+    let second = ingest_receipt(
+        &db,
+        input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-DUP", &p),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(second, IngestionOutcome::DuplicateMessage));
+
+    let rows: Vec<DbReceipt> = db.select("receipt").await.unwrap();
+    let matches: Vec<_> = rows
+        .iter()
+        .filter(|r| r.whatsapp_message_id == "MID-DUP")
+        .collect();
+    assert_eq!(matches.len(), 1, "duplicate must not insert a second row");
+}
+
+#[tokio::test]
+async fn ingest_leaves_amount_none_when_parse_fails() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(None);
+
+    let r = ingested(
+        ingest_receipt(
+            &db,
+            input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_JID, "MID-NO-AMT", &p),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    assert_eq!(r.extracted_amount, None);
+    assert_eq!(r.amount_matches, None);
+}
+
+#[tokio::test]
+async fn ingest_accepts_raw_phone_without_jid_suffix() {
+    let db = fresh_db().await;
+    link_default_group(&db).await;
+    let p = parsed(Some("₦10,000.00"));
+
+    let r = ingested(
+        ingest_receipt(
+            &db,
+            input(FIXTURE_CHAT_ID, FIXTURE_MEMBER_PHONE, "MID-RAW", &p),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    assert!(r.member_matched, "raw phone must still match stored member");
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -210,3 +210,42 @@ fn full_receipt_with_ocr_hash_and_space_noise() {
     assert_eq!(r.bank.as_deref(), Some("GTBank"));
     assert_eq!(r.amount.as_deref(), Some("₦15,000.00"));
 }
+
+// ── parse_amount_to_kobo ─────────────────────────────────────────────────────
+
+use poolpay::parser::parse_amount_to_kobo;
+
+#[test]
+fn kobo_naira_symbol_with_decimals() {
+    assert_eq!(parse_amount_to_kobo("₦10,000.00"), Some(1_000_000));
+}
+
+#[test]
+fn kobo_naira_symbol_no_decimals() {
+    assert_eq!(parse_amount_to_kobo("₦10,000"), Some(1_000_000));
+}
+
+#[test]
+fn kobo_single_decimal_digit() {
+    assert_eq!(parse_amount_to_kobo("₦10,000.5"), Some(1_000_050));
+}
+
+#[test]
+fn kobo_ngn_prefix() {
+    assert_eq!(parse_amount_to_kobo("NGN 97,800.25"), Some(9_780_025));
+}
+
+#[test]
+fn kobo_hash_prefix() {
+    assert_eq!(parse_amount_to_kobo("#500.00"), Some(50_000));
+}
+
+#[test]
+fn kobo_rejects_unprefixed() {
+    assert_eq!(parse_amount_to_kobo("10,000.00"), None);
+}
+
+#[test]
+fn kobo_rejects_garbage() {
+    assert_eq!(parse_amount_to_kobo("₦not-a-number"), None);
+}


### PR DESCRIPTION
## Summary

- Wires the routing helpers from #18 into a real pipeline: chat → group, dedupe on message id, member-by-phone, active cycle, amount parse + compare, INSERT pending receipt.
- Adds `parse_amount_to_kobo` helper and strips WhatsApp JID suffixes (`@c.us`) before phone lookup. Amount match uses a 1 NGN tolerance to absorb OCR drift.
- Main loop now calls `ingest_receipt` after OCR. Existing generic echo reply is untouched — the structured quoted replies (match / mismatch / not-linked / not-registered / no-active-cycle) land in the next PR.
- 15 new tests (8 ingestion integration, 7 parser unit). Total 170 passing.

## Out of scope

- Quoted replies and per-outcome messages — next PR.
- No behaviour change to any existing API endpoint.

## Test plan

- [x] `cargo test` — 170 passed / 170 total
- [x] `cargo clippy --all-targets` — no new warnings (existing `map_or` ones remain, tracked in #15)