### PR TITLE
[FEAT] - Auth rate limiting (Plan 3 / BE-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,19 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 
 # Directory where receipt files are saved during OCR (default: OS temp dir)
 # RECEIPT_DOWNLOAD_DIR=/tmp/receipt_engine
+
+# --- Auth rate limiting (Plan 3 / BE-2) ---
+# Per-IP limiter mounted on /api/auth/verify-credentials and /api/auth/ensure-user.
+# Steady request budget per minute; burst is the bucket size before slow-down.
+# AUTH_RATE_LIMIT_PER_MINUTE=60
+# AUTH_RATE_LIMIT_BURST=10
+
+# Composite (ip, email) failure limiter on /api/auth/verify-credentials.
+# Only failed logins consume quota. Defaults: 5 failures per 900s (15 min).
+# AUTH_CREDENTIAL_FAILURE_LIMIT=5
+# AUTH_CREDENTIAL_FAILURE_WINDOW_SECS=900
+
+# Only set to "true" when the service sits behind a trusted reverse proxy
+# (Fly, Vercel edge, nginx) that sets X-Forwarded-For. Leaving it false in
+# front-of-proxy deployments collapses rate limiting to the proxy's IP.
+# TRUST_PROXY_HEADERS=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,23 +1382,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.12.2",
- "spade",
-]
-
-[[package]]
-name = "geo"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
@@ -1412,6 +1405,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
+ "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -1423,6 +1417,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -1496,6 +1491,29 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
 
 [[package]]
 name = "group"
@@ -2525,6 +2543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,7 +3040,9 @@ dependencies = [
  "argon2",
  "axum",
  "chrono",
+ "dashmap",
  "dotenv",
+ "governor",
  "hex",
  "hmac",
  "http-body-util",
@@ -3027,6 +3059,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3169,6 +3202,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -3334,6 +3382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4198,6 +4255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,7 +4494,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.28.0",
+ "geo 0.32.0",
  "prost",
  "prost-types",
  "rust_decimal",
@@ -4981,6 +5047,22 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,13 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 
+# Rate limiting — tower-governor mounts a per-IP limiter on the auth endpoints;
+# governor + dashmap back the composite (ip, email) failure limiter that blunts
+# credential brute-force on /api/auth/verify-credentials
+tower_governor = { version = "0.8", default-features = false, features = ["axum"] }
+governor = "0.10"
+dashmap = "6"
+
 [dev-dependencies]
 # HTTP service test utilities — used in API integration tests
 tower = { version = "0.5", features = ["util"] }

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -89,7 +89,49 @@ RECEIPT_DOWNLOAD_DIR=/tmp/receipts
 # Log verbosity (default: info)
 # Options: debug, info, warn, error
 RUST_LOG=info
+
+# --- Auth rate limiting (Plan 3 / BE-2) ---
+# Per-IP limiter on /api/auth/verify-credentials and /api/auth/ensure-user.
+AUTH_RATE_LIMIT_PER_MINUTE=60
+AUTH_RATE_LIMIT_BURST=10
+
+# Composite (ip, email) failure limiter on /api/auth/verify-credentials.
+# Only failed logins consume quota; successful logins never count.
+AUTH_CREDENTIAL_FAILURE_LIMIT=5
+AUTH_CREDENTIAL_FAILURE_WINDOW_SECS=900
+
+# Trust X-Forwarded-For as the client IP. Only set when the service sits
+# behind a reverse proxy that strips user-supplied copies of that header
+# (Fly, Vercel edge, nginx). Default false.
+TRUST_PROXY_HEADERS=false
 ```
+
+### Auth Rate Limiting
+
+Two layers protect the HMAC-gated auth surface:
+
+- **Per-IP (`tower_governor`)** — a steady quota of `AUTH_RATE_LIMIT_PER_MINUTE`
+  requests per minute with a burst of `AUTH_RATE_LIMIT_BURST`, applied to
+  both `/api/auth/verify-credentials` and `/api/auth/ensure-user`. Runs
+  before HMAC verification so anonymous floods are dropped cheaply.
+- **Composite `(ip, email_normalised)`** — in-handler limiter on
+  `/api/auth/verify-credentials`. Up to `AUTH_CREDENTIAL_FAILURE_LIMIT`
+  failures per `AUTH_CREDENTIAL_FAILURE_WINDOW_SECS`. Successful logins do
+  not consume quota, so legitimate users are never penalised.
+
+When a limit is hit the response is `429 Too Many Requests` with a
+`Retry-After` header in seconds. Legitimate callers should honour it.
+
+**Tuning:** raise the per-IP numbers if a single shared office NAT hits
+the limit; lower the credential-failure numbers if brute-force attempts
+show up in the `auth_event` log with `reason="rate_limited"`. Values are
+loaded at boot — restart the service after edits.
+
+**Trust headers only behind a trusted proxy.** With `TRUST_PROXY_HEADERS=false`
+(default), the limiter keys on the direct peer IP. Behind a proxy that
+leaves that as the proxy's own IP, set `TRUST_PROXY_HEADERS=true` so the
+proxy's `X-Forwarded-For` is honoured — but only if the proxy strips any
+client-supplied copy of that header, otherwise callers can spoof their IP.
 
 ### Production Security
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -115,9 +115,14 @@ Two layers protect the HMAC-gated auth surface:
   both `/api/auth/verify-credentials` and `/api/auth/ensure-user`. Runs
   before HMAC verification so anonymous floods are dropped cheaply.
 - **Composite `(ip, email_normalised)`** — in-handler limiter on
-  `/api/auth/verify-credentials`. Up to `AUTH_CREDENTIAL_FAILURE_LIMIT`
-  failures per `AUTH_CREDENTIAL_FAILURE_WINDOW_SECS`. Successful logins do
-  not consume quota, so legitimate users are never penalised.
+  `/api/auth/verify-credentials`. Token-bucket with burst
+  `AUTH_CREDENTIAL_FAILURE_LIMIT` that refills one slot every
+  `AUTH_CREDENTIAL_FAILURE_WINDOW_SECS / AUTH_CREDENTIAL_FAILURE_LIMIT`
+  seconds — an average rate of `LIMIT` failures per `WINDOW_SECS` with
+  burst tolerance. Attackers spacing attempts out can exceed `LIMIT`
+  within a rolling `WINDOW_SECS` interval; if you need a strict fixed-
+  window guarantee, switch the implementation to a counter. Successful
+  logins do not consume quota, so legitimate users are never penalised.
 
 When a limit is hit the response is `429 Too Many Requests` with a
 `Retry-After` header in seconds. Legitimate callers should honour it.

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -71,7 +71,7 @@ pub async fn verify_credentials(
     match result {
         Ok(user) => {
             let user_id = record_id_to_string(user.id);
-            let _ = record_auth_event(
+            record_auth_event(
                 &db,
                 Some(user_id.clone()),
                 "login_success",
@@ -95,7 +95,7 @@ pub async fn verify_credentials(
             let key = (client_ip, email_normalised.clone());
             match limiter.charge_failure(&key) {
                 Ok(()) => {
-                    let _ = record_auth_event(
+                    record_auth_event(
                         &db,
                         user_id,
                         "login_failure",
@@ -107,7 +107,7 @@ pub async fn verify_credentials(
                     Err(AppError::Unauthorized)
                 }
                 Err(retry_after_secs) => {
-                    let _ = record_auth_event(
+                    record_auth_event(
                         &db,
                         user_id,
                         "login_failure",
@@ -377,7 +377,7 @@ async fn record_auth_event(
     success: bool,
     reason: Option<&str>,
     ip: Option<&str>,
-) -> Result<(), AppError> {
+) {
     let content = AuthEventContent {
         user_id,
         event_type: event_type.into(),
@@ -390,7 +390,8 @@ async fn record_auth_event(
     // auth_event writes are fire-and-forget at every callsite: telemetry
     // failure must never block a login. We still warn so ops can alert on
     // "auth_event insert failed" without the error propagating into the
-    // request path. Always return Ok to make misuse impossible.
+    // request path. Returning `()` makes that contract explicit — callers
+    // cannot mistake this for a fallible operation worth handling.
     if let Err(e) = db
         .create::<Option<DbAuthEvent>>("auth_event")
         .content(content)
@@ -398,5 +399,4 @@ async fn record_auth_event(
     {
         tracing::warn!(error = %e, event_type, "auth_event insert failed");
     }
-    Ok(())
 }

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -8,7 +8,7 @@
 //! never auto-linked on email match. A second provider for the same person
 //! becomes a deliberate, authenticated FE linking flow (not in BE-1).
 
-use axum::{Json, extract::State};
+use axum::{Extension, Json, extract::State};
 use serde::{Deserialize, Serialize};
 
 use crate::api::models::{
@@ -17,6 +17,7 @@ use crate::api::models::{
 };
 use crate::auth::hmac::HmacVerifiedJson;
 use crate::auth::password;
+use crate::auth::rate_limit::{ClientIp, CredentialFailureLimiter};
 use crate::db::DbConn;
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
@@ -48,6 +49,8 @@ pub struct VerifyCredentialsResponse {
 
 pub async fn verify_credentials(
     State(db): State<DbConn>,
+    Extension(limiter): Extension<CredentialFailureLimiter>,
+    ClientIp(client_ip): ClientIp,
     HmacVerifiedJson(req): HmacVerifiedJson<VerifyCredentialsRequest>,
 ) -> Result<Json<VerifyCredentialsResponse>, AppError> {
     if req.email.len() > MAX_EMAIL_LEN {
@@ -57,24 +60,97 @@ pub async fn verify_credentials(
         return Err(AppError::BadRequest("password too long".into()));
     }
     let email_normalised = req.email.trim().to_lowercase();
-    if email_normalised.is_empty() || req.password.is_empty() {
-        let _ = record_auth_event(&db, None, "login_failure", false, Some("missing_fields")).await;
-        return Err(AppError::Unauthorized);
+
+    // Run the actual credential check. Success and failure produce identical
+    // error shapes to the caller (`AppError::Unauthorized` — mapped to 401),
+    // but failure carries the `user_id` (if any) and a reason tag so we can
+    // emit a precise `auth_event` and charge the composite limiter.
+    let result = authenticate_credentials(&db, &email_normalised, &req.password).await;
+
+    match result {
+        Ok(user) => {
+            let user_id = record_id_to_string(user.id);
+            let _ =
+                record_auth_event(&db, Some(user_id.clone()), "login_success", true, None).await;
+            Ok(Json(VerifyCredentialsResponse {
+                user_id,
+                email: user.email,
+                role: user.role,
+                must_reset_password: user.must_reset_password,
+            }))
+        }
+        Err(AuthFailure::Internal(e)) => Err(e),
+        Err(AuthFailure::Rejected { user_id, reason }) => {
+            // Charge the (ip, email) bucket. If the caller has already
+            // exhausted their budget, upgrade 401 → 429 so a brute-force
+            // client visibly backs off instead of silently grinding.
+            let key = (client_ip, email_normalised.clone());
+            match limiter.charge_failure(&key) {
+                Ok(()) => {
+                    let _ =
+                        record_auth_event(&db, user_id, "login_failure", false, Some(reason)).await;
+                    Err(AppError::Unauthorized)
+                }
+                Err(retry_after_secs) => {
+                    let _ = record_auth_event(
+                        &db,
+                        user_id,
+                        "login_failure",
+                        false,
+                        Some("rate_limited"),
+                    )
+                    .await;
+                    Err(AppError::TooManyRequests {
+                        retry_after_secs: Some(retry_after_secs),
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Outcome of `authenticate_credentials` — either the verified active user or
+/// a tagged failure. `Internal` covers DB-level surprises that must not be
+/// masked as a 401.
+enum AuthFailure {
+    Rejected {
+        user_id: Option<String>,
+        reason: &'static str,
+    },
+    Internal(AppError),
+}
+
+impl From<AppError> for AuthFailure {
+    fn from(e: AppError) -> Self {
+        AuthFailure::Internal(e)
+    }
+}
+
+async fn authenticate_credentials(
+    db: &DbConn,
+    email_normalised: &str,
+    password: &str,
+) -> Result<DbUser, AuthFailure> {
+    if email_normalised.is_empty() || password.is_empty() {
+        return Err(AuthFailure::Rejected {
+            user_id: None,
+            reason: "missing_fields",
+        });
     }
 
     // Lookup via user_identity — the canonical identity key. Every credentials
     // user has exactly one ('credentials', email_normalised) identity row,
     // enforced by the UNIQUE index on user_identity.
-    let identity = find_identity(&db, CREDENTIALS_PROVIDER, &email_normalised).await?;
+    let identity = find_identity(db, CREDENTIALS_PROVIDER, email_normalised).await?;
     let user = match &identity {
         Some(i) => {
-            let u = find_user_by_id(&db, &i.user_id).await?;
+            let u = find_user_by_id(db, &i.user_id).await?;
             if u.is_none() {
                 // Orphaned identity — row exists but its user is gone. This
                 // indicates DB corruption, not a user-facing auth failure.
-                return Err(AppError::Internal(
+                return Err(AuthFailure::Internal(AppError::Internal(
                     "identity references missing user".into(),
-                ));
+                )));
             }
             u
         }
@@ -82,35 +158,32 @@ pub async fn verify_credentials(
     };
 
     let stored_hash = user.as_ref().and_then(|u| u.password_hash.as_deref());
-    let matches = password::verify_or_dummy(&req.password, stored_hash)?;
+    let matches = password::verify_or_dummy(password, stored_hash)?;
 
     let Some(user) = user else {
-        let _ = record_auth_event(&db, None, "login_failure", false, Some("unknown_email")).await;
-        return Err(AppError::Unauthorized);
+        return Err(AuthFailure::Rejected {
+            user_id: None,
+            reason: "unknown_email",
+        });
     };
 
     if !matches {
         let uid = record_id_to_string(user.id.clone());
-        let _ = record_auth_event(&db, Some(uid), "login_failure", false, Some("bad_password"))
-            .await;
-        return Err(AppError::Unauthorized);
+        return Err(AuthFailure::Rejected {
+            user_id: Some(uid),
+            reason: "bad_password",
+        });
     }
 
     if user.status != "active" || user.deleted_at.is_some() {
         let uid = record_id_to_string(user.id.clone());
-        let _ = record_auth_event(&db, Some(uid), "login_failure", false, Some("disabled")).await;
-        return Err(AppError::Unauthorized);
+        return Err(AuthFailure::Rejected {
+            user_id: Some(uid),
+            reason: "disabled",
+        });
     }
 
-    let user_id = record_id_to_string(user.id);
-    let _ = record_auth_event(&db, Some(user_id.clone()), "login_success", true, None).await;
-
-    Ok(Json(VerifyCredentialsResponse {
-        user_id,
-        email: user.email,
-        role: user.role,
-        must_reset_password: user.must_reset_password,
-    }))
+    Ok(user)
 }
 
 // ── ensure-user (social JIT provisioning) ─────────────────────────────────────

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -67,11 +67,19 @@ pub async fn verify_credentials(
     // emit a precise `auth_event` and charge the composite limiter.
     let result = authenticate_credentials(&db, &email_normalised, &req.password).await;
 
+    let client_ip_str = client_ip.to_string();
     match result {
         Ok(user) => {
             let user_id = record_id_to_string(user.id);
-            let _ =
-                record_auth_event(&db, Some(user_id.clone()), "login_success", true, None).await;
+            let _ = record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                "login_success",
+                true,
+                None,
+                Some(&client_ip_str),
+            )
+            .await;
             Ok(Json(VerifyCredentialsResponse {
                 user_id,
                 email: user.email,
@@ -87,8 +95,15 @@ pub async fn verify_credentials(
             let key = (client_ip, email_normalised.clone());
             match limiter.charge_failure(&key) {
                 Ok(()) => {
-                    let _ =
-                        record_auth_event(&db, user_id, "login_failure", false, Some(reason)).await;
+                    let _ = record_auth_event(
+                        &db,
+                        user_id,
+                        "login_failure",
+                        false,
+                        Some(reason),
+                        Some(&client_ip_str),
+                    )
+                    .await;
                     Err(AppError::Unauthorized)
                 }
                 Err(retry_after_secs) => {
@@ -98,6 +113,7 @@ pub async fn verify_credentials(
                         "login_failure",
                         false,
                         Some("rate_limited"),
+                        Some(&client_ip_str),
                     )
                     .await;
                     Err(AppError::TooManyRequests {
@@ -360,11 +376,12 @@ async fn record_auth_event(
     event_type: &str,
     success: bool,
     reason: Option<&str>,
+    ip: Option<&str>,
 ) -> Result<(), AppError> {
     let content = AuthEventContent {
         user_id,
         event_type: event_type.into(),
-        ip: None,
+        ip: ip.map(str::to_string),
         user_agent: None,
         success,
         reason: reason.map(str::to_string),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,11 +6,11 @@ pub mod models;
 use axum::{
     http::{header, Method},
     routing::{delete, get, patch, post},
-    Router,
+    Extension, Router,
 };
 use tower_http::cors::CorsLayer;
 
-use crate::auth::rate_limit::{self, RateLimitConfig};
+use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
 use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
@@ -30,6 +30,11 @@ pub fn router(db: DbConn) -> Router {
 pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
     let cors = build_cors();
 
+    // Composite (ip, email) failure limiter — charged only on 401 from
+    // verify_credentials. Scoped to the auth sub-router via Extension so
+    // other handlers cannot accidentally consume from it.
+    let credential_failure_limiter = CredentialFailureLimiter::new(&rate_cfg);
+
     // Per-IP limiter mounted only on the auth endpoints — public reads and
     // admin routes stay untouched. Sub-router keeps the layer scoped.
     let auth_router = Router::new()
@@ -38,7 +43,9 @@ pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
             post(auth_endpoints::verify_credentials),
         )
         .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user))
-        .layer(rate_limit::build_per_ip_layer(&rate_cfg));
+        .layer(rate_limit::build_per_ip_layer(&rate_cfg))
+        .layer(Extension(credential_failure_limiter))
+        .layer(Extension(rate_cfg.clone()));
 
     let mut router = Router::new()
         // Public read endpoints

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use tower_http::cors::CorsLayer;
 
+use crate::auth::rate_limit::{self, RateLimitConfig};
 use crate::db::DbConn;
 use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
@@ -20,7 +21,24 @@ use handlers::{
 
 /// Build the Axum router with all API routes and CORS middleware.
 pub fn router(db: DbConn) -> Router {
+    router_with_config(db, RateLimitConfig::from_env())
+}
+
+/// Build the router with an explicit rate-limit config — used by tests that
+/// need to inject tuned limits (e.g. small bucket sizes that are easy to
+/// exhaust without wall-clock delays).
+pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
     let cors = build_cors();
+
+    // Per-IP limiter mounted only on the auth endpoints — public reads and
+    // admin routes stay untouched. Sub-router keeps the layer scoped.
+    let auth_router = Router::new()
+        .route(
+            "/api/auth/verify-credentials",
+            post(auth_endpoints::verify_credentials),
+        )
+        .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user))
+        .layer(rate_limit::build_per_ip_layer(&rate_cfg));
 
     let mut router = Router::new()
         // Public read endpoints
@@ -50,9 +68,8 @@ pub fn router(db: DbConn) -> Router {
         .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
         .route("/api/admin/whatsapp-links", post(create_whatsapp_link))
         .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link))
-        // HMAC-gated auth endpoints (called by NextAuth)
-        .route("/api/auth/verify-credentials", post(auth_endpoints::verify_credentials))
-        .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user));
+        // Auth endpoints (HMAC-gated, rate-limited) are merged below
+        .merge(auth_router);
 
     // Fail-closed: the destructive test reset endpoint is only mounted when
     // APP_ENV is explicitly "development" or "test". If the env var is

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::StatusCode,
+    http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -27,25 +27,41 @@ pub enum AppError {
     Unauthorized,
     Forbidden(String),
     Conflict(String),
+    /// `retry_after_secs` populates the `Retry-After` header when present.
+    TooManyRequests {
+        retry_after_secs: Option<u64>,
+    },
     Internal(String),
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
-            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized".to_string()),
-            AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
-            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg),
+        match self {
+            AppError::NotFound(msg) => simple(StatusCode::NOT_FOUND, msg),
+            AppError::BadRequest(msg) => simple(StatusCode::BAD_REQUEST, msg),
+            AppError::Unauthorized => simple(StatusCode::UNAUTHORIZED, "unauthorized".to_string()),
+            AppError::Forbidden(msg) => simple(StatusCode::FORBIDDEN, msg),
+            AppError::Conflict(msg) => simple(StatusCode::CONFLICT, msg),
+            AppError::TooManyRequests { retry_after_secs } => {
+                let mut resp = simple(StatusCode::TOO_MANY_REQUESTS, "too many requests".to_string());
+                if let Some(secs) = retry_after_secs {
+                    if let Ok(v) = HeaderValue::from_str(&secs.to_string()) {
+                        resp.headers_mut().insert(header::RETRY_AFTER, v);
+                    }
+                }
+                resp
+            }
             // Don't leak internal error details to the caller.
-            AppError::Internal(_) => (
+            AppError::Internal(_) => simple(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "an internal error occurred".to_string(),
             ),
-        };
-        (status, Json(ErrorBody { error: message })).into_response()
+        }
     }
+}
+
+fn simple(status: StatusCode, message: String) -> Response {
+    (status, Json(ErrorBody { error: message })).into_response()
 }
 
 impl From<surrealdb::Error> for AppError {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -6,3 +6,4 @@
 pub mod bootstrap;
 pub mod hmac;
 pub mod password;
+pub mod rate_limit;

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -306,5 +306,14 @@ impl CredentialFailureLimiter {
 }
 
 fn retry_after_secs(neg: &NotUntil<governor::clock::QuantaInstant>) -> u64 {
-    neg.wait_time_from(DefaultClock::default().now()).as_secs()
+    // Round up and floor at 1s: `Duration::as_secs()` truncates, so a sub-second
+    // wait would surface as `Retry-After: 0` and invite immediate retry loops.
+    let wait = neg.wait_time_from(DefaultClock::default().now());
+    let secs = wait.as_secs();
+    let rounded = if wait.subsec_nanos() > 0 {
+        secs.saturating_add(1)
+    } else {
+        secs
+    };
+    rounded.max(1)
 }

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -18,8 +18,8 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::ConnectInfo;
-use axum::http::Request;
+use axum::extract::{ConnectInfo, FromRequestParts};
+use axum::http::{Extensions, HeaderMap, Request, request::Parts};
 use governor::clock::{Clock, DefaultClock};
 use governor::state::keyed::DashMapStateStore;
 use governor::{NotUntil, Quota, RateLimiter};
@@ -149,9 +149,20 @@ impl KeyExtractor for AuthIpKeyExtractor {
 }
 
 fn extract_ip<T>(req: &Request<T>, trust_proxy: bool, test_mode: bool) -> Option<IpAddr> {
+    resolve_client_ip(req.headers(), req.extensions(), trust_proxy, test_mode)
+}
+
+/// Resolve the client IP from already-borrowed header/extension views. Used
+/// both by the tower-governor key extractor and by the `ClientIp` handler
+/// extractor so the two limiters key on the same IP.
+pub fn resolve_client_ip(
+    headers: &HeaderMap,
+    extensions: &Extensions,
+    trust_proxy: bool,
+    test_mode: bool,
+) -> Option<IpAddr> {
     if test_mode {
-        if let Some(ip) = req
-            .headers()
+        if let Some(ip) = headers
             .get(TEST_PEER_IP_HEADER)
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<IpAddr>().ok())
@@ -160,8 +171,7 @@ fn extract_ip<T>(req: &Request<T>, trust_proxy: bool, test_mode: bool) -> Option
         }
     }
     if trust_proxy {
-        if let Some(ip) = req
-            .headers()
+        if let Some(ip) = headers
             .get("x-forwarded-for")
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.split(',').next())
@@ -171,9 +181,38 @@ fn extract_ip<T>(req: &Request<T>, trust_proxy: bool, test_mode: bool) -> Option
             return Some(ip);
         }
     }
-    req.extensions()
+    extensions
         .get::<ConnectInfo<SocketAddr>>()
         .map(|ci| ci.0.ip())
+}
+
+/// Handler extractor that yields the caller's IP using the same rules as the
+/// per-IP rate limiter. Requires `RateLimitConfig` to be present as a request
+/// extension — mounted by the auth sub-router. Falls back to 127.0.0.1 when
+/// nothing is available so a broken extension layer cannot 500 every call.
+pub struct ClientIp(pub IpAddr);
+
+impl<S> FromRequestParts<S> for ClientIp
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let cfg = parts
+            .extensions
+            .get::<RateLimitConfig>()
+            .cloned()
+            .unwrap_or_else(RateLimitConfig::from_env);
+        let ip = resolve_client_ip(
+            &parts.headers,
+            &parts.extensions,
+            cfg.trust_proxy_headers,
+            cfg.test_mode,
+        )
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        Ok(ClientIp(ip))
+    }
 }
 
 // ── per-IP layer ──────────────────────────────────────────────────────────────
@@ -252,18 +291,9 @@ impl CredentialFailureLimiter {
         }
     }
 
-    /// Peek at the key without consuming a slot. Returns `Ok` when the caller
-    /// is still inside budget, `Err(retry_after_secs)` when the bucket is
-    /// empty.
-    pub fn check(&self, key: &CredentialFailureKey) -> Result<(), u64> {
-        match self.inner.check_key(key) {
-            Ok(_) => Ok(()),
-            Err(neg) => Err(retry_after_secs(&neg)),
-        }
-    }
-
-    /// Consume one slot to charge a failure. Returns `Err(retry_after_secs)`
-    /// if the bucket is already empty.
+    /// Consume one slot to charge a failed credential attempt. Returns
+    /// `Err(retry_after_secs)` when the bucket is already empty — the caller
+    /// should translate that into a 429 instead of the usual 401.
     pub fn charge_failure(&self, key: &CredentialFailureKey) -> Result<(), u64> {
         match self.inner.check_key(key) {
             Ok(_) => Ok(()),

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -1,0 +1,277 @@
+//! Rate limiting for the HMAC-gated auth endpoints (Plan 3, BE-2).
+//!
+//! Two layers compose:
+//!
+//!   * **Per-IP** — a `tower_governor` `GovernorLayer` mounted in front of
+//!     `/api/auth/verify-credentials` and `/api/auth/ensure-user`. Runs before
+//!     HMAC verification so anonymous floods are dropped cheaply.
+//!   * **Composite `(ip, email_normalised)`** — an in-handler limiter on
+//!     `verify_credentials` that charges a quota slot only on a failed login
+//!     attempt. Successful logins never consume quota.
+//!
+//! Limits are configured via env; see `.env.example`. The peer-IP source is
+//! governed by `TRUST_PROXY_HEADERS` — only set that to `true` when the
+//! service sits behind a proxy that strips client-supplied headers.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use governor::clock::{Clock, DefaultClock};
+use governor::state::keyed::DashMapStateStore;
+use governor::{NotUntil, Quota, RateLimiter};
+use tower_governor::GovernorLayer;
+use tower_governor::errors::GovernorError;
+use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
+use tower_governor::key_extractor::KeyExtractor;
+
+// ── env keys & defaults ───────────────────────────────────────────────────────
+
+const ENV_PER_IP_PER_MINUTE: &str = "AUTH_RATE_LIMIT_PER_MINUTE";
+const ENV_PER_IP_BURST: &str = "AUTH_RATE_LIMIT_BURST";
+const ENV_CRED_FAILURE_LIMIT: &str = "AUTH_CREDENTIAL_FAILURE_LIMIT";
+const ENV_CRED_FAILURE_WINDOW_SECS: &str = "AUTH_CREDENTIAL_FAILURE_WINDOW_SECS";
+const ENV_TRUST_PROXY_HEADERS: &str = "TRUST_PROXY_HEADERS";
+const ENV_APP_ENV: &str = "APP_ENV";
+
+const DEFAULT_PER_IP_PER_MINUTE: u32 = 60;
+const DEFAULT_PER_IP_BURST: u32 = 10;
+const DEFAULT_CRED_FAILURE_LIMIT: u32 = 5;
+const DEFAULT_CRED_FAILURE_WINDOW_SECS: u64 = 900;
+
+/// Header tests set to simulate a peer IP when the service is exercised via
+/// `tower::ServiceExt::oneshot`, which has no `ConnectInfo`. Never honoured in
+/// production — only when `APP_ENV` is `development` or `test`.
+pub const TEST_PEER_IP_HEADER: &str = "x-test-peer-ip";
+
+// ── config ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    pub per_ip_per_minute: u32,
+    pub per_ip_burst: u32,
+    pub credential_failure_limit: u32,
+    pub credential_failure_window_secs: u64,
+    pub trust_proxy_headers: bool,
+    pub test_mode: bool,
+}
+
+impl RateLimitConfig {
+    /// Load config from env with documented defaults. Invalid values fall back
+    /// to the default and emit a warning rather than panic — misconfiguring
+    /// rate limits should not take the whole service down.
+    pub fn from_env() -> Self {
+        Self {
+            per_ip_per_minute: parse_u32(ENV_PER_IP_PER_MINUTE, DEFAULT_PER_IP_PER_MINUTE),
+            per_ip_burst: parse_u32(ENV_PER_IP_BURST, DEFAULT_PER_IP_BURST),
+            credential_failure_limit: parse_u32(
+                ENV_CRED_FAILURE_LIMIT,
+                DEFAULT_CRED_FAILURE_LIMIT,
+            ),
+            credential_failure_window_secs: parse_u64(
+                ENV_CRED_FAILURE_WINDOW_SECS,
+                DEFAULT_CRED_FAILURE_WINDOW_SECS,
+            ),
+            trust_proxy_headers: parse_bool(ENV_TRUST_PROXY_HEADERS, false),
+            test_mode: matches!(
+                std::env::var(ENV_APP_ENV).as_deref(),
+                Ok("development" | "test")
+            ),
+        }
+    }
+}
+
+fn parse_u32(key: &str, default: u32) -> u32 {
+    match std::env::var(key) {
+        Ok(v) => v.parse::<u32>().unwrap_or_else(|_| {
+            tracing::warn!(env = key, value = %v, "invalid u32 — using default");
+            default
+        }),
+        Err(_) => default,
+    }
+}
+
+fn parse_u64(key: &str, default: u64) -> u64 {
+    match std::env::var(key) {
+        Ok(v) => v.parse::<u64>().unwrap_or_else(|_| {
+            tracing::warn!(env = key, value = %v, "invalid u64 — using default");
+            default
+        }),
+        Err(_) => default,
+    }
+}
+
+fn parse_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"),
+        Err(_) => default,
+    }
+}
+
+// ── key extractor ─────────────────────────────────────────────────────────────
+
+/// Extracts the client IP from, in order:
+///   1. `X-Test-Peer-Ip` header — only when `APP_ENV` is development/test.
+///   2. `X-Forwarded-For` (first hop) — only when `trust_proxy_headers=true`.
+///   3. `ConnectInfo<SocketAddr>` — the actual peer IP.
+#[derive(Debug, Clone)]
+pub struct AuthIpKeyExtractor {
+    trust_proxy_headers: bool,
+    test_mode: bool,
+}
+
+impl AuthIpKeyExtractor {
+    pub fn new(cfg: &RateLimitConfig) -> Self {
+        Self {
+            trust_proxy_headers: cfg.trust_proxy_headers,
+            test_mode: cfg.test_mode,
+        }
+    }
+}
+
+impl KeyExtractor for AuthIpKeyExtractor {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
+        if let Some(ip) = extract_ip(req, self.trust_proxy_headers, self.test_mode) {
+            return Ok(ip);
+        }
+        // If we somehow have no peer IP (shouldn't happen in production with
+        // `into_make_service_with_connect_info`), bucket all such requests
+        // together under 127.0.0.1 rather than 500-ing the caller. Keeping
+        // the service available is more important than perfect per-IP
+        // accounting in an edge case.
+        Ok(IpAddr::V4(Ipv4Addr::LOCALHOST))
+    }
+}
+
+fn extract_ip<T>(req: &Request<T>, trust_proxy: bool, test_mode: bool) -> Option<IpAddr> {
+    if test_mode {
+        if let Some(ip) = req
+            .headers()
+            .get(TEST_PEER_IP_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<IpAddr>().ok())
+        {
+            return Some(ip);
+        }
+    }
+    if trust_proxy {
+        if let Some(ip) = req
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.split(',').next())
+            .map(str::trim)
+            .and_then(|s| s.parse::<IpAddr>().ok())
+        {
+            return Some(ip);
+        }
+    }
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+}
+
+// ── per-IP layer ──────────────────────────────────────────────────────────────
+
+pub type AuthGovernorConfig =
+    GovernorConfig<AuthIpKeyExtractor, governor::middleware::NoOpMiddleware>;
+
+/// Build the `tower_governor` config for the per-IP limiter on auth endpoints.
+///
+/// Panics only at startup if the configured values are zero — surfacing a
+/// misconfig loud and early is better than silently shipping an un-limited
+/// auth surface.
+pub fn build_per_ip_config(cfg: &RateLimitConfig) -> Arc<AuthGovernorConfig> {
+    let burst = NonZeroU32::new(cfg.per_ip_burst).expect("AUTH_RATE_LIMIT_BURST must be > 0");
+    let per_min = NonZeroU32::new(cfg.per_ip_per_minute)
+        .expect("AUTH_RATE_LIMIT_PER_MINUTE must be > 0");
+
+    // `tower_governor`'s builder takes a replenish-period + burst-size. Convert
+    // "N requests per minute, burst B" into "replenish one cell every 60/N
+    // seconds, bucket size B". Clamp the period to >=1ms so a misconfig does
+    // not produce a zero duration.
+    let period = Duration::from_millis((60_000 / u64::from(per_min.get())).max(1));
+
+    let config = GovernorConfigBuilder::default()
+        .period(period)
+        .burst_size(burst.get())
+        .key_extractor(AuthIpKeyExtractor::new(cfg))
+        .finish()
+        .expect("rate-limit config must be non-zero");
+
+    Arc::new(config)
+}
+
+pub fn build_per_ip_layer(
+    cfg: &RateLimitConfig,
+) -> GovernorLayer<AuthIpKeyExtractor, governor::middleware::NoOpMiddleware, axum::body::Body> {
+    GovernorLayer::new(build_per_ip_config(cfg))
+}
+
+// ── composite (ip, email) failure limiter ─────────────────────────────────────
+
+/// Key for the composite limiter. Email is normalised (trim + lowercase) by
+/// the caller to match the identity-lookup path used in `verify_credentials`.
+pub type CredentialFailureKey = (IpAddr, String);
+
+type CredentialFailureRateLimiter = RateLimiter<
+    CredentialFailureKey,
+    DashMapStateStore<CredentialFailureKey>,
+    DefaultClock,
+>;
+
+/// Charges one quota slot per failed credential attempt per `(ip, email)` pair.
+/// Successful logins never call `charge_failure`, so they never consume quota.
+#[derive(Clone)]
+pub struct CredentialFailureLimiter {
+    inner: Arc<CredentialFailureRateLimiter>,
+}
+
+impl CredentialFailureLimiter {
+    pub fn new(cfg: &RateLimitConfig) -> Self {
+        let limit = NonZeroU32::new(cfg.credential_failure_limit)
+            .expect("AUTH_CREDENTIAL_FAILURE_LIMIT must be > 0");
+        let window = cfg.credential_failure_window_secs.max(1);
+
+        // Bucket of size `limit` that replenishes one cell every
+        // `window / limit` seconds — a continuous-refill analogue of
+        // "N failures per window". E.g. 5 per 900s → one slot every 180s.
+        let replenish = Duration::from_secs(window / u64::from(limit.get()));
+        let quota = Quota::with_period(replenish)
+            .expect("credential-failure replenish period must be non-zero")
+            .allow_burst(limit);
+
+        let limiter = RateLimiter::dashmap(quota);
+        Self {
+            inner: Arc::new(limiter),
+        }
+    }
+
+    /// Peek at the key without consuming a slot. Returns `Ok` when the caller
+    /// is still inside budget, `Err(retry_after_secs)` when the bucket is
+    /// empty.
+    pub fn check(&self, key: &CredentialFailureKey) -> Result<(), u64> {
+        match self.inner.check_key(key) {
+            Ok(_) => Ok(()),
+            Err(neg) => Err(retry_after_secs(&neg)),
+        }
+    }
+
+    /// Consume one slot to charge a failure. Returns `Err(retry_after_secs)`
+    /// if the bucket is already empty.
+    pub fn charge_failure(&self, key: &CredentialFailureKey) -> Result<(), u64> {
+        match self.inner.check_key(key) {
+            Ok(_) => Ok(()),
+            Err(neg) => Err(retry_after_secs(&neg)),
+        }
+    }
+}
+
+fn retry_after_secs(neg: &NotUntil<governor::clock::QuantaInstant>) -> u64 {
+    neg.wait_time_from(DefaultClock::default().now()).as_secs()
+}

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -278,9 +278,12 @@ impl CredentialFailureLimiter {
         let window = cfg.credential_failure_window_secs.max(1);
 
         // Bucket of size `limit` that replenishes one cell every
-        // `window / limit` seconds — a continuous-refill analogue of
-        // "N failures per window". E.g. 5 per 900s → one slot every 180s.
-        let replenish = Duration::from_secs(window / u64::from(limit.get()));
+        // `window / limit` — a continuous-refill analogue of "N failures per
+        // window". E.g. 5 per 900s → one slot every 180s. Computed in
+        // milliseconds so very high limits (large default in tests) still
+        // produce a non-zero period.
+        let replenish_ms = (window * 1000 / u64::from(limit.get())).max(1);
+        let replenish = Duration::from_millis(replenish_ms);
         let quota = Quota::with_period(replenish)
             .expect("credential-failure replenish period must be non-zero")
             .allow_burst(limit);

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -60,9 +60,12 @@ pub struct RateLimitConfig {
 }
 
 impl RateLimitConfig {
-    /// Load config from env with documented defaults. Invalid values fall back
-    /// to the default and emit a warning rather than panic — misconfiguring
-    /// rate limits should not take the whole service down.
+    /// Load config from env with documented defaults. Non-numeric values fall
+    /// back to the default and emit a warning rather than panic. Zero values
+    /// (e.g. `AUTH_RATE_LIMIT_BURST=0`) are a fatal misconfig and will panic
+    /// at startup in `build_per_ip_config` / `CredentialFailureLimiter::new`
+    /// — we'd rather fail loudly at boot than silently ship an un-limited
+    /// auth surface.
     pub fn from_env() -> Self {
         Self {
             per_ip_per_minute: parse_u32(ENV_PER_IP_PER_MINUTE, DEFAULT_PER_IP_PER_MINUTE),
@@ -106,7 +109,14 @@ fn parse_u64(key: &str, default: u64) -> u64 {
 
 fn parse_bool(key: &str, default: bool) -> bool {
     match std::env::var(key) {
-        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes"),
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" => true,
+            "false" | "0" | "no" => false,
+            _ => {
+                tracing::warn!(env = key, value = %v, "invalid bool — using default");
+                default
+            }
+        },
         Err(_) => default,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,13 @@ async fn main() {
             .await
             .expect("Failed to bind Axum listener");
         info!(addr = %addr, "API server listening");
-        if let Err(e) = axum::serve(listener, router).await {
+        // `into_make_service_with_connect_info` populates the `ConnectInfo`
+        // extension on every request — required by the per-IP rate-limit key
+        // extractor in `src/auth/rate_limit.rs`. Without it, every client
+        // would share a single bucket when sitting behind the default
+        // service factory.
+        let service = router.into_make_service_with_connect_info::<SocketAddr>();
+        if let Err(e) = axum::serve(listener, service).await {
             error!(error = %e, "API server error");
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use poolpay::auth::rate_limit::RateLimitConfig;
 use poolpay::{api, auth, db, extractor, ingestion, parser, replies, whatsapp};
 use poolpay::api::models::now_iso;
 
@@ -58,21 +59,20 @@ async fn main() {
         }
     }
 
+    // Parse rate-limit config once at boot and reuse the same instance for
+    // both the boot-time safety warning and the router. Previously main.rs
+    // duplicated `TRUST_PROXY_HEADERS` parsing which drifted from
+    // `parse_bool()` semantics — reusing `RateLimitConfig::from_env()` here
+    // guarantees the warning fires for exactly the same inputs the limiter
+    // actually trusts.
+    let rate_cfg = RateLimitConfig::from_env();
+
     // When the per-IP limiter is configured to trust proxy headers, the
     // deployed proxy MUST strip any client-supplied X-Forwarded-For before
     // setting its own — otherwise a client can spoof their source IP and
     // bypass per-IP rate limiting. Emit a prominent warning at boot so a
     // misconfigured proxy cannot silently neutralise the limiter.
-    let trust_proxy = env::var("TRUST_PROXY_HEADERS")
-        .ok()
-        .map(|v| {
-            matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "true" | "1" | "yes"
-            )
-        })
-        .unwrap_or(false);
-    if trust_proxy && env::var("APP_ENV").as_deref() == Ok("production") {
+    if rate_cfg.trust_proxy_headers && env::var("APP_ENV").as_deref() == Ok("production") {
         warn!(
             "TRUST_PROXY_HEADERS=true in production — confirm the upstream proxy \
              strips client-supplied X-Forwarded-For before appending; otherwise \
@@ -103,7 +103,7 @@ async fn main() {
         let addr: SocketAddr = bind_addr
             .parse()
             .expect("API_BIND_ADDR is not a valid socket address");
-        let router = api::router(api_db);
+        let router = api::router_with_config(api_db, rate_cfg);
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .expect("Failed to bind Axum listener");

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,10 +63,15 @@ async fn main() {
     // setting its own — otherwise a client can spoof their source IP and
     // bypass per-IP rate limiting. Emit a prominent warning at boot so a
     // misconfigured proxy cannot silently neutralise the limiter.
-    let trust_proxy = matches!(
-        env::var("TRUST_PROXY_HEADERS").as_deref(),
-        Ok("true" | "1" | "yes")
-    );
+    let trust_proxy = env::var("TRUST_PROXY_HEADERS")
+        .ok()
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "true" | "1" | "yes"
+            )
+        })
+        .unwrap_or(false);
     if trust_proxy && env::var("APP_ENV").as_deref() == Ok("production") {
         warn!(
             "TRUST_PROXY_HEADERS=true in production — confirm the upstream proxy \

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,23 @@ async fn main() {
         }
     }
 
+    // When the per-IP limiter is configured to trust proxy headers, the
+    // deployed proxy MUST strip any client-supplied X-Forwarded-For before
+    // setting its own — otherwise a client can spoof their source IP and
+    // bypass per-IP rate limiting. Emit a prominent warning at boot so a
+    // misconfigured proxy cannot silently neutralise the limiter.
+    let trust_proxy = matches!(
+        env::var("TRUST_PROXY_HEADERS").as_deref(),
+        Ok("true" | "1" | "yes")
+    );
+    if trust_proxy && env::var("APP_ENV").as_deref() == Ok("production") {
+        warn!(
+            "TRUST_PROXY_HEADERS=true in production — confirm the upstream proxy \
+             strips client-supplied X-Forwarded-For before appending; otherwise \
+             per-IP rate limiting can be bypassed by header spoofing"
+        );
+    }
+
     // Pre-warm the dummy Argon2 hash so the first unknown-email login path is
     // not measurably slower than subsequent ones (closes a timing side channel
     // around user enumeration).

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -11,7 +11,12 @@ use axum::{
 use http_body_util::BodyExt;
 use poolpay::{
     api,
-    auth::{bootstrap, hmac::sign_for_testing, password},
+    auth::{
+        bootstrap,
+        hmac::sign_for_testing,
+        password,
+        rate_limit::{RateLimitConfig, TEST_PEER_IP_HEADER},
+    },
     db,
 };
 use std::sync::OnceLock;
@@ -37,13 +42,39 @@ fn init_env() {
 }
 
 async fn test_app() -> (Router, poolpay::db::DbConn) {
+    build_app(lax_rate_cfg()).await
+}
+
+async fn build_app(rate_cfg: RateLimitConfig) -> (Router, poolpay::db::DbConn) {
     init_env();
     let conn = db::init_memory().await.expect("failed to init test DB");
     bootstrap::ensure_admin_user(&conn)
         .await
         .expect("bootstrap seed must succeed");
-    let router = api::router(conn.clone());
+    let router = api::router_with_config(conn.clone(), rate_cfg);
     (router, conn)
+}
+
+/// Non-restrictive config used by every non-rate-limit test. Large buckets so
+/// the existing tests cannot trip a 429 by accident.
+fn lax_rate_cfg() -> RateLimitConfig {
+    RateLimitConfig {
+        per_ip_per_minute: 60,
+        per_ip_burst: 1000,
+        credential_failure_limit: 1000,
+        credential_failure_window_secs: 900,
+        trust_proxy_headers: false,
+        test_mode: true,
+    }
+}
+
+fn hmac_request_with_ip(uri: &str, body: &serde_json::Value, peer_ip: &str) -> Request<Body> {
+    let mut req = hmac_request(uri, body);
+    req.headers_mut().insert(
+        TEST_PEER_IP_HEADER,
+        peer_ip.parse().expect("valid header value"),
+    );
+    req
 }
 
 fn hmac_request(uri: &str, body: &serde_json::Value) -> Request<Body> {
@@ -284,6 +315,233 @@ async fn bootstrap_is_idempotent() {
         .unwrap();
     let counts: Vec<i64> = resp.take("count").unwrap_or_default();
     assert_eq!(counts.first().copied().unwrap_or(0), 1);
+}
+
+// ── Rate limiting (Plan 3 / BE-2) ─────────────────────────────────────────────
+
+fn strict_credential_cfg() -> RateLimitConfig {
+    // Composite limiter: 5 failures per 900s. Per-IP stays generous so it
+    // doesn't overshadow the composite limit in these tests.
+    RateLimitConfig {
+        per_ip_per_minute: 60,
+        per_ip_burst: 1000,
+        credential_failure_limit: 5,
+        credential_failure_window_secs: 900,
+        trust_proxy_headers: false,
+        test_mode: true,
+    }
+}
+
+fn strict_per_ip_cfg() -> RateLimitConfig {
+    // Per-IP limiter with a tiny burst so tests can exhaust it in-process.
+    // `per_ip_per_minute=60` → one replenish per second; burst=2 means the
+    // third consecutive hit gets 429.
+    RateLimitConfig {
+        per_ip_per_minute: 60,
+        per_ip_burst: 2,
+        credential_failure_limit: 1000,
+        credential_failure_window_secs: 900,
+        trust_proxy_headers: false,
+        test_mode: true,
+    }
+}
+
+#[tokio::test]
+async fn credential_failure_limit_returns_429_after_limit() {
+    let (app, _db) = build_app(strict_credential_cfg()).await;
+    let body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": "wrong",
+    });
+
+    for _ in 0..5 {
+        let resp = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/verify-credentials", &body, "10.0.0.1"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // 6th failure from the same (ip, email) exhausts the bucket → 429.
+    let resp = call(
+        app,
+        hmac_request_with_ip("/api/auth/verify-credentials", &body, "10.0.0.1"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        resp.headers().contains_key("retry-after"),
+        "429 must carry a Retry-After header"
+    );
+}
+
+#[tokio::test]
+async fn credential_failure_limit_isolates_by_email() {
+    let (app, _db) = build_app(strict_credential_cfg()).await;
+
+    // Exhaust the bucket for ghost-a@.
+    let body_a = serde_json::json!({ "email": "ghost-a@example.com", "password": "x" });
+    for _ in 0..5 {
+        let resp = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/verify-credentials", &body_a, "10.0.0.2"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // Same IP, different email → still 401, not 429.
+    let body_b = serde_json::json!({ "email": "ghost-b@example.com", "password": "x" });
+    let resp = call(
+        app,
+        hmac_request_with_ip("/api/auth/verify-credentials", &body_b, "10.0.0.2"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn credential_failure_limit_isolates_by_ip() {
+    let (app, _db) = build_app(strict_credential_cfg()).await;
+    let body = serde_json::json!({ "email": "ghost@example.com", "password": "x" });
+
+    for _ in 0..5 {
+        let resp = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/verify-credentials", &body, "10.0.0.3"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // Different IP, same email → still 401, not 429.
+    let resp = call(
+        app,
+        hmac_request_with_ip("/api/auth/verify-credentials", &body, "10.0.0.99"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn credential_failure_limit_is_not_consumed_by_success() {
+    let (app, _db) = build_app(strict_credential_cfg()).await;
+
+    // Burn 4 failures against the real admin account.
+    let bad = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": "wrong",
+    });
+    for _ in 0..4 {
+        let resp = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/verify-credentials", &bad, "10.0.0.4"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // A correct password must not consume the remaining slot.
+    let good = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": BOOTSTRAP_PASSWORD,
+    });
+    let ok = call(
+        app.clone(),
+        hmac_request_with_ip("/api/auth/verify-credentials", &good, "10.0.0.4"),
+    )
+    .await;
+    assert_eq!(ok.status(), StatusCode::OK);
+
+    // Hence one more failure is still allowed (5th failure total, still 401).
+    let resp5 = call(
+        app.clone(),
+        hmac_request_with_ip("/api/auth/verify-credentials", &bad, "10.0.0.4"),
+    )
+    .await;
+    assert_eq!(resp5.status(), StatusCode::UNAUTHORIZED);
+
+    // The 6th failure finally exhausts the bucket.
+    let resp6 = call(
+        app,
+        hmac_request_with_ip("/api/auth/verify-credentials", &bad, "10.0.0.4"),
+    )
+    .await;
+    assert_eq!(resp6.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test]
+async fn per_ip_limit_returns_429_after_burst() {
+    let (app, _db) = build_app(strict_per_ip_cfg()).await;
+    let body = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "sub-rate-1",
+        "email": "rate@example.com",
+    });
+
+    // First two requests fit the burst.
+    for _ in 0..2 {
+        let resp = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/ensure-user", &body, "10.0.1.1"),
+        )
+        .await;
+        // Either 200 (first) or 200 (second idempotent); never 429 yet.
+        assert!(
+            resp.status() == StatusCode::OK,
+            "first burst hits must succeed, got {}",
+            resp.status()
+        );
+    }
+
+    // Third consecutive hit from the same IP exceeds the burst → 429. Tower
+    // governor replies 429 before the handler runs, so HMAC validity is
+    // irrelevant.
+    let resp = call(
+        app,
+        hmac_request_with_ip("/api/auth/ensure-user", &body, "10.0.1.1"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test]
+async fn per_ip_limit_isolates_by_ip() {
+    let (app, _db) = build_app(strict_per_ip_cfg()).await;
+    let body = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "sub-rate-2",
+        "email": "rate2@example.com",
+    });
+
+    // Exhaust the bucket from one IP.
+    for _ in 0..2 {
+        let _ = call(
+            app.clone(),
+            hmac_request_with_ip("/api/auth/ensure-user", &body, "10.0.2.1"),
+        )
+        .await;
+    }
+    let blocked = call(
+        app.clone(),
+        hmac_request_with_ip("/api/auth/ensure-user", &body, "10.0.2.1"),
+    )
+    .await;
+    assert_eq!(blocked.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // A fresh IP must not inherit the neighbour's empty bucket.
+    let other = serde_json::json!({
+        "provider": "google",
+        "providerSubject": "sub-rate-2",
+        "email": "rate2@example.com",
+    });
+    let ok = call(
+        app,
+        hmac_request_with_ip("/api/auth/ensure-user", &other, "10.0.2.99"),
+    )
+    .await;
+    assert_eq!(ok.status(), StatusCode::OK);
 }
 
 // ── Password primitives sanity check ──────────────────────────────────────────

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -334,10 +334,11 @@ fn strict_credential_cfg() -> RateLimitConfig {
 
 fn strict_per_ip_cfg() -> RateLimitConfig {
     // Per-IP limiter with a tiny burst so tests can exhaust it in-process.
-    // `per_ip_per_minute=60` → one replenish per second; burst=2 means the
-    // third consecutive hit gets 429.
+    // `per_ip_per_minute=1` → one replenish per minute; burst=2 means the
+    // third consecutive hit gets 429 without any risk of a token refilling
+    // mid-test on slow CI.
     RateLimitConfig {
-        per_ip_per_minute: 60,
+        per_ip_per_minute: 1,
         per_ip_burst: 2,
         credential_failure_limit: 1000,
         credential_failure_window_secs: 900,


### PR DESCRIPTION
## Summary
- Mounts a per-IP `tower_governor` layer on `/api/auth/verify-credentials` and `/api/auth/ensure-user`, running before HMAC verification so anonymous floods are dropped cheaply.
- Adds a composite `(ip, email_normalised)` failure limiter on `/verify-credentials`. Only failed logins consume quota — successful logins never penalise legitimate users. Exhaustion upgrades 401 → 429 with a `Retry-After` header.
- New env knobs (`AUTH_RATE_LIMIT_PER_MINUTE/BURST`, `AUTH_CREDENTIAL_FAILURE_LIMIT/WINDOW_SECS`, `TRUST_PROXY_HEADERS`) documented in `.env.example` and `docs/RUNBOOK.md`.

## Design notes
- `AuthIpKeyExtractor` resolves the client IP from, in order: `X-Test-Peer-Ip` (test mode only), `X-Forwarded-For` (only when `TRUST_PROXY_HEADERS=true`), `ConnectInfo<SocketAddr>`. The handler-level `ClientIp` extractor shares the same logic so both limiters key on the same IP.
- `main.rs` now serves with `into_make_service_with_connect_info::<SocketAddr>` so `ConnectInfo` reaches the key extractor.
- `AppError::TooManyRequests { retry_after_secs }` maps to 429 with `Retry-After`.
- Charging strategy: governor's `check_key` consumes on success, so the composite limiter only calls it on a failed login path. The attacker still pays Argon2 cost on the attempt that hits the limit, but Layer A (per-IP) handles raw CPU-exhaustion DoS.

## Commit structure (7 atomic commits, ~100 lines each)
1. `[ADD]` pull `tower_governor`, `governor`, `dashmap`
2. `[FEAT]` rate-limit config loader + `AuthIpKeyExtractor` + `ClientIp`
3. `[FEAT]` mount per-IP layer on the auth sub-router
4. `[FEAT]` `AppError::TooManyRequests` with `Retry-After`
5. `[FEAT]` composite `(ip, email)` failure limiter in `verify_credentials`
6. `[TEST]` integration tests for per-IP and composite limiters
7. `[DOCS]` RUNBOOK rate-limit section + BE-2 ticked in plan-3

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 199 tests green (+6 new rate-limit tests)
- [x] Reviewer: confirm `TRUST_PROXY_HEADERS` default (`false`) matches deployment plan
- [x] Reviewer: sanity-check per-IP defaults (60/min, burst 10) vs expected legit traffic shape
- [ ] Smoke: run locally, fire 6 bad passwords from the same IP+email → expect the 6th response as `429` with `Retry-After`

## Related
- Plan 3 / BE-2 — `wiki/poolpay/roadmap/plan-3-auth-rbac.md`
- Plan 4 / PB-1 — cross-ref only; closed by this PR