### PR TITLE
[FEAT] Structured quoted replies for receipt ingestion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod extractor;
 pub mod ingestion;
 pub mod models;
 pub mod parser;
+pub mod replies;
 pub mod routing;
 pub mod whatsapp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use poolpay::{api, db, extractor, ingestion, parser, whatsapp};
+use poolpay::{api, db, extractor, ingestion, parser, replies, whatsapp};
 use poolpay::api::models::now_iso;
 
 use dotenv::dotenv;
@@ -132,7 +132,29 @@ async fn main() {
                                                     received_at: now_iso(),
                                                 };
                                                 match ingestion::ingest_receipt(&surreal_db, input).await {
-                                                    Ok(outcome) => info!(?outcome, "Ingestion outcome"),
+                                                    Ok(outcome) => {
+                                                        info!(?outcome, "Ingestion outcome");
+                                                        if let Some(reply) =
+                                                            replies::format_reply(&outcome, &parsed)
+                                                        {
+                                                            match whatsapp::send_quoted_message(
+                                                                &client,
+                                                                &instance_id,
+                                                                &api_token,
+                                                                cid,
+                                                                mid,
+                                                                &reply,
+                                                            )
+                                                            .await
+                                                            {
+                                                                Ok(_) => info!(chat_id = cid, "Reply sent"),
+                                                                Err(e) => {
+                                                                    error!(error = %e, "Failed to send reply");
+                                                                    processing_ok = false;
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                     Err(e) => {
                                                         error!(error = ?e, "Ingestion failed");
                                                         processing_ok = false;
@@ -145,36 +167,6 @@ async fn main() {
                                                 has_message_id = message_id.is_some(),
                                                 "Skipping ingestion — notification missing required ids"
                                             ),
-                                        }
-
-                                        if let Some(chat_id) = chat_id {
-                                            let sender = parsed.sender.unwrap_or_else(|| "unknown".to_string());
-                                            let bank = parsed.bank.unwrap_or_else(|| "unknown".to_string());
-                                            let amount = parsed.amount.unwrap_or_else(|| "unknown".to_string());
-
-                                            let reply = format!(
-                                                "✅ Sender: {}\nBank: {}\nAmount: {}",
-                                                sender, bank, amount,
-                                            );
-
-                                            match whatsapp::send_message(
-                                                &client,
-                                                &instance_id,
-                                                &api_token,
-                                                chat_id,
-                                                &reply,
-                                            )
-                                            .await
-                                            {
-                                                Ok(_) => info!(chat_id, "Reply sent"),
-                                                Err(e) => {
-                                                    error!(error = %e, "Failed to send reply");
-                                                    processing_ok = false;
-                                                }
-                                            }
-                                        } else {
-                                            error!("No chat_id found — cannot send reply");
-                                            processing_ok = false;
                                         }
                                     }
                                     Err(e) => {

--- a/src/replies.rs
+++ b/src/replies.rs
@@ -1,0 +1,173 @@
+//! Formats the WhatsApp reply that follows an ingestion attempt.
+//!
+//! Pure text formatting — no DB, no network. Given an `IngestionOutcome`
+//! (and, for the successful path, the parsed receipt fields) it returns
+//! the exact message body the poller should quote-reply with. A `None`
+//! return means the caller should stay silent (e.g. duplicates — the
+//! sender already received a reply on the first ingestion).
+
+use crate::ingestion::{IngestedReceipt, IngestionOutcome};
+use crate::models::ParsedReceipt;
+
+/// Produce the WhatsApp reply for an ingestion outcome.
+///
+/// Returns `None` for outcomes where a reply would be noise — currently
+/// only `DuplicateMessage`.
+pub fn format_reply(outcome: &IngestionOutcome, parsed: &ParsedReceipt) -> Option<String> {
+    match outcome {
+        IngestionOutcome::DuplicateMessage => None,
+        IngestionOutcome::NotLinked => Some(not_linked()),
+        IngestionOutcome::Ingested(r) => Some(format_ingested(r, parsed)),
+    }
+}
+
+fn not_linked() -> String {
+    "⚠️ This chat isn't linked to a PoolPay group yet. Ask your group admin to link it before sending receipts.".to_string()
+}
+
+fn format_ingested(r: &IngestedReceipt, parsed: &ParsedReceipt) -> String {
+    if !r.member_matched {
+        return "⚠️ We couldn't match your phone number to a member of this group. Ask your admin to register you, then resend the receipt.".to_string();
+    }
+    if !r.cycle_matched {
+        return "📬 Receipt saved. This group has no active cycle right now, so an admin will review it manually.".to_string();
+    }
+
+    let sender = parsed.sender.as_deref().unwrap_or("unknown");
+    let bank = parsed.bank.as_deref().unwrap_or("unknown");
+    let amount = parsed
+        .amount
+        .as_deref()
+        .map(str::to_string)
+        .unwrap_or_else(|| "unreadable".to_string());
+
+    match r.amount_matches {
+        Some(true) => format!(
+            "✅ Receipt received — pending admin review.\nSender: {sender}\nBank: {bank}\nAmount: {amount}"
+        ),
+        Some(false) => {
+            let expected = r
+                .expected_amount
+                .map(format_kobo)
+                .unwrap_or_else(|| "unknown".to_string());
+            format!(
+                "⚠️ Amount mismatch — pending admin review.\nSender: {sender}\nBank: {bank}\nExtracted: {amount}\nExpected: {expected}"
+            )
+        }
+        None => format!(
+            "📬 Receipt received — we couldn't read the amount clearly, so an admin will review it.\nSender: {sender}\nBank: {bank}"
+        ),
+    }
+}
+
+/// Render a kobo integer as a naira string (`₦10,000.00`) for display.
+fn format_kobo(kobo: i64) -> String {
+    let naira = kobo / 100;
+    let fraction = (kobo % 100).abs();
+
+    let whole = naira.abs().to_string();
+    let mut with_commas = String::with_capacity(whole.len() + whole.len() / 3);
+    for (i, ch) in whole.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            with_commas.push(',');
+        }
+        with_commas.push(ch);
+    }
+    let whole_commas: String = with_commas.chars().rev().collect();
+    let sign = if kobo < 0 { "-" } else { "" };
+    format!("{sign}₦{whole_commas}.{fraction:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ingestion::{IngestedReceipt, IngestionOutcome};
+
+    fn parsed(sender: &str, bank: &str, amount: Option<&str>) -> ParsedReceipt {
+        ParsedReceipt {
+            sender: Some(sender.into()),
+            bank: Some(bank.into()),
+            amount: amount.map(str::to_string),
+        }
+    }
+
+    fn receipt(member: bool, cycle: bool, matches: Option<bool>) -> IngestedReceipt {
+        IngestedReceipt {
+            receipt_id: "r1".into(),
+            group_id: "1".into(),
+            member_matched: member,
+            cycle_matched: cycle,
+            extracted_amount: Some(1_000_000),
+            expected_amount: Some(1_000_000),
+            amount_matches: matches,
+        }
+    }
+
+    #[test]
+    fn duplicate_has_no_reply() {
+        let p = parsed("x", "y", Some("₦10,000.00"));
+        assert!(format_reply(&IngestionOutcome::DuplicateMessage, &p).is_none());
+    }
+
+    #[test]
+    fn not_linked_prompts_admin_link() {
+        let p = parsed("x", "y", Some("₦10,000.00"));
+        let reply = format_reply(&IngestionOutcome::NotLinked, &p).unwrap();
+        assert!(reply.contains("isn't linked"));
+        assert!(reply.contains("admin"));
+    }
+
+    #[test]
+    fn unregistered_sender_prompts_registration() {
+        let p = parsed("x", "y", Some("₦10,000.00"));
+        let out = IngestionOutcome::Ingested(receipt(false, true, None));
+        let reply = format_reply(&out, &p).unwrap();
+        assert!(reply.contains("couldn't match your phone"));
+    }
+
+    #[test]
+    fn no_active_cycle_acknowledges_manual_review() {
+        let p = parsed("x", "y", Some("₦10,000.00"));
+        let out = IngestionOutcome::Ingested(receipt(true, false, None));
+        let reply = format_reply(&out, &p).unwrap();
+        assert!(reply.contains("no active cycle"));
+    }
+
+    #[test]
+    fn full_match_returns_success_summary() {
+        let p = parsed("Adaeze Okonkwo", "GTBank", Some("₦10,000.00"));
+        let out = IngestionOutcome::Ingested(receipt(true, true, Some(true)));
+        let reply = format_reply(&out, &p).unwrap();
+        assert!(reply.starts_with("✅"));
+        assert!(reply.contains("Adaeze Okonkwo"));
+        assert!(reply.contains("GTBank"));
+        assert!(reply.contains("₦10,000.00"));
+    }
+
+    #[test]
+    fn amount_mismatch_shows_extracted_and_expected() {
+        let p = parsed("Adaeze Okonkwo", "GTBank", Some("₦500.00"));
+        let mut r = receipt(true, true, Some(false));
+        r.extracted_amount = Some(50_000);
+        r.expected_amount = Some(1_000_000);
+        let reply = format_reply(&IngestionOutcome::Ingested(r), &p).unwrap();
+        assert!(reply.contains("mismatch"));
+        assert!(reply.contains("₦500.00"));
+        assert!(reply.contains("₦10,000.00"));
+    }
+
+    #[test]
+    fn unreadable_amount_notes_admin_review() {
+        let p = parsed("Adaeze Okonkwo", "GTBank", None);
+        let out = IngestionOutcome::Ingested(receipt(true, true, None));
+        let reply = format_reply(&out, &p).unwrap();
+        assert!(reply.contains("couldn't read the amount"));
+    }
+
+    #[test]
+    fn format_kobo_renders_standard_amounts() {
+        assert_eq!(format_kobo(1_000_000), "₦10,000.00");
+        assert_eq!(format_kobo(50), "₦0.50");
+        assert_eq!(format_kobo(123_456_789), "₦1,234,567.89");
+    }
+}

--- a/src/whatsapp.rs
+++ b/src/whatsapp.rs
@@ -90,6 +90,36 @@ pub async fn send_message(
     Ok(())
 }
 
+/// Sends a text message as a quoted reply to an existing WhatsApp message.
+///
+/// Mirrors `send_message` but adds Green API's `quotedMessageId` field so the
+/// reply is threaded under the original receipt. `message_id_to_quote` must be
+/// the `idMessage` value from the notification that prompted this reply.
+pub async fn send_quoted_message(
+    client: &Client,
+    instance_id: &str,
+    api_token: &str,
+    chat_id: &str,
+    message_id_to_quote: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let url = api_url(instance_id, "sendMessage", api_token);
+
+    let body = serde_json::json!({
+        "chatId": chat_id,
+        "message": message,
+        "quotedMessageId": message_id_to_quote,
+    });
+
+    let response = client.post(&url).json(&body).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await?;
+        return Err(format!("Green API error {}: {}", status, text).into());
+    }
+    Ok(())
+}
+
 /// Downloads a file from the URL in the given FileMessageData and saves it to DOWNLOAD_DIR.
 /// The filename is derived from the receipt ID to ensure uniqueness across messages.
 pub async fn download_file(


### PR DESCRIPTION
## Summary

- Replaces the generic echo reply with outcome-specific messages keyed off `IngestionOutcome`: not-linked, not-registered, no-active-cycle, full match, amount mismatch, unreadable amount. Duplicates stay silent.
- Adds `whatsapp::send_quoted_message` (uses Green API's `quotedMessageId`) so replies thread under the original receipt.
- Reply formatting is a pure module (`src/replies.rs`) — no DB, no network — covered by 8 unit tests.

## Out of scope

- No ingestion logic changes — this is purely the reply layer.
- No API endpoint changes.

## Test plan

- [x] `cargo test` — 178 passed / 178 total (+8 vs main)
- [x] `cargo clippy --all-targets` — no new warnings