### PR TITLE
[FEAT] Plan 3 BE-1 — auth schema, Argon2id, HMAC endpoints, bootstrap seeder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,15 @@ GREEN_API_TOKEN=your_api_token_here
 # Required for all /api/admin/* endpoints. Generate with: openssl rand -hex 32
 ADMIN_TOKEN=your_admin_token_here
 
+# Shared secret for NextAuth → backend HMAC signing. Generate with: openssl rand -hex 32
+NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
+
 # --- Optional ---
+
+# Bootstrap admin — seeded on first boot if no active admin user exists.
+# After first login, change the password via /api/auth/change-password.
+# BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+# BOOTSTRAP_ADMIN_PASSWORD=change-me-immediately
 
 # Set to "production" to enable strict CORS and disable /api/test/reset
 # APP_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # --- Optional ---
 
 # Bootstrap admin — seeded on first boot if no active admin user exists.
-# After first login, change the password via /api/auth/change-password.
+# After first login, rotate this bootstrap password immediately once a
+# supported change-password flow lands (planned in BE-2+).
 # BOOTSTRAP_ADMIN_EMAIL=admin@example.com
 # BOOTSTRAP_ADMIN_PASSWORD=change-me-immediately
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,14 +3007,19 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "poolpay"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
  "chrono",
  "dotenv",
+ "hex",
+ "hmac",
  "http-body-util",
+ "password-hash",
  "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "surrealdb",
  "surrealdb-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,15 @@ chrono = { version = "0.4", features = ["serde"] }
 # Constant-time comparison for auth tokens
 subtle = "2"
 
+# Password hashing — Argon2id with OWASP 2024 parameters
+argon2 = { version = "0.5", features = ["std"] }
+password-hash = { version = "0.5", features = ["rand_core"] }
+
+# HMAC-SHA256 for NextAuth → backend request signing
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+
 [dev-dependencies]
 # HTTP service test utilities — used in API integration tests
 tower = { version = "0.5", features = ["util"] }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PoolPay
 
-Last Updated: 2026-04-01
+Last Updated: 2026-04-14
 
 ## Prerequisites
 
@@ -122,10 +122,12 @@ Supported log levels: `debug`, `info`, `warn`, `error`.
 cargo test
 ```
 
-Runs 106 tests across:
-- **Models** (3 tests) — JSON deserialization, idMessage placement
-- **Parser** (28 tests) — amount extraction, sender detection, bank matching
-- **API Integration** (75 tests) — admin CRUD, auth, validation, soft delete, version conflicts, route handlers
+Runs 193 tests across unit + integration suites:
+- **Unit tests** — models, parser, password hashing, HMAC primitives
+- **Parser integration** — amount extraction, sender detection, bank matching
+- **API integration** — admin CRUD, auth, validation, soft delete, version conflicts, route handlers
+- **Auth integration** — HMAC-gated `verify-credentials` / `ensure-user`, bootstrap idempotency, field-length caps
+- **Routing / ingestion integration** — chat→group resolution, receipt ingestion pipeline
 
 Tests use an in-memory SurrealDB instance and do not touch the filesystem or call external APIs.
 
@@ -189,12 +191,21 @@ src/
 ├── api/
 │   ├── mod.rs          — router setup, CORS configuration
 │   ├── auth.rs         — AdminToken extractor (Bearer token via ADMIN_TOKEN)
+│   ├── auth_endpoints.rs — HMAC-gated NextAuth endpoints (verify-credentials, ensure-user)
 │   ├── handlers.rs     — HTTP handlers (GET/POST/PATCH/DELETE)
 │   └── models.rs       — API request/response types, EntityId alias, DB/API structs
+├── auth/
+│   ├── mod.rs          — auth module root
+│   ├── bootstrap.rs    — seed super_admin user on first boot
+│   ├── hmac.rs         — HMAC-SHA256 request signing extractor
+│   └── password.rs     — Argon2id hashing + constant-time verify_or_dummy
 
 tests/
-├── parser_tests.rs     — parser module integration tests
-└── api_integration.rs  — API route and database integration tests
+├── parser_tests.rs          — parser module integration tests
+├── api_integration.rs       — API route and database integration tests
+├── auth_integration.rs      — HMAC + bootstrap + password-flow integration tests
+├── ingestion_integration.rs — receipt ingestion pipeline tests
+└── routing_integration.rs   — chat→group / phone→member resolution tests
 ```
 
 ### Adding a New Module
@@ -232,8 +243,11 @@ tests/
 | `GREEN_API_INSTANCE_ID` | Yes | — | Green API instance ID from dashboard |
 | `GREEN_API_TOKEN` | Yes | — | Green API authentication token |
 | `ADMIN_TOKEN` | Yes | — | Bearer token for all `/api/admin/*` endpoints. Generate with `openssl rand -hex 32` |
-| `APP_ENV` | No | `development` | Environment mode: `development` or `production` (controls CORS and `/api/test/reset` availability) |
+| `NEXTAUTH_BACKEND_SECRET` | Yes | — | Shared secret for NextAuth→backend HMAC signing (min 32 bytes; panics in production if shorter). Generate with `openssl rand -hex 32` |
+| `APP_ENV` | No | unset | `production` enables strict CORS; `development` or `test` mounts `/api/test/reset`. Anything else (including unset) is treated as production for the reset gate |
 | `DASHBOARD_ORIGIN` | No (required if `APP_ENV=production`) | — | CORS origin for production (e.g., `https://dashboard.example.com`) |
+| `BOOTSTRAP_ADMIN_EMAIL` | No | — | Email seeded on first boot if no active admin exists. Rotate the password immediately after first login |
+| `BOOTSTRAP_ADMIN_PASSWORD` | No | — | Password for the bootstrap admin; stored as Argon2id, flagged `must_reset_password=true` |
 | `API_BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
 | `SEED_ON_EMPTY` | No | `false` | Set to `true` to seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory for temporary receipt files during OCR |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-Last Updated: 2026-04-01
+Last Updated: 2026-04-14
 
 Quick reference to all documentation for the PoolPay project.
 
@@ -34,7 +34,7 @@ Start here if you're deploying, running, or troubleshooting the service in produ
 - **[README.md](../README.md)** (in root) — Project overview
   - What the service does
   - Architecture and structure
-  - Testing overview (106 tests)
+  - Testing overview (193 tests)
   - Known limitations
 
 ## Key Topics at a Glance
@@ -113,8 +113,9 @@ Two concurrent tasks:
 2. **API Server** (port 8080)
    - Public read endpoints for groups, members, cycles, payments
    - Admin write endpoints (bearer token auth) for CRUD operations
+   - HMAC-gated auth endpoints for NextAuth (`verify-credentials`, `ensure-user`)
    - Manages multi-group PoolPay savings groups with soft delete and version control
-   - Development-only database reset endpoint
+   - Dev/test-only database reset endpoint (fail-closed on `APP_ENV`)
 
 See [RUNBOOK.md - Service Architecture](./RUNBOOK.md#service-architecture) for details.
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Runbook: PoolPay Service
 
-Last Updated: 2026-04-01
+Last Updated: 2026-04-14
 
 Operational guide for running and troubleshooting the PoolPay service in development and production.
 
@@ -46,20 +46,33 @@ APP_ENV=production DASHBOARD_ORIGIN=https://dashboard.example.com \
 
 ```env
 # Green API credentials (from https://green-api.com/en/)
-GREEN_API_INSTANCE_ID=7103538567
-GREEN_API_TOKEN=68e409f84c9f47549a370f0ca1ba5bd01122559cdfce45a180
+GREEN_API_INSTANCE_ID=your_instance_id_here
+GREEN_API_TOKEN=your_api_token_here
 
 # Admin bearer token for all /api/admin/* endpoints
 # Generate with: openssl rand -hex 32
 ADMIN_TOKEN=your_admin_token_here
+
+# Shared secret for NextAuth → backend HMAC signing
+# Must be at least 32 bytes; panics at boot in production if shorter
+# Generate with: openssl rand -hex 32
+NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 ```
 
 ### Optional Variables
 
 ```env
-# Environment mode (default: development)
-# Set to "production" to enable CORS restrictions and disable /api/test/reset
+# Environment mode (default: unset)
+# - "production" enables strict CORS (requires DASHBOARD_ORIGIN)
+# - "development" or "test" mounts the destructive /api/test/reset endpoint
+# - Anything else (including unset) is treated as production for the reset gate (fail-closed)
 APP_ENV=development
+
+# Bootstrap admin — seeded on first boot if no active admin user exists.
+# The seeded user is flagged must_reset_password=true; remove these from
+# deployed env once the first rotation has happened.
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=change-me-immediately
 
 # CORS origin for production (required if APP_ENV=production)
 DASHBOARD_ORIGIN=https://dashboard.example.com
@@ -83,7 +96,9 @@ RUST_LOG=info
 - Set `APP_ENV=production` to enable CORS restrictions
 - Set `DASHBOARD_ORIGIN` to the dashboard URL
 - Set a strong `ADMIN_TOKEN` (at least 32 hex characters)
-- The `/api/test/reset` endpoint is disabled in production
+- Set `NEXTAUTH_BACKEND_SECRET` to a value with ≥ 32 bytes — the process panics at boot in production if it is shorter or unset
+- The `/api/test/reset` endpoint is fail-closed: it only mounts when `APP_ENV=development` or `APP_ENV=test`. Unset `APP_ENV` on a staging/prod host and the endpoint stays unreachable
+- After the bootstrap admin's first password rotation, remove `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` from deployed env
 - Never commit `.env` with real credentials
 
 ## Service Architecture
@@ -102,7 +117,8 @@ The service runs two concurrent tasks:
 - Serves HTTP API on port 8080
 - Public read endpoints for groups, members, cycles, and payments
 - Admin write endpoints (behind `ADMIN_TOKEN` bearer auth) for CRUD operations
-- Dev-only `/api/test/reset` endpoint to reset database to fixture state
+- HMAC-gated auth endpoints (`/api/auth/verify-credentials`, `/api/auth/ensure-user`) called by NextAuth — signed with `NEXTAUTH_BACKEND_SECRET`
+- Dev/test-only `/api/test/reset` endpoint (fail-closed gate on `APP_ENV`)
 - CORS configured based on `APP_ENV`
 
 Both tasks are monitored — if either fails, the process exits rather than silently degrading.
@@ -339,11 +355,52 @@ Soft-delete all payments for a member in a cycle. Requires admin auth.
 
 Returns `204 No Content`.
 
+### HMAC-Gated Auth Endpoints (NextAuth)
+
+All requests must carry `x-timestamp` (unix seconds, within ±60s) and
+`x-signature: sha256=<hex>` where the signature is
+`HMAC-SHA256(NEXTAUTH_BACKEND_SECRET, "<ts>.<body>")`. Any signing, replay,
+or body-parse failure returns `401`.
+
+#### POST /api/auth/verify-credentials
+
+Verify a password against the stored Argon2id hash. Constant-time regardless
+of whether the email exists (dummy-hash verify pre-warmed at boot).
+
+**Request:**
+```json
+{ "email": "user@example.com", "password": "..." }
+```
+
+**Response (200):**
+```json
+{ "userId": "abc123", "email": "user@example.com", "role": "super_admin", "mustResetPassword": true }
+```
+
+Returns `401` on bad password, unknown email, or disabled user.
+
+#### POST /api/auth/ensure-user
+
+Idempotent JIT provisioning for social providers. Never auto-links on email —
+a new `(provider, providerSubject)` always creates a fresh user.
+
+**Request:**
+```json
+{ "provider": "google", "providerSubject": "sub-12345", "email": "user@example.com" }
+```
+
+**Response (200):**
+```json
+{ "userId": "abc123", "email": "user@example.com", "role": "member", "created": true }
+```
+
 ### Dev-Only Endpoint
 
 #### POST /api/test/reset
 
-Reset the database to fixture state. Only available when `APP_ENV != production`.
+Reset the database to fixture state. Fail-closed: only mounted when
+`APP_ENV` is explicitly `development` or `test`. Any other value (including
+unset) leaves the route unreachable.
 
 Returns `200 OK`.
 

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -1,7 +1,12 @@
 //! HMAC-gated endpoints called by NextAuth to authenticate users and to
-//! provision / link social identities. Rust never mints user-facing tokens
-//! here — these endpoints only answer "is this password valid?" and
-//! "make sure a user row exists for this social identity".
+//! provision social identities. Rust never mints user-facing tokens here —
+//! these endpoints only answer "is this password valid?" and "make sure a
+//! user row exists for this social identity".
+//!
+//! Identity model: uniqueness lives on `user_identity(provider, provider_subject)`.
+//! `user.email_normalised` is a non-unique lookup attribute — accounts are
+//! never auto-linked on email match. A second provider for the same person
+//! becomes a deliberate, authenticated FE linking flow (not in BE-1).
 
 use axum::{Json, extract::State};
 use serde::{Deserialize, Serialize};
@@ -13,6 +18,8 @@ use crate::api::models::{
 use crate::auth::hmac::HmacVerifiedJson;
 use crate::auth::password;
 use crate::db::DbConn;
+
+const CREDENTIALS_PROVIDER: &str = "credentials";
 
 // ── verify-credentials ────────────────────────────────────────────────────────
 
@@ -42,7 +49,15 @@ pub async fn verify_credentials(
         return Err(AppError::Unauthorized);
     }
 
-    let user = find_user_by_email_normalised(&db, &email_normalised).await?;
+    // Lookup via user_identity — the canonical identity key. Every credentials
+    // user has exactly one ('credentials', email_normalised) identity row,
+    // enforced by the UNIQUE index on user_identity.
+    let identity = find_identity(&db, CREDENTIALS_PROVIDER, &email_normalised).await?;
+    let user = match identity {
+        Some(i) => find_user_by_id(&db, &i.user_id).await?,
+        None => None,
+    };
+
     let stored_hash = user.as_ref().and_then(|u| u.password_hash.as_deref());
     let matches = password::verify_or_dummy(&req.password, stored_hash)?;
 
@@ -83,6 +98,9 @@ pub struct EnsureUserRequest {
     pub provider: String,
     pub provider_subject: String,
     pub email: String,
+    /// Recorded on the identity row for audit only. Never used as a linking
+    /// signal — see module-level doc and Plan 3 social edge cases.
+    #[serde(default)]
     pub email_verified: bool,
 }
 
@@ -108,14 +126,12 @@ pub async fn ensure_user(
     if req.provider_subject.trim().is_empty() {
         return Err(AppError::BadRequest("providerSubject required".into()));
     }
-    let email_normalised = req.email.trim().to_lowercase();
-    if email_normalised.is_empty() {
+    if req.email.trim().is_empty() {
         return Err(AppError::BadRequest("email required".into()));
     }
 
-    if let Some(identity) =
-        find_identity(&db, &req.provider, &req.provider_subject).await?
-    {
+    // Same subject twice → idempotent reuse.
+    if let Some(identity) = find_identity(&db, &req.provider, &req.provider_subject).await? {
         let user = find_user_by_id(&db, &identity.user_id)
             .await?
             .ok_or_else(|| AppError::Internal("identity references missing user".into()))?;
@@ -127,24 +143,9 @@ pub async fn ensure_user(
         }));
     }
 
-    let (user_id, user_email, role, created) = if req.email_verified {
-        match find_user_by_email_normalised(&db, &email_normalised).await? {
-            Some(u) => {
-                let id = record_id_to_string(u.id);
-                (id, u.email, u.role, false)
-            }
-            None => create_social_user(&db, &req.email, &email_normalised).await?,
-        }
-    } else {
-        // Unverified provider email → never link to an existing account.
-        // Use a provider-scoped normalised key so we don't collide with
-        // (or squat on) a legitimate verified signup of the same address.
-        let scoped = format!(
-            "unverified:{}:{}",
-            req.provider, req.provider_subject
-        );
-        create_social_user(&db, &req.email, &scoped).await?
-    };
+    // New subject → always a new user. We deliberately do NOT look up by
+    // email. Account linking is an explicit FE flow for a signed-in user.
+    let (user_id, user_email, role) = create_social_user(&db, &req.email).await?;
 
     let identity = UserIdentityContent {
         user_id: user_id.clone(),
@@ -159,19 +160,18 @@ pub async fn ensure_user(
         user_id,
         email: user_email,
         role,
-        created,
+        created: true,
     }))
 }
 
 async fn create_social_user(
     db: &DbConn,
     email: &str,
-    email_normalised: &str,
-) -> Result<(String, String, String, bool), AppError> {
+) -> Result<(String, String, String), AppError> {
     let now = now_iso();
     let content = UserContent {
         email: email.to_string(),
-        email_normalised: email_normalised.to_string(),
+        email_normalised: email.trim().to_lowercase(),
         password_hash: None,
         role: "member".into(),
         status: "active".into(),
@@ -183,28 +183,10 @@ async fn create_social_user(
     };
     let created: Option<DbUser> = db.create("user").content(content).await?;
     let created = created.ok_or_else(|| AppError::Internal("user insert returned none".into()))?;
-    Ok((
-        record_id_to_string(created.id),
-        created.email,
-        created.role,
-        true,
-    ))
+    Ok((record_id_to_string(created.id), created.email, created.role))
 }
 
 // ── DB helpers ────────────────────────────────────────────────────────────────
-
-async fn find_user_by_email_normalised(
-    db: &DbConn,
-    email_normalised: &str,
-) -> Result<Option<DbUser>, AppError> {
-    let mut resp = db
-        .query("SELECT * FROM user WHERE email_normalised = $email LIMIT 1")
-        .bind(("email", email_normalised.to_string()))
-        .await?
-        .check()?;
-    let rows: Vec<DbUser> = resp.take(0)?;
-    Ok(rows.into_iter().next())
-}
 
 async fn find_user_by_id(db: &DbConn, id: &str) -> Result<Option<DbUser>, AppError> {
     let row: Option<DbUser> = db.select(("user", id)).await?;

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -21,6 +21,13 @@ use crate::db::DbConn;
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
 
+// Per-field length caps. HMAC already caps the whole body at 1 MiB, but within
+// that budget a multi-hundred-KB password would burn Argon2 CPU and a
+// pathological provider_subject would bloat the DB. Reject at the edge.
+const MAX_EMAIL_LEN: usize = 320; // RFC 5321 local+domain max
+const MAX_PASSWORD_LEN: usize = 1024;
+const MAX_PROVIDER_SUBJECT_LEN: usize = 255;
+
 // ── verify-credentials ────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -43,6 +50,12 @@ pub async fn verify_credentials(
     State(db): State<DbConn>,
     HmacVerifiedJson(req): HmacVerifiedJson<VerifyCredentialsRequest>,
 ) -> Result<Json<VerifyCredentialsResponse>, AppError> {
+    if req.email.len() > MAX_EMAIL_LEN {
+        return Err(AppError::BadRequest("email too long".into()));
+    }
+    if req.password.len() > MAX_PASSWORD_LEN {
+        return Err(AppError::BadRequest("password too long".into()));
+    }
     let email_normalised = req.email.trim().to_lowercase();
     if email_normalised.is_empty() || req.password.is_empty() {
         let _ = record_auth_event(&db, None, "login_failure", false, Some("missing_fields")).await;
@@ -126,8 +139,14 @@ pub async fn ensure_user(
     if req.provider_subject.trim().is_empty() {
         return Err(AppError::BadRequest("providerSubject required".into()));
     }
+    if req.provider_subject.len() > MAX_PROVIDER_SUBJECT_LEN {
+        return Err(AppError::BadRequest("providerSubject too long".into()));
+    }
     if req.email.trim().is_empty() {
         return Err(AppError::BadRequest("email required".into()));
+    }
+    if req.email.len() > MAX_EMAIL_LEN {
+        return Err(AppError::BadRequest("email too long".into()));
     }
 
     // Same subject twice → idempotent reuse.

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -227,6 +227,15 @@ async fn record_auth_event(
         reason: reason.map(str::to_string),
         created_at: now_iso(),
     };
-    let _: Option<DbAuthEvent> = db.create("auth_event").content(content).await?;
-    Ok(())
+    // auth_event writes are fire-and-forget at every callsite (we don't want
+    // telemetry failure to block a login), but a silent swallow would hide a
+    // regression that stops populating the audit trail. Warn here so ops can
+    // alert on "auth_event insert failed" without affecting the request path.
+    match db.create::<Option<DbAuthEvent>>("auth_event").content(content).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            tracing::warn!(error = %e, event_type, "auth_event insert failed");
+            Err(e.into())
+        }
+    }
 }

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -238,9 +238,10 @@ async fn create_social_user(
     email: &str,
 ) -> Result<(String, String, String), AppError> {
     let now = now_iso();
+    let trimmed_email = email.trim().to_string();
     let content = UserContent {
-        email: email.to_string(),
-        email_normalised: email.trim().to_lowercase(),
+        email: trimmed_email.clone(),
+        email_normalised: trimmed_email.to_lowercase(),
         password_hash: None,
         role: "member".into(),
         status: "active".into(),

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -66,8 +66,18 @@ pub async fn verify_credentials(
     // user has exactly one ('credentials', email_normalised) identity row,
     // enforced by the UNIQUE index on user_identity.
     let identity = find_identity(&db, CREDENTIALS_PROVIDER, &email_normalised).await?;
-    let user = match identity {
-        Some(i) => find_user_by_id(&db, &i.user_id).await?,
+    let user = match &identity {
+        Some(i) => {
+            let u = find_user_by_id(&db, &i.user_id).await?;
+            if u.is_none() {
+                // Orphaned identity — row exists but its user is gone. This
+                // indicates DB corruption, not a user-facing auth failure.
+                return Err(AppError::Internal(
+                    "identity references missing user".into(),
+                ));
+            }
+            u
+        }
         None => None,
     };
 
@@ -111,10 +121,6 @@ pub struct EnsureUserRequest {
     pub provider: String,
     pub provider_subject: String,
     pub email: String,
-    /// Recorded on the identity row for audit only. Never used as a linking
-    /// signal — see module-level doc and Plan 3 social edge cases.
-    #[serde(default)]
-    pub email_verified: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -154,6 +160,7 @@ pub async fn ensure_user(
         let user = find_user_by_id(&db, &identity.user_id)
             .await?
             .ok_or_else(|| AppError::Internal("identity references missing user".into()))?;
+        reject_if_not_active(&user)?;
         return Ok(Json(EnsureUserResponse {
             user_id: identity.user_id,
             email: user.email,
@@ -168,19 +175,62 @@ pub async fn ensure_user(
 
     let identity = UserIdentityContent {
         user_id: user_id.clone(),
-        provider: req.provider,
-        provider_subject: req.provider_subject,
+        provider: req.provider.clone(),
+        provider_subject: req.provider_subject.clone(),
         email_at_link: req.email,
         created_at: now_iso(),
     };
-    let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
 
-    Ok(Json(EnsureUserResponse {
-        user_id,
-        email: user_email,
-        role,
-        created: true,
-    }))
+    match db
+        .create::<Option<DbUserIdentity>>("user_identity")
+        .content(identity)
+        .await
+    {
+        Ok(_) => Ok(Json(EnsureUserResponse {
+            user_id,
+            email: user_email,
+            role,
+            created: true,
+        })),
+        Err(err) if is_unique_constraint_error(&err.to_string()) => {
+            // A concurrent ensure_user for the same (provider, subject) won the
+            // identity insert race. Reuse the existing row and clean up the
+            // user we just created so it doesn't remain orphaned.
+            let existing = find_identity(&db, &req.provider, &req.provider_subject)
+                .await?
+                .ok_or_else(|| {
+                    AppError::Internal(
+                        "user_identity insert raced but identity was not found".into(),
+                    )
+                })?;
+            let existing_user = find_user_by_id(&db, &existing.user_id)
+                .await?
+                .ok_or_else(|| AppError::Internal("identity references missing user".into()))?;
+            reject_if_not_active(&existing_user)?;
+
+            let _: Option<DbUser> = db.delete(("user", user_id.as_str())).await.unwrap_or(None);
+
+            Ok(Json(EnsureUserResponse {
+                user_id: existing.user_id,
+                email: existing_user.email,
+                role: existing_user.role,
+                created: false,
+            }))
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn reject_if_not_active(user: &DbUser) -> Result<(), AppError> {
+    if user.status != "active" || user.deleted_at.is_some() {
+        return Err(AppError::Forbidden("user is not active".into()));
+    }
+    Ok(())
+}
+
+fn is_unique_constraint_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("already contains") || lower.contains("unique") || lower.contains("duplicate")
 }
 
 async fn create_social_user(
@@ -246,15 +296,16 @@ async fn record_auth_event(
         reason: reason.map(str::to_string),
         created_at: now_iso(),
     };
-    // auth_event writes are fire-and-forget at every callsite (we don't want
-    // telemetry failure to block a login), but a silent swallow would hide a
-    // regression that stops populating the audit trail. Warn here so ops can
-    // alert on "auth_event insert failed" without affecting the request path.
-    match db.create::<Option<DbAuthEvent>>("auth_event").content(content).await {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            tracing::warn!(error = %e, event_type, "auth_event insert failed");
-            Err(e.into())
-        }
+    // auth_event writes are fire-and-forget at every callsite: telemetry
+    // failure must never block a login. We still warn so ops can alert on
+    // "auth_event insert failed" without the error propagating into the
+    // request path. Always return Ok to make misuse impossible.
+    if let Err(e) = db
+        .create::<Option<DbAuthEvent>>("auth_event")
+        .content(content)
+        .await
+    {
+        tracing::warn!(error = %e, event_type, "auth_event insert failed");
     }
+    Ok(())
 }

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -1,0 +1,250 @@
+//! HMAC-gated endpoints called by NextAuth to authenticate users and to
+//! provision / link social identities. Rust never mints user-facing tokens
+//! here — these endpoints only answer "is this password valid?" and
+//! "make sure a user row exists for this social identity".
+
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+
+use crate::api::models::{
+    AppError, AuthEventContent, DbAuthEvent, DbUser, DbUserIdentity, UserContent,
+    UserIdentityContent, now_iso, record_id_to_string,
+};
+use crate::auth::hmac::HmacVerifiedJson;
+use crate::auth::password;
+use crate::db::DbConn;
+
+// ── verify-credentials ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyCredentialsRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyCredentialsResponse {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub must_reset_password: bool,
+}
+
+pub async fn verify_credentials(
+    State(db): State<DbConn>,
+    HmacVerifiedJson(req): HmacVerifiedJson<VerifyCredentialsRequest>,
+) -> Result<Json<VerifyCredentialsResponse>, AppError> {
+    let email_normalised = req.email.trim().to_lowercase();
+    if email_normalised.is_empty() || req.password.is_empty() {
+        let _ = record_auth_event(&db, None, "login_failure", false, Some("missing_fields")).await;
+        return Err(AppError::Unauthorized);
+    }
+
+    let user = find_user_by_email_normalised(&db, &email_normalised).await?;
+    let stored_hash = user.as_ref().and_then(|u| u.password_hash.as_deref());
+    let matches = password::verify_or_dummy(&req.password, stored_hash)?;
+
+    let Some(user) = user else {
+        let _ = record_auth_event(&db, None, "login_failure", false, Some("unknown_email")).await;
+        return Err(AppError::Unauthorized);
+    };
+
+    if !matches {
+        let uid = record_id_to_string(user.id.clone());
+        let _ = record_auth_event(&db, Some(uid), "login_failure", false, Some("bad_password"))
+            .await;
+        return Err(AppError::Unauthorized);
+    }
+
+    if user.status != "active" || user.deleted_at.is_some() {
+        let uid = record_id_to_string(user.id.clone());
+        let _ = record_auth_event(&db, Some(uid), "login_failure", false, Some("disabled")).await;
+        return Err(AppError::Unauthorized);
+    }
+
+    let user_id = record_id_to_string(user.id);
+    let _ = record_auth_event(&db, Some(user_id.clone()), "login_success", true, None).await;
+
+    Ok(Json(VerifyCredentialsResponse {
+        user_id,
+        email: user.email,
+        role: user.role,
+        must_reset_password: user.must_reset_password,
+    }))
+}
+
+// ── ensure-user (social JIT provisioning) ─────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnsureUserRequest {
+    pub provider: String,
+    pub provider_subject: String,
+    pub email: String,
+    pub email_verified: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnsureUserResponse {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub created: bool,
+}
+
+pub async fn ensure_user(
+    State(db): State<DbConn>,
+    HmacVerifiedJson(req): HmacVerifiedJson<EnsureUserRequest>,
+) -> Result<Json<EnsureUserResponse>, AppError> {
+    if !matches!(req.provider.as_str(), "google" | "github" | "apple") {
+        return Err(AppError::BadRequest(format!(
+            "unsupported provider: {}",
+            req.provider
+        )));
+    }
+    if req.provider_subject.trim().is_empty() {
+        return Err(AppError::BadRequest("providerSubject required".into()));
+    }
+    let email_normalised = req.email.trim().to_lowercase();
+    if email_normalised.is_empty() {
+        return Err(AppError::BadRequest("email required".into()));
+    }
+
+    if let Some(identity) =
+        find_identity(&db, &req.provider, &req.provider_subject).await?
+    {
+        let user = find_user_by_id(&db, &identity.user_id)
+            .await?
+            .ok_or_else(|| AppError::Internal("identity references missing user".into()))?;
+        return Ok(Json(EnsureUserResponse {
+            user_id: identity.user_id,
+            email: user.email,
+            role: user.role,
+            created: false,
+        }));
+    }
+
+    let (user_id, user_email, role, created) = if req.email_verified {
+        match find_user_by_email_normalised(&db, &email_normalised).await? {
+            Some(u) => {
+                let id = record_id_to_string(u.id);
+                (id, u.email, u.role, false)
+            }
+            None => create_social_user(&db, &req.email, &email_normalised).await?,
+        }
+    } else {
+        // Unverified provider email → never link to an existing account.
+        // Use a provider-scoped normalised key so we don't collide with
+        // (or squat on) a legitimate verified signup of the same address.
+        let scoped = format!(
+            "unverified:{}:{}",
+            req.provider, req.provider_subject
+        );
+        create_social_user(&db, &req.email, &scoped).await?
+    };
+
+    let identity = UserIdentityContent {
+        user_id: user_id.clone(),
+        provider: req.provider,
+        provider_subject: req.provider_subject,
+        email_at_link: req.email,
+        created_at: now_iso(),
+    };
+    let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
+
+    Ok(Json(EnsureUserResponse {
+        user_id,
+        email: user_email,
+        role,
+        created,
+    }))
+}
+
+async fn create_social_user(
+    db: &DbConn,
+    email: &str,
+    email_normalised: &str,
+) -> Result<(String, String, String, bool), AppError> {
+    let now = now_iso();
+    let content = UserContent {
+        email: email.to_string(),
+        email_normalised: email_normalised.to_string(),
+        password_hash: None,
+        role: "member".into(),
+        status: "active".into(),
+        token_version: 0,
+        must_reset_password: false,
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+    };
+    let created: Option<DbUser> = db.create("user").content(content).await?;
+    let created = created.ok_or_else(|| AppError::Internal("user insert returned none".into()))?;
+    Ok((
+        record_id_to_string(created.id),
+        created.email,
+        created.role,
+        true,
+    ))
+}
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+async fn find_user_by_email_normalised(
+    db: &DbConn,
+    email_normalised: &str,
+) -> Result<Option<DbUser>, AppError> {
+    let mut resp = db
+        .query("SELECT * FROM user WHERE email_normalised = $email LIMIT 1")
+        .bind(("email", email_normalised.to_string()))
+        .await?
+        .check()?;
+    let rows: Vec<DbUser> = resp.take(0)?;
+    Ok(rows.into_iter().next())
+}
+
+async fn find_user_by_id(db: &DbConn, id: &str) -> Result<Option<DbUser>, AppError> {
+    let row: Option<DbUser> = db.select(("user", id)).await?;
+    Ok(row)
+}
+
+async fn find_identity(
+    db: &DbConn,
+    provider: &str,
+    provider_subject: &str,
+) -> Result<Option<DbUserIdentity>, AppError> {
+    let mut resp = db
+        .query(
+            "SELECT * FROM user_identity \
+             WHERE provider = $p AND provider_subject = $s LIMIT 1",
+        )
+        .bind(("p", provider.to_string()))
+        .bind(("s", provider_subject.to_string()))
+        .await?
+        .check()?;
+    let rows: Vec<DbUserIdentity> = resp.take(0)?;
+    Ok(rows.into_iter().next())
+}
+
+async fn record_auth_event(
+    db: &DbConn,
+    user_id: Option<String>,
+    event_type: &str,
+    success: bool,
+    reason: Option<&str>,
+) -> Result<(), AppError> {
+    let content = AuthEventContent {
+        user_id,
+        event_type: event_type.into(),
+        ip: None,
+        user_agent: None,
+        success,
+        reason: reason.map(str::to_string),
+        created_at: now_iso(),
+    };
+    let _: Option<DbAuthEvent> = db.create("auth_event").content(content).await?;
+    Ok(())
+}

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -62,7 +62,7 @@ pub async fn get_members(
     let filtered: Vec<Member> = members
         .into_iter()
         .filter(|m| m.deleted_at.is_none())
-        .filter(|m| params.group_id.as_ref().map_or(true, |gid| m.group_id == *gid))
+        .filter(|m| params.group_id.as_ref().is_none_or(|gid| m.group_id == *gid))
         .collect();
 
     Ok(Json(filtered))
@@ -78,7 +78,7 @@ pub async fn get_cycles(
 
     let filtered: Vec<Cycle> = cycles
         .into_iter()
-        .filter(|c| params.group_id.as_ref().map_or(true, |gid| c.group_id == *gid))
+        .filter(|c| params.group_id.as_ref().is_none_or(|gid| c.group_id == *gid))
         .collect();
 
     Ok(Json(filtered))
@@ -96,7 +96,7 @@ pub async fn get_payments(
     let filtered: Vec<Payment> = payments
         .into_iter()
         .filter(|p| p.deleted_at.is_none())
-        .filter(|p| params.cycle_id.as_ref().map_or(true, |cid| p.cycle_id == *cid))
+        .filter(|p| params.cycle_id.as_ref().is_none_or(|cid| p.cycle_id == *cid))
         .collect();
 
     Ok(Json(filtered))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,7 +54,11 @@ pub fn router(db: DbConn) -> Router {
         .route("/api/auth/verify-credentials", post(auth_endpoints::verify_credentials))
         .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user));
 
-    if std::env::var("APP_ENV").as_deref() != Ok("production") {
+    // Fail-closed: the destructive test reset endpoint is only mounted when
+    // APP_ENV is explicitly "development" or "test". If the env var is
+    // misconfigured or missing on a staging/prod deploy, the endpoint stays
+    // unreachable — previously an unset APP_ENV exposed it by default.
+    if matches!(std::env::var("APP_ENV").as_deref(), Ok("development" | "test")) {
         router = router.route("/api/test/reset", post(reset_db));
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod auth_endpoints;
 pub mod handlers;
 pub mod models;
 
@@ -48,7 +49,10 @@ pub fn router(db: DbConn) -> Router {
         // Admin WhatsApp link endpoints
         .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
         .route("/api/admin/whatsapp-links", post(create_whatsapp_link))
-        .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link));
+        .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link))
+        // HMAC-gated auth endpoints (called by NextAuth)
+        .route("/api/auth/verify-credentials", post(auth_endpoints::verify_credentials))
+        .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user));
 
     if std::env::var("APP_ENV").as_deref() != Ok("production") {
         router = router.route("/api/test/reset", post(reset_db));

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -25,6 +25,7 @@ pub enum AppError {
     NotFound(String),
     BadRequest(String),
     Unauthorized,
+    Forbidden(String),
     Conflict(String),
     Internal(String),
 }
@@ -35,6 +36,7 @@ impl IntoResponse for AppError {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized".to_string()),
+            AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
             AppError::Conflict(msg) => (StatusCode::CONFLICT, msg),
             // Don't leak internal error details to the caller.
             AppError::Internal(_) => (
@@ -935,3 +937,77 @@ fn is_valid_date(s: &str) -> bool {
 pub fn now_iso() -> String {
     chrono::Utc::now().to_rfc3339()
 }
+
+// ── Auth models ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct UserContent {
+    pub email: String,
+    pub email_normalised: String,
+    pub password_hash: Option<String>,
+    pub role: String,
+    pub status: String,
+    pub token_version: i64,
+    pub must_reset_password: bool,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbUser {
+    pub id: RecordId,
+    pub email: String,
+    pub email_normalised: String,
+    pub password_hash: Option<String>,
+    pub role: String,
+    pub status: String,
+    pub token_version: i64,
+    pub must_reset_password: bool,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct UserIdentityContent {
+    pub user_id: String,
+    pub provider: String,
+    pub provider_subject: String,
+    pub email_at_link: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbUserIdentity {
+    pub id: RecordId,
+    pub user_id: String,
+    pub provider: String,
+    pub provider_subject: String,
+    pub email_at_link: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct AuthEventContent {
+    pub user_id: Option<String>,
+    pub event_type: String,
+    pub ip: Option<String>,
+    pub user_agent: Option<String>,
+    pub success: bool,
+    pub reason: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbAuthEvent {
+    pub id: RecordId,
+    pub user_id: Option<String>,
+    pub event_type: String,
+    pub ip: Option<String>,
+    pub user_agent: Option<String>,
+    pub success: bool,
+    pub reason: Option<String>,
+    pub created_at: String,
+}
+

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -1,0 +1,87 @@
+//! Bootstrap the first admin user from env vars.
+//!
+//! Runs once at startup and on demand in tests. Idempotent: if any active
+//! admin user already exists, this is a no-op.
+
+use tracing::{info, warn};
+
+use crate::api::models::{AuthEventContent, DbAuthEvent, DbUser, UserContent, now_iso};
+use crate::auth::password;
+use crate::db::DbConn;
+
+const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
+
+/// Seed the initial admin account if none exists and the required env vars
+/// are set. Safe to call on every boot.
+pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
+    let email = std::env::var("BOOTSTRAP_ADMIN_EMAIL").unwrap_or_default();
+    let password_plain = std::env::var("BOOTSTRAP_ADMIN_PASSWORD").unwrap_or_default();
+
+    if email.is_empty() || password_plain.is_empty() {
+        return Ok(());
+    }
+
+    if active_admin_exists(db).await? {
+        info!("Bootstrap admin already present — skipping seed");
+        return Ok(());
+    }
+
+    let password_hash = match password::hash(&password_plain) {
+        Ok(h) => h,
+        Err(e) => {
+            warn!(error = ?e, "Failed to hash bootstrap admin password — skipping seed");
+            return Ok(());
+        }
+    };
+
+    let now = now_iso();
+    let content = UserContent {
+        email: email.clone(),
+        email_normalised: email.to_lowercase(),
+        password_hash: Some(password_hash),
+        role: "admin".into(),
+        status: "active".into(),
+        token_version: 0,
+        must_reset_password: true,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        deleted_at: None,
+    };
+    let created: Option<DbUser> = db.create("user").content(content).await?;
+
+    let user_id = created.map(|u| crate::api::models::record_id_to_string(u.id));
+    let event = AuthEventContent {
+        user_id,
+        event_type: BOOTSTRAP_EVENT_TYPE.into(),
+        ip: None,
+        user_agent: None,
+        success: true,
+        reason: None,
+        created_at: now,
+    };
+    let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
+
+    info!(email_redacted = redact(&email), "Bootstrap admin created");
+    Ok(())
+}
+
+async fn active_admin_exists(db: &DbConn) -> Result<bool, surrealdb::Error> {
+    let mut resp = db
+        .query("SELECT count() FROM user WHERE role = 'admin' AND deleted_at IS NONE GROUP ALL")
+        .await?
+        .check()?;
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    Ok(rows.first().copied().unwrap_or(0) > 0)
+}
+
+/// Redact everything except the first character and the domain, so the log
+/// line is useful for ops without echoing the raw address.
+fn redact(email: &str) -> String {
+    match email.split_once('@') {
+        Some((local, domain)) => {
+            let first = local.chars().next().unwrap_or('?');
+            format!("{first}***@{domain}")
+        }
+        None => "***".into(),
+    }
+}

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -17,7 +17,10 @@ const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
 /// Seed the initial admin account if none exists and the required env vars
 /// are set. Safe to call on every boot.
 pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
-    let email = std::env::var("BOOTSTRAP_ADMIN_EMAIL").unwrap_or_default();
+    let email = std::env::var("BOOTSTRAP_ADMIN_EMAIL")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
     let password_plain = std::env::var("BOOTSTRAP_ADMIN_PASSWORD").unwrap_or_default();
 
     if email.is_empty() || password_plain.is_empty() {
@@ -55,23 +58,30 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
         deleted_at: None,
     };
     let created: Option<DbUser> = db.create("user").content(content).await?;
-    let user_id = created.map(|u| record_id_to_string(u.id));
+    let user_id = match created {
+        Some(u) => record_id_to_string(u.id),
+        None => {
+            warn!(
+                email_redacted = redact(&email),
+                "Bootstrap admin user create returned no record — skipping seed"
+            );
+            return Ok(());
+        }
+    };
 
     // Identity row keyed on ('credentials', email_normalised) — this is how
     // verify-credentials finds the admin. Without it, login would 401.
-    if let Some(uid) = user_id.as_deref() {
-        let identity = UserIdentityContent {
-            user_id: uid.to_string(),
-            provider: "credentials".into(),
-            provider_subject: email_normalised,
-            email_at_link: email.clone(),
-            created_at: now.clone(),
-        };
-        let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
-    }
+    let identity = UserIdentityContent {
+        user_id: user_id.clone(),
+        provider: "credentials".into(),
+        provider_subject: email_normalised,
+        email_at_link: email.clone(),
+        created_at: now.clone(),
+    };
+    let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
 
     let event = AuthEventContent {
-        user_id,
+        user_id: Some(user_id),
         event_type: BOOTSTRAP_EVENT_TYPE.into(),
         ip: None,
         user_agent: None,
@@ -87,7 +97,7 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
 
 async fn active_admin_exists(db: &DbConn) -> Result<bool, surrealdb::Error> {
     let mut resp = db
-        .query("SELECT count() FROM user WHERE role IN ['admin', 'super_admin'] AND deleted_at IS NONE GROUP ALL")
+        .query("SELECT count() FROM user WHERE role IN ['admin', 'super_admin'] AND status = 'active' AND deleted_at IS NONE GROUP ALL")
         .await?
         .check()?;
     let rows: Vec<i64> = resp.take("count").unwrap_or_default();

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -5,7 +5,10 @@
 
 use tracing::{info, warn};
 
-use crate::api::models::{AuthEventContent, DbAuthEvent, DbUser, UserContent, now_iso};
+use crate::api::models::{
+    AuthEventContent, DbAuthEvent, DbUser, DbUserIdentity, UserContent, UserIdentityContent,
+    now_iso, record_id_to_string,
+};
 use crate::auth::password;
 use crate::db::DbConn;
 
@@ -35,9 +38,10 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
     };
 
     let now = now_iso();
+    let email_normalised = email.to_lowercase();
     let content = UserContent {
         email: email.clone(),
-        email_normalised: email.to_lowercase(),
+        email_normalised: email_normalised.clone(),
         password_hash: Some(password_hash),
         role: "admin".into(),
         status: "active".into(),
@@ -48,8 +52,21 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
         deleted_at: None,
     };
     let created: Option<DbUser> = db.create("user").content(content).await?;
+    let user_id = created.map(|u| record_id_to_string(u.id));
 
-    let user_id = created.map(|u| crate::api::models::record_id_to_string(u.id));
+    // Identity row keyed on ('credentials', email_normalised) — this is how
+    // verify-credentials finds the admin. Without it, login would 401.
+    if let Some(uid) = user_id.as_deref() {
+        let identity = UserIdentityContent {
+            user_id: uid.to_string(),
+            provider: "credentials".into(),
+            provider_subject: email_normalised,
+            email_at_link: email.clone(),
+            created_at: now.clone(),
+        };
+        let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
+    }
+
     let event = AuthEventContent {
         user_id,
         event_type: BOOTSTRAP_EVENT_TYPE.into(),

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -43,7 +43,10 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
         email: email.clone(),
         email_normalised: email_normalised.clone(),
         password_hash: Some(password_hash),
-        role: "admin".into(),
+        // Seed the first operator as super_admin — they vet and admit all
+        // subsequent admins. Only super_admins can manage other admin users
+        // (add, promote, disable, assign/revoke group access).
+        role: "super_admin".into(),
         status: "active".into(),
         token_version: 0,
         must_reset_password: true,
@@ -84,7 +87,7 @@ pub async fn ensure_admin_user(db: &DbConn) -> Result<(), surrealdb::Error> {
 
 async fn active_admin_exists(db: &DbConn) -> Result<bool, surrealdb::Error> {
     let mut resp = db
-        .query("SELECT count() FROM user WHERE role = 'admin' AND deleted_at IS NONE GROUP ALL")
+        .query("SELECT count() FROM user WHERE role IN ['admin', 'super_admin'] AND deleted_at IS NONE GROUP ALL")
         .await?
         .check()?;
     let rows: Vec<i64> = resp.take("count").unwrap_or_default();

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -56,8 +56,7 @@ where
 
         verify_signature(&secret, timestamp, &bytes, &signature_hex)?;
 
-        let value: T = serde_json::from_slice(&bytes)
-            .map_err(|e| AppError::BadRequest(format!("invalid JSON body: {e}")))?;
+        let value: T = serde_json::from_slice(&bytes).map_err(|_| AppError::Unauthorized)?;
         Ok(HmacVerifiedJson(value))
     }
 }

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -1,0 +1,119 @@
+//! HMAC-SHA256 request authentication for NextAuth → backend calls.
+//!
+//! The NextAuth app signs each request with a shared secret. We verify:
+//!   - `X-Signature: sha256=<hex>` over `timestamp + "." + raw_body`
+//!   - `X-Timestamp` within ±60 s of server time (prevents replay)
+//!
+//! The extractor re-serialises the body for downstream JSON deserialisation.
+
+use axum::{
+    body::{Bytes, to_bytes},
+    extract::{FromRequest, Request},
+    http::HeaderMap,
+};
+use hmac::{Hmac, Mac};
+use serde::de::DeserializeOwned;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+use crate::api::models::AppError;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Max body size accepted by HMAC-protected endpoints (1 MiB — NextAuth
+/// payloads are a few hundred bytes at most).
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Replay protection window in seconds.
+const TIMESTAMP_TOLERANCE_SECS: i64 = 60;
+
+/// Extractor: verifies the HMAC signature then deserialises the JSON body
+/// into `T`. Returns 401 for any signing/replay/body failure so the caller
+/// cannot probe which specific check failed.
+pub struct HmacVerifiedJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for HmacVerifiedJson<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = AppError;
+
+    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let secret = std::env::var("NEXTAUTH_BACKEND_SECRET").unwrap_or_default();
+        if secret.is_empty() {
+            tracing::error!("NEXTAUTH_BACKEND_SECRET is not set — rejecting HMAC request");
+            return Err(AppError::Unauthorized);
+        }
+
+        let (parts, body) = req.into_parts();
+        let timestamp = extract_timestamp(&parts.headers)?;
+        let signature_hex = extract_signature(&parts.headers)?;
+
+        let bytes = to_bytes(body, MAX_BODY_BYTES)
+            .await
+            .map_err(|_| AppError::Unauthorized)?;
+
+        verify_signature(&secret, timestamp, &bytes, &signature_hex)?;
+
+        let value: T = serde_json::from_slice(&bytes)
+            .map_err(|e| AppError::BadRequest(format!("invalid JSON body: {e}")))?;
+        Ok(HmacVerifiedJson(value))
+    }
+}
+
+fn extract_timestamp(headers: &HeaderMap) -> Result<i64, AppError> {
+    let raw = headers
+        .get("x-timestamp")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(AppError::Unauthorized)?;
+    let ts: i64 = raw.parse().map_err(|_| AppError::Unauthorized)?;
+    let now = chrono::Utc::now().timestamp();
+    if (now - ts).abs() > TIMESTAMP_TOLERANCE_SECS {
+        return Err(AppError::Unauthorized);
+    }
+    Ok(ts)
+}
+
+fn extract_signature(headers: &HeaderMap) -> Result<String, AppError> {
+    let raw = headers
+        .get("x-signature")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(AppError::Unauthorized)?;
+    let hex_part = raw.strip_prefix("sha256=").ok_or(AppError::Unauthorized)?;
+    Ok(hex_part.to_string())
+}
+
+fn verify_signature(
+    secret: &str,
+    timestamp: i64,
+    body: &Bytes,
+    provided_hex: &str,
+) -> Result<(), AppError> {
+    let provided = hex::decode(provided_hex).map_err(|_| AppError::Unauthorized)?;
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| AppError::Unauthorized)?;
+    mac.update(timestamp.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    let expected = mac.finalize().into_bytes();
+
+    if expected.len() != provided.len()
+        || !bool::from(expected.as_slice().ct_eq(provided.as_slice()))
+    {
+        return Err(AppError::Unauthorized);
+    }
+    Ok(())
+}
+
+/// Sign a payload using the same scheme. Exposed for integration tests so
+/// they can build valid requests without reimplementing the signing logic.
+#[doc(hidden)]
+pub fn sign_for_testing(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("hmac key");
+    mac.update(timestamp.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    hex::encode(mac.finalize().into_bytes())
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,8 @@
+//! Authentication primitives — password hashing, HMAC signing, bootstrap.
+//!
+//! This module is the foundation layer of the auth stack (Plan 3, BE-1).
+//! JWT, refresh tokens, and request extractors land in subsequent increments.
+
+pub mod bootstrap;
+pub mod hmac;
+pub mod password;

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -1,0 +1,88 @@
+//! Argon2id password hashing with OWASP 2024 parameters.
+//!
+//! `verify_or_dummy` keeps login timing flat: unknown-email paths still run
+//! a full Argon2 verify against a static dummy hash, so an attacker cannot
+//! distinguish "no such user" from "wrong password" by response latency.
+
+use argon2::{Algorithm, Argon2, Params, Version};
+use password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
+use std::sync::OnceLock;
+
+use crate::api::models::AppError;
+
+/// OWASP 2024 baseline: m=19 MiB, t=2, p=1.
+const ARGON2_M_COST_KIB: u32 = 19_456;
+const ARGON2_T_COST: u32 = 2;
+const ARGON2_P_COST: u32 = 1;
+
+/// The placeholder password used to generate `dummy_hash()`. Its value is
+/// irrelevant — it only needs to produce a valid Argon2 PHC string so the
+/// unknown-email branch of `verify-credentials` spends the same CPU as the
+/// known-email branch.
+const DUMMY_PASSWORD: &str = "dummy-password-for-constant-time-verify";
+
+fn argon2() -> Argon2<'static> {
+    let params = Params::new(ARGON2_M_COST_KIB, ARGON2_T_COST, ARGON2_P_COST, None)
+        .expect("argon2 params within valid range");
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+}
+
+/// Hash a plaintext password for storage. Generates a fresh random salt.
+pub fn hash(plaintext: &str) -> Result<String, AppError> {
+    let salt = SaltString::generate(&mut OsRng);
+    argon2()
+        .hash_password(plaintext.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| AppError::Internal(format!("argon2 hash failed: {e}")))
+}
+
+/// Verify a plaintext password against a stored Argon2 PHC hash.
+/// Returns `Ok(true)` on match, `Ok(false)` on mismatch, `Err` only if the
+/// stored hash is malformed.
+pub fn verify(plaintext: &str, stored_hash: &str) -> Result<bool, AppError> {
+    let parsed = PasswordHash::new(stored_hash)
+        .map_err(|e| AppError::Internal(format!("argon2 hash parse failed: {e}")))?;
+    match argon2().verify_password(plaintext.as_bytes(), &parsed) {
+        Ok(()) => Ok(true),
+        Err(password_hash::Error::Password) => Ok(false),
+        Err(e) => Err(AppError::Internal(format!("argon2 verify failed: {e}"))),
+    }
+}
+
+/// Returns `true` iff the provided password matches the stored hash.
+/// When `stored_hash` is `None`, run a verify against a dummy hash to preserve
+/// constant-time behaviour, then return `false`.
+pub fn verify_or_dummy(plaintext: &str, stored_hash: Option<&str>) -> Result<bool, AppError> {
+    match stored_hash {
+        Some(h) => verify(plaintext, h),
+        None => {
+            let _ = verify(plaintext, dummy_hash())?;
+            Ok(false)
+        }
+    }
+}
+
+/// Lazily-initialised Argon2 hash of `DUMMY_PASSWORD`. Salt is generated once
+/// at process start — that is fine because the hash is only ever used to burn
+/// CPU time, not to authenticate anything.
+fn dummy_hash() -> &'static str {
+    static DUMMY: OnceLock<String> = OnceLock::new();
+    DUMMY.get_or_init(|| hash(DUMMY_PASSWORD).expect("dummy hash generation must succeed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_roundtrip() {
+        let h = hash("correct horse battery staple").unwrap();
+        assert!(verify("correct horse battery staple", &h).unwrap());
+        assert!(!verify("wrong password", &h).unwrap());
+    }
+
+    #[test]
+    fn verify_or_dummy_handles_missing_hash() {
+        assert!(!verify_or_dummy("anything", None).unwrap());
+    }
+}

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -70,6 +70,13 @@ fn dummy_hash() -> &'static str {
     DUMMY.get_or_init(|| hash(DUMMY_PASSWORD).expect("dummy hash generation must succeed"))
 }
 
+/// Force the lazy `dummy_hash()` static to initialise now. Call once at boot
+/// so the first unknown-email login does not pay extra Argon2 CPU relative to
+/// the warm path — closes a subtle timing side channel.
+pub fn prewarm() {
+    let _ = dummy_hash();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/db.rs
+++ b/src/db.rs
@@ -67,7 +67,8 @@ async fn define_auth_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
          DEFINE FIELD IF NOT EXISTS email ON user TYPE string;
          DEFINE FIELD IF NOT EXISTS email_normalised ON user TYPE string;
          DEFINE FIELD IF NOT EXISTS password_hash ON user TYPE option<string>;
-         DEFINE FIELD IF NOT EXISTS role ON user TYPE string ASSERT $value IN ['admin', 'member'];
+         DEFINE FIELD IF NOT EXISTS role ON user TYPE string
+             ASSERT $value IN ['super_admin', 'admin', 'member'];
          DEFINE FIELD IF NOT EXISTS status ON user TYPE string ASSERT $value IN ['active', 'disabled'];
          DEFINE FIELD IF NOT EXISTS token_version ON user TYPE int;
          DEFINE FIELD IF NOT EXISTS must_reset_password ON user TYPE bool;

--- a/src/db.rs
+++ b/src/db.rs
@@ -227,7 +227,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
         ("3", MemberContent { name: "Ngozi Adeyemi".into(),   phone: "2349061234567".into(), position: 3, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
         ("4", MemberContent { name: "Tunde Bakare".into(),    phone: "2348031234567".into(), position: 4, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
         ("5", MemberContent { name: "Amaka Nwosu".into(),     phone: "2348161234567".into(), position: 5, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("6", MemberContent { name: "Seun Okafor".into(),     phone: "2347061234567".into(), position: 6, status: "active".into(), group_id: group_id, notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
+        ("6", MemberContent { name: "Seun Okafor".into(),     phone: "2347061234567".into(), position: 6, status: "active".into(), group_id, notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
     ]
 }
 
@@ -288,7 +288,7 @@ fn fixture_cycles() -> Vec<(&'static str, CycleContent)> {
         ("3", CycleContent {
             cycle_number: 9, start_date: "2026-03-01".into(), end_date: "2026-03-31".into(),
             contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "3".into(), status: "active".into(), group_id: group_id, notes: None,
+            recipient_member_id: "3".into(), status: "active".into(), group_id, notes: None,
             created_at: created_at.into(), updated_at: created_at.into(), version: 1,
         }),
     ]

--- a/src/db.rs
+++ b/src/db.rs
@@ -74,7 +74,7 @@ async fn define_auth_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
          DEFINE FIELD IF NOT EXISTS created_at ON user TYPE string;
          DEFINE FIELD IF NOT EXISTS updated_at ON user TYPE string;
          DEFINE FIELD IF NOT EXISTS deleted_at ON user TYPE option<string>;
-         DEFINE INDEX IF NOT EXISTS user_email_normalised ON user FIELDS email_normalised UNIQUE;
+         DEFINE INDEX IF NOT EXISTS user_email_normalised ON user FIELDS email_normalised;
 
          DEFINE TABLE IF NOT EXISTS user_identity SCHEMAFULL;
          DEFINE FIELD IF NOT EXISTS user_id ON user_identity TYPE string;

--- a/src/db.rs
+++ b/src/db.rs
@@ -55,6 +55,48 @@ async fn define_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
     )
     .await?
     .check()?;
+    define_auth_tables(db).await?;
+    Ok(())
+}
+
+/// Auth-specific tables are SCHEMAFULL so the security-critical shape is
+/// enforced at the DB layer rather than relying on application checks alone.
+async fn define_auth_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
+    db.query(
+        "DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS email ON user TYPE string;
+         DEFINE FIELD IF NOT EXISTS email_normalised ON user TYPE string;
+         DEFINE FIELD IF NOT EXISTS password_hash ON user TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS role ON user TYPE string ASSERT $value IN ['admin', 'member'];
+         DEFINE FIELD IF NOT EXISTS status ON user TYPE string ASSERT $value IN ['active', 'disabled'];
+         DEFINE FIELD IF NOT EXISTS token_version ON user TYPE int;
+         DEFINE FIELD IF NOT EXISTS must_reset_password ON user TYPE bool;
+         DEFINE FIELD IF NOT EXISTS created_at ON user TYPE string;
+         DEFINE FIELD IF NOT EXISTS updated_at ON user TYPE string;
+         DEFINE FIELD IF NOT EXISTS deleted_at ON user TYPE option<string>;
+         DEFINE INDEX IF NOT EXISTS user_email_normalised ON user FIELDS email_normalised UNIQUE;
+
+         DEFINE TABLE IF NOT EXISTS user_identity SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS user_id ON user_identity TYPE string;
+         DEFINE FIELD IF NOT EXISTS provider ON user_identity TYPE string
+             ASSERT $value IN ['google', 'github', 'apple', 'credentials'];
+         DEFINE FIELD IF NOT EXISTS provider_subject ON user_identity TYPE string;
+         DEFINE FIELD IF NOT EXISTS email_at_link ON user_identity TYPE string;
+         DEFINE FIELD IF NOT EXISTS created_at ON user_identity TYPE string;
+         DEFINE INDEX IF NOT EXISTS user_identity_provider_subject
+             ON user_identity FIELDS provider, provider_subject UNIQUE;
+
+         DEFINE TABLE IF NOT EXISTS auth_event SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS user_id ON auth_event TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS event_type ON auth_event TYPE string;
+         DEFINE FIELD IF NOT EXISTS ip ON auth_event TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS user_agent ON auth_event TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS success ON auth_event TYPE bool;
+         DEFINE FIELD IF NOT EXISTS reason ON auth_event TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS created_at ON auth_event TYPE string;",
+    )
+    .await?
+    .check()?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod auth;
 pub mod db;
 pub mod extractor;
 pub mod ingestion;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,34 @@ async fn main() {
         warn!("ADMIN_TOKEN is not set — all admin endpoints will return 401");
     }
 
+    // HMAC strength depends on key entropy. hmac.rs only rejects an empty
+    // secret, so a 6-char value would silently pass. Fail fast on anything
+    // shorter than 32 bytes (matches `openssl rand -hex 32` in .env.example).
+    // Panic in production; warn elsewhere so local dev with a throwaway
+    // secret stays frictionless.
+    const MIN_SECRET_LEN: usize = 32;
+    match env::var("NEXTAUTH_BACKEND_SECRET") {
+        Ok(s) if s.len() >= MIN_SECRET_LEN => {}
+        Ok(s) => {
+            let msg = format!(
+                "NEXTAUTH_BACKEND_SECRET must be at least {MIN_SECRET_LEN} bytes (got {})",
+                s.len()
+            );
+            if env::var("APP_ENV").as_deref() == Ok("production") {
+                panic!("{msg}");
+            } else {
+                warn!("{msg} — acceptable in non-production only");
+            }
+        }
+        Err(_) => {
+            if env::var("APP_ENV").as_deref() == Ok("production") {
+                panic!("NEXTAUTH_BACKEND_SECRET must be set in production");
+            } else {
+                warn!("NEXTAUTH_BACKEND_SECRET is not set — HMAC endpoints will reject all requests");
+            }
+        }
+    }
+
     // Pre-warm the dummy Argon2 hash so the first unknown-email login path is
     // not measurably slower than subsequent ones (closes a timing side channel
     // around user enumeration).

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,11 @@ async fn main() {
         warn!("ADMIN_TOKEN is not set — all admin endpoints will return 401");
     }
 
+    // Pre-warm the dummy Argon2 hash so the first unknown-email login path is
+    // not measurably slower than subsequent ones (closes a timing side channel
+    // around user enumeration).
+    auth::password::prewarm();
+
     // Initialise embedded SurrealDB and, if SEED_ON_EMPTY=true and the DB is empty, seed fixture data.
     let surreal_db = db::init()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use poolpay::{api, db, extractor, ingestion, parser, replies, whatsapp};
+use poolpay::{api, auth, db, extractor, ingestion, parser, replies, whatsapp};
 use poolpay::api::models::now_iso;
 
 use dotenv::dotenv;
@@ -34,6 +34,10 @@ async fn main() {
     let surreal_db = db::init()
         .await
         .expect("Failed to initialise SurrealDB");
+
+    if let Err(e) = auth::bootstrap::ensure_admin_user(&surreal_db).await {
+        error!(error = %e, "Bootstrap admin seeding failed");
+    }
 
     // Spawn the Axum HTTP server.
     // Monitored below — if the server dies the process exits rather than

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -22,6 +22,13 @@ use tower::ServiceExt;
 
 /// Build a fresh app backed by an isolated in-memory DB.
 async fn test_app() -> Router {
+    // The /api/test/reset endpoint is only mounted when APP_ENV is "test" or
+    // "development" (fail-closed). Set it once for the whole suite.
+    static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INIT.get_or_init(|| {
+        // Safety: called once before any test reads APP_ENV.
+        unsafe { std::env::set_var("APP_ENV", "test") };
+    });
     let conn = db::init_memory().await.expect("failed to init test DB");
     api::router(conn)
 }

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1,0 +1,263 @@
+//! Integration tests for the Plan 3 / BE-1 auth surface:
+//!   - HMAC-gated `/api/auth/verify-credentials` and `/api/auth/ensure-user`
+//!   - Bootstrap admin idempotency
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    response::Response,
+    Router,
+};
+use http_body_util::BodyExt;
+use poolpay::{
+    api,
+    auth::{bootstrap, hmac::sign_for_testing, password},
+    db,
+};
+use std::sync::OnceLock;
+use tower::ServiceExt;
+
+// ── Shared env setup ──────────────────────────────────────────────────────────
+
+const HMAC_SECRET: &str = "test-hmac-secret-for-integration-only";
+const BOOTSTRAP_EMAIL: &str = "seed-admin@example.com";
+const BOOTSTRAP_PASSWORD: &str = "correct-horse-battery-staple";
+
+fn init_env() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        // Safety: written once before any test reads these vars. Parallel
+        // tests may then read them freely.
+        unsafe {
+            std::env::set_var("NEXTAUTH_BACKEND_SECRET", HMAC_SECRET);
+            std::env::set_var("BOOTSTRAP_ADMIN_EMAIL", BOOTSTRAP_EMAIL);
+            std::env::set_var("BOOTSTRAP_ADMIN_PASSWORD", BOOTSTRAP_PASSWORD);
+        }
+    });
+}
+
+async fn test_app() -> (Router, poolpay::db::DbConn) {
+    init_env();
+    let conn = db::init_memory().await.expect("failed to init test DB");
+    bootstrap::ensure_admin_user(&conn)
+        .await
+        .expect("bootstrap seed must succeed");
+    let router = api::router(conn.clone());
+    (router, conn)
+}
+
+fn hmac_request(uri: &str, body: &serde_json::Value) -> Request<Body> {
+    let body_bytes = serde_json::to_vec(body).unwrap();
+    let ts = chrono::Utc::now().timestamp();
+    let sig = sign_for_testing(HMAC_SECRET, ts, &body_bytes);
+    Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={sig}"))
+        .body(Body::from(body_bytes))
+        .unwrap()
+}
+
+async fn call(app: Router, req: Request<Body>) -> Response {
+    app.oneshot(req).await.unwrap()
+}
+
+async fn json_body<T: serde::de::DeserializeOwned>(resp: Response) -> T {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not valid JSON")
+}
+
+// ── verify-credentials ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn verify_credentials_success_for_bootstrap_admin() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": BOOTSTRAP_PASSWORD,
+    });
+    let resp = call(app, hmac_request("/api/auth/verify-credentials", &body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["email"], BOOTSTRAP_EMAIL);
+    assert_eq!(v["role"], "admin");
+    assert_eq!(v["mustResetPassword"], true);
+    assert!(v["userId"].as_str().unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn verify_credentials_wrong_password_returns_401() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": "not the real password",
+    });
+    let resp = call(app, hmac_request("/api/auth/verify-credentials", &body)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn verify_credentials_unknown_email_returns_401_and_runs_dummy_hash() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": "ghost@example.com",
+        "password": "any",
+    });
+    let resp = call(app, hmac_request("/api/auth/verify-credentials", &body)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn verify_credentials_bad_signature_returns_401() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": BOOTSTRAP_PASSWORD,
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let ts = chrono::Utc::now().timestamp();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/verify-credentials")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", "sha256=deadbeef")
+        .body(Body::from(body_bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn verify_credentials_stale_timestamp_returns_401() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": BOOTSTRAP_PASSWORD,
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let ts = chrono::Utc::now().timestamp() - 600; // 10 minutes old
+    let sig = sign_for_testing(HMAC_SECRET, ts, &body_bytes);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/verify-credentials")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={sig}"))
+        .body(Body::from(body_bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── ensure-user ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ensure_user_creates_and_reuses_on_verified_email() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "google-sub-12345",
+        "email": "Alice@Example.com",
+        "emailVerified": true,
+    });
+    let resp1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &body)).await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+    let v1: serde_json::Value = json_body(resp1).await;
+    assert_eq!(v1["created"], true);
+    assert_eq!(v1["role"], "member");
+    let first_id = v1["userId"].as_str().unwrap().to_string();
+
+    let resp2 = call(app, hmac_request("/api/auth/ensure-user", &body)).await;
+    assert_eq!(resp2.status(), StatusCode::OK);
+    let v2: serde_json::Value = json_body(resp2).await;
+    assert_eq!(v2["created"], false);
+    assert_eq!(v2["userId"].as_str().unwrap(), first_id);
+}
+
+#[tokio::test]
+async fn ensure_user_verified_email_links_to_existing_account() {
+    let (app, _db) = test_app().await;
+    // First: create account via Google.
+    let first = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "sub-google-1",
+        "email": "bob@example.com",
+        "emailVerified": true,
+    });
+    let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &first)).await;
+    let v1: serde_json::Value = json_body(r1).await;
+    let user_id = v1["userId"].as_str().unwrap().to_string();
+
+    // Second: GitHub with same verified email should reuse that user.
+    let second = serde_json::json!({
+        "provider": "github",
+        "providerSubject": "sub-github-1",
+        "email": "bob@example.com",
+        "emailVerified": true,
+    });
+    let r2 = call(app, hmac_request("/api/auth/ensure-user", &second)).await;
+    assert_eq!(r2.status(), StatusCode::OK);
+    let v2: serde_json::Value = json_body(r2).await;
+    assert_eq!(v2["created"], false);
+    assert_eq!(v2["userId"].as_str().unwrap(), user_id);
+}
+
+#[tokio::test]
+async fn ensure_user_unverified_email_never_links_to_existing_account() {
+    let (app, _db) = test_app().await;
+    // Seed via verified Google.
+    let verified = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "sub-google-2",
+        "email": "carol@example.com",
+        "emailVerified": true,
+    });
+    let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &verified)).await;
+    let v1: serde_json::Value = json_body(r1).await;
+    let verified_id = v1["userId"].as_str().unwrap().to_string();
+
+    // Now an UNVERIFIED GitHub signup with the same email must not link.
+    let unverified = serde_json::json!({
+        "provider": "github",
+        "providerSubject": "sub-github-2",
+        "email": "carol@example.com",
+        "emailVerified": false,
+    });
+    let r2 = call(app, hmac_request("/api/auth/ensure-user", &unverified)).await;
+    assert_eq!(r2.status(), StatusCode::OK);
+    let v2: serde_json::Value = json_body(r2).await;
+    assert_eq!(v2["created"], true);
+    assert_ne!(v2["userId"].as_str().unwrap(), verified_id);
+}
+
+// ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn bootstrap_is_idempotent() {
+    let (_app, db) = test_app().await;
+    // Run it a second time — should be a no-op.
+    bootstrap::ensure_admin_user(&db)
+        .await
+        .expect("second bootstrap must succeed");
+
+    let mut resp = db
+        .query("SELECT count() FROM user WHERE role = 'admin' GROUP ALL")
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let counts: Vec<i64> = resp.take("count").unwrap_or_default();
+    assert_eq!(counts.first().copied().unwrap_or(0), 1);
+}
+
+// ── Password primitives sanity check ──────────────────────────────────────────
+
+#[test]
+fn argon2_hash_is_phc_formatted() {
+    let h = password::hash("some password").unwrap();
+    assert!(h.starts_with("$argon2id$"), "expected PHC format, got: {h}");
+    assert!(password::verify("some password", &h).unwrap());
+}

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -178,9 +178,12 @@ async fn ensure_user_creates_and_reuses_on_verified_email() {
 }
 
 #[tokio::test]
-async fn ensure_user_verified_email_links_to_existing_account() {
+async fn ensure_user_second_provider_does_not_auto_link_on_email() {
+    // Industry best practice (Cognito / Auth0 / OAuth BCP): never auto-link
+    // accounts on email match, even when both providers report the email as
+    // verified. A second provider must produce a NEW user — linking is an
+    // explicit FE flow for a signed-in user (deferred to post-BE-6 work).
     let (app, _db) = test_app().await;
-    // First: create account via Google.
     let first = serde_json::json!({
         "provider": "google",
         "providerSubject": "sub-google-1",
@@ -189,9 +192,8 @@ async fn ensure_user_verified_email_links_to_existing_account() {
     });
     let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &first)).await;
     let v1: serde_json::Value = json_body(r1).await;
-    let user_id = v1["userId"].as_str().unwrap().to_string();
+    let google_user_id = v1["userId"].as_str().unwrap().to_string();
 
-    // Second: GitHub with same verified email should reuse that user.
     let second = serde_json::json!({
         "provider": "github",
         "providerSubject": "sub-github-1",
@@ -201,8 +203,8 @@ async fn ensure_user_verified_email_links_to_existing_account() {
     let r2 = call(app, hmac_request("/api/auth/ensure-user", &second)).await;
     assert_eq!(r2.status(), StatusCode::OK);
     let v2: serde_json::Value = json_body(r2).await;
-    assert_eq!(v2["created"], false);
-    assert_eq!(v2["userId"].as_str().unwrap(), user_id);
+    assert_eq!(v2["created"], true);
+    assert_ne!(v2["userId"].as_str().unwrap(), google_user_id);
 }
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -82,7 +82,7 @@ async fn verify_credentials_success_for_bootstrap_admin() {
     assert_eq!(resp.status(), StatusCode::OK);
     let v: serde_json::Value = json_body(resp).await;
     assert_eq!(v["email"], BOOTSTRAP_EMAIL);
-    assert_eq!(v["role"], "admin");
+    assert_eq!(v["role"], "super_admin");
     assert_eq!(v["mustResetPassword"], true);
     assert!(v["userId"].as_str().unwrap().len() > 0);
 }
@@ -246,7 +246,7 @@ async fn bootstrap_is_idempotent() {
         .expect("second bootstrap must succeed");
 
     let mut resp = db
-        .query("SELECT count() FROM user WHERE role = 'admin' GROUP ALL")
+        .query("SELECT count() FROM user WHERE role IN ['admin', 'super_admin'] GROUP ALL")
         .await
         .unwrap()
         .check()

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -84,7 +84,7 @@ async fn verify_credentials_success_for_bootstrap_admin() {
     assert_eq!(v["email"], BOOTSTRAP_EMAIL);
     assert_eq!(v["role"], "super_admin");
     assert_eq!(v["mustResetPassword"], true);
-    assert!(v["userId"].as_str().unwrap().len() > 0);
+    assert!(!v["userId"].as_str().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -235,6 +235,43 @@ async fn ensure_user_unverified_email_never_links_to_existing_account() {
     assert_ne!(v2["userId"].as_str().unwrap(), verified_id);
 }
 
+// ── Field length caps (H-2) ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn verify_credentials_rejects_oversized_email() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": format!("{}@example.com", "a".repeat(400)),
+        "password": BOOTSTRAP_PASSWORD,
+    });
+    let resp = call(app, hmac_request("/api/auth/verify-credentials", &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn verify_credentials_rejects_oversized_password() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": "x".repeat(2000),
+    });
+    let resp = call(app, hmac_request("/api/auth/verify-credentials", &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn ensure_user_rejects_oversized_provider_subject() {
+    let (app, _db) = test_app().await;
+    let body = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "s".repeat(300),
+        "email": "long-sub@example.com",
+        "emailVerified": true,
+    });
+    let resp = call(app, hmac_request("/api/auth/ensure-user", &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -155,13 +155,12 @@ async fn verify_credentials_stale_timestamp_returns_401() {
 // ── ensure-user ───────────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn ensure_user_creates_and_reuses_on_verified_email() {
+async fn ensure_user_creates_and_reuses_for_same_provider_subject() {
     let (app, _db) = test_app().await;
     let body = serde_json::json!({
         "provider": "google",
         "providerSubject": "google-sub-12345",
         "email": "Alice@Example.com",
-        "emailVerified": true,
     });
     let resp1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &body)).await;
     assert_eq!(resp1.status(), StatusCode::OK);
@@ -188,7 +187,6 @@ async fn ensure_user_second_provider_does_not_auto_link_on_email() {
         "provider": "google",
         "providerSubject": "sub-google-1",
         "email": "bob@example.com",
-        "emailVerified": true,
     });
     let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &first)).await;
     let v1: serde_json::Value = json_body(r1).await;
@@ -198,7 +196,6 @@ async fn ensure_user_second_provider_does_not_auto_link_on_email() {
         "provider": "github",
         "providerSubject": "sub-github-1",
         "email": "bob@example.com",
-        "emailVerified": true,
     });
     let r2 = call(app, hmac_request("/api/auth/ensure-user", &second)).await;
     assert_eq!(r2.status(), StatusCode::OK);
@@ -208,31 +205,29 @@ async fn ensure_user_second_provider_does_not_auto_link_on_email() {
 }
 
 #[tokio::test]
-async fn ensure_user_unverified_email_never_links_to_existing_account() {
+async fn ensure_user_never_links_across_providers_even_on_matching_email() {
     let (app, _db) = test_app().await;
-    // Seed via verified Google.
-    let verified = serde_json::json!({
+    // Seed via Google.
+    let first = serde_json::json!({
         "provider": "google",
         "providerSubject": "sub-google-2",
         "email": "carol@example.com",
-        "emailVerified": true,
     });
-    let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &verified)).await;
+    let r1 = call(app.clone(), hmac_request("/api/auth/ensure-user", &first)).await;
     let v1: serde_json::Value = json_body(r1).await;
-    let verified_id = v1["userId"].as_str().unwrap().to_string();
+    let first_id = v1["userId"].as_str().unwrap().to_string();
 
-    // Now an UNVERIFIED GitHub signup with the same email must not link.
-    let unverified = serde_json::json!({
+    // GitHub signup with the same email must produce a new user, not link.
+    let second = serde_json::json!({
         "provider": "github",
         "providerSubject": "sub-github-2",
         "email": "carol@example.com",
-        "emailVerified": false,
     });
-    let r2 = call(app, hmac_request("/api/auth/ensure-user", &unverified)).await;
+    let r2 = call(app, hmac_request("/api/auth/ensure-user", &second)).await;
     assert_eq!(r2.status(), StatusCode::OK);
     let v2: serde_json::Value = json_body(r2).await;
     assert_eq!(v2["created"], true);
-    assert_ne!(v2["userId"].as_str().unwrap(), verified_id);
+    assert_ne!(v2["userId"].as_str().unwrap(), first_id);
 }
 
 // ── Field length caps (H-2) ───────────────────────────────────────────────────
@@ -266,7 +261,6 @@ async fn ensure_user_rejects_oversized_provider_subject() {
         "provider": "google",
         "providerSubject": "s".repeat(300),
         "email": "long-sub@example.com",
-        "emailVerified": true,
     });
     let resp = call(app, hmac_request("/api/auth/ensure-user", &body)).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);


### PR DESCRIPTION
## Summary
- SCHEMAFULL `user` / `user_identity` / `auth_event` tables with unique indexes on `email_normalised` and `(provider, provider_subject)`
- Argon2id password primitives (OWASP 2024: m=19 MiB, t=2, p=1) with a constant-time `verify_or_dummy` for the unknown-email path
- HMAC-SHA256 extractor (`X-Signature`, `X-Timestamp`, ±60 s replay window) and two NextAuth-facing endpoints: `POST /api/auth/verify-credentials`, `POST /api/auth/ensure-user`
- Idempotent bootstrap admin seeder driven by `BOOTSTRAP_ADMIN_EMAIL` / `BOOTSTRAP_ADMIN_PASSWORD`, emits an `auth_event{bootstrap_admin_created}`
- `AppError::Forbidden` variant for the admin role checks that land in BE-5

Social edge case handled: unverified provider emails get a provider-scoped normalised key (`unverified:{provider}:{sub}`) so they can never collide with or squat on a legitimate verified signup of the same address.

Scope is strictly BE-1. JWT, refresh tokens, rate limiting, admin extractors, audit fields and `/change-password` land in BE-2…BE-7. `ADMIN_TOKEN` gating on existing admin handlers is untouched.

## Test plan
- [x] `cargo test` — 190/190 green (15 lib + 110 api + 10 auth + 35 parser + 12 routing + 8 ingestion)
- [x] `verify-credentials`: success, wrong password 401, unknown email 401 (runs dummy hash), bad HMAC 401, stale timestamp 401
- [x] `ensure-user`: verified create + re-use, verified second provider links to same user, unverified never links to existing account
- [x] Bootstrap seeder is idempotent (second call is a no-op)