### PR TITLE
Plan 3 / BE-3: JWT verifier, refresh rotation, and RBAC extractors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,32 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # (Fly, Vercel edge, nginx) that sets X-Forwarded-For. Leaving it false in
 # front-of-proxy deployments collapses rate limiting to the proxy's IP.
 # TRUST_PROXY_HEADERS=false
+
+# --- JWT verifier (Plan 3 / BE-3) ---
+# RS256 key material for access-token verification and minting. One JSON
+# array of { kid, public_pem, private_pem?, is_active } entries. Exactly
+# one `is_active: true` entry is required — that key mints new tokens;
+# the others are accepted during rotation windows.
+#
+# Generate a keypair with:
+#   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt.pem
+#   openssl rsa -in jwt.pem -pubout -out jwt.pub
+#
+# APP_ENV=production REQUIRES JWT_KEYS. In dev/test, leaving it unset
+# auto-generates an ephemeral RSA-2048 keypair on boot so `cargo run`
+# works without setup — a warning is logged so it cannot go unnoticed.
+# JWT_KEYS=[{"kid":"2026-q2","is_active":true,"public_pem":"-----BEGIN PUBLIC KEY-----\n...","private_pem":"-----BEGIN PRIVATE KEY-----\n..."}]
+
+# Access-token audience and issuer claims. Must match whatever the
+# upstream minter (NextAuth in BE-4) puts on tokens or verification fails.
+# JWT_AUDIENCE=poolpay-api
+# JWT_ISSUER=poolpay-nextauth
+
+# Access-token lifetime in seconds. Short on purpose — refresh rotates.
+# JWT_ACCESS_TTL_SECS=900
+
+# Clock-skew tolerance when validating exp/nbf/iat.
+# JWT_LEEWAY_SECS=60
+
+# Refresh-token lifetime in seconds. Default: 14 days.
+# JWT_REFRESH_TTL_SECS=1209600

--- a/.env.example
+++ b/.env.example
@@ -59,8 +59,8 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 
 # --- JWT verifier (Plan 3 / BE-3) ---
 # RS256 key material for access-token verification and minting. One JSON
-# array of { kid, public_pem, private_pem?, is_active } entries. Exactly
-# one `is_active: true` entry is required — that key mints new tokens;
+# array of { kid, public_pem, private_pem?, active } entries. Exactly
+# one `active: true` entry is required — that key mints new tokens;
 # the others are accepted during rotation windows.
 #
 # Generate a keypair with:
@@ -70,7 +70,7 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # APP_ENV=production REQUIRES JWT_KEYS. In dev/test, leaving it unset
 # auto-generates an ephemeral RSA-2048 keypair on boot so `cargo run`
 # works without setup — a warning is logged so it cannot go unnoticed.
-# JWT_KEYS=[{"kid":"2026-q2","is_active":true,"public_pem":"-----BEGIN PUBLIC KEY-----\n...","private_pem":"-----BEGIN PRIVATE KEY-----\n..."}]
+# JWT_KEYS=[{"kid":"2026-q2","active":true,"public_pem":"-----BEGIN PUBLIC KEY-----\n...","private_pem":"-----BEGIN PRIVATE KEY-----\n..."}]
 
 # Access-token audience and issuer claims. Must match whatever the
 # upstream minter (NextAuth in BE-4) puts on tokens or verification fails.

--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,11 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 #   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt.pem
 #   openssl rsa -in jwt.pem -pubout -out jwt.pub
 #
-# APP_ENV=production REQUIRES JWT_KEYS. In dev/test, leaving it unset
-# auto-generates an ephemeral RSA-2048 keypair on boot so `cargo run`
-# works without setup — a warning is logged so it cannot go unnoticed.
+# APP_ENV=production REQUIRES JWT_KEYS. Only when APP_ENV is explicitly
+# set to `development` or `test` does leaving JWT_KEYS unset auto-generate
+# an ephemeral RSA-2048 keypair on boot (a warning is logged). Missing or
+# unrecognised APP_ENV values fail closed — set APP_ENV=development for
+# frictionless `cargo run`.
 # JWT_KEYS=[{"kid":"2026-q2","active":true,"public_pem":"-----BEGIN PUBLIC KEY-----\n...","private_pem":"-----BEGIN PRIVATE KEY-----\n..."}]
 
 # Access-token audience and issuer claims. Must match whatever the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,21 +2188,6 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
@@ -3062,7 +3047,7 @@ dependencies = [
  "hex",
  "hmac",
  "http-body-util",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "password-hash",
  "rand 0.8.5",
  "regex",
@@ -4432,7 +4417,7 @@ dependencies = [
  "http",
  "humantime",
  "ipnet",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "lexicmp",
  "md-5",
  "mime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,6 +3064,7 @@ dependencies = [
  "http-body-util",
  "jsonwebtoken 9.3.1",
  "password-hash",
+ "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
  "rsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,21 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
@@ -3039,6 +3054,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "axum",
+ "base64",
  "chrono",
  "dashmap",
  "dotenv",
@@ -3046,9 +3062,11 @@ dependencies = [
  "hex",
  "hmac",
  "http-body-util",
+ "jsonwebtoken 9.3.1",
  "password-hash",
  "regex",
  "reqwest 0.12.28",
+ "rsa",
  "serde",
  "serde_json",
  "sha2",
@@ -4413,7 +4431,7 @@ dependencies = [
  "http",
  "humantime",
  "ipnet",
- "jsonwebtoken",
+ "jsonwebtoken 10.3.0",
  "lexicmp",
  "md-5",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,11 @@ rsa = { version = "0.9", features = ["pem"] }
 # Base64url encoding for opaque refresh tokens
 base64 = "0.22"
 
+# Random bytes — ephemeral JWT key generation in dev/test and opaque refresh
+# token material. `rsa` already depends on `rand`, listing it explicitly keeps
+# the dependency intentional.
+rand = "0.8"
+
 [dev-dependencies]
 # HTTP service test utilities — used in API integration tests
 tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,17 @@ tower_governor = { version = "0.8", default-features = false, features = ["axum"
 governor = "0.10"
 dashmap = "6"
 
+# JWT verification + signing — RS256, kid-indexed key map for rotation (Plan 3 / BE-3)
+jsonwebtoken = "9"
+
+# RSA keygen — only used to mint an ephemeral dev/test keypair when JWT_KEYS is
+# unset outside production. Prod panics at boot without JWT_KEYS, so this dep is
+# never exercised on the hot path.
+rsa = { version = "0.9", features = ["pem"] }
+
+# Base64url encoding for opaque refresh tokens
+base64 = "0.22"
+
 [dev-dependencies]
 # HTTP service test utilities — used in API integration tests
 tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ governor = "0.10"
 dashmap = "6"
 
 # JWT verification + signing — RS256, kid-indexed key map for rotation (Plan 3 / BE-3)
-jsonwebtoken = "9"
+jsonwebtoken = "10"
 
 # RSA keygen — only used to mint an ephemeral dev/test keypair when JWT_KEYS is
 # unset outside production. Prod panics at boot without JWT_KEYS, so this dep is

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -182,9 +182,12 @@ wires NextAuth to call this surface; today the extractors ride behind
 
 **Production requires `JWT_KEYS`.** With `APP_ENV=production` the
 process panics at boot if `JWT_KEYS` is missing or contains no active
-entry. In dev/test, an ephemeral RSA-2048 keypair is generated on boot
-and a warning is logged — this keeps `cargo run` frictionless but is
-unsafe to deploy (every restart invalidates every outstanding token).
+entry. When `APP_ENV` is explicitly set to `development` or `test`, an
+ephemeral RSA-2048 keypair is generated on boot and a warning is logged —
+this keeps `cargo run` frictionless but is unsafe to deploy (every
+restart invalidates every outstanding token). Missing or unrecognised
+`APP_ENV` values fail closed, so local setups must set `APP_ENV`
+explicitly.
 
 **Refresh rotation = theft detection.** The rotation endpoint follows
 RFC 6749 BCP §4.12: every use of a refresh token revokes the original

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -107,7 +107,7 @@ TRUST_PROXY_HEADERS=false
 
 # --- JWT verifier (Plan 3 / BE-3) ---
 # RS256 key material. JSON array of entries:
-#   [{"kid":"...","is_active":true,"public_pem":"...","private_pem":"..."}]
+#   [{"kid":"...","active":true,"public_pem":"...","private_pem":"..."}]
 # Exactly one entry must be active — that key mints new access tokens;
 # inactive entries are accepted during rotation. Required in production.
 # JWT_KEYS=...
@@ -165,11 +165,11 @@ wires NextAuth to call this surface; today the extractors ride behind
 `#[allow(dead_code)]`.
 
 - **`JWT_KEYS`** — JSON array of keypairs:
-  `[{ "kid": "...", "is_active": true, "public_pem": "...", "private_pem": "..." }]`.
+  `[{ "kid": "...", "active": true, "public_pem": "...", "private_pem": "..." }]`.
   Exactly one active entry is required. The active key mints tokens
   inside `/api/auth/refresh`; any listed key verifies incoming access
   tokens (staged rotation: publish the new key as inactive, flip
-  `is_active` once the upstream minter has picked it up, then remove
+  `active` once the upstream minter has picked it up, then remove
   the old entry one refresh cycle later).
 - **`JWT_AUDIENCE` / `JWT_ISSUER`** — enforced on every access token.
   Must match whatever the upstream minter stamps on tokens; a mismatch

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -190,7 +190,7 @@ restart invalidates every outstanding token). Missing or unrecognised
 explicitly.
 
 **Refresh rotation = theft detection.** The rotation endpoint follows
-RFC 6749 BCP §4.12: every use of a refresh token revokes the original
+OAuth 2.0 Security BCP (RFC 9700) §4.12: every use of a refresh token revokes the original
 row and issues a new one in the same family. Presenting an already-
 rotated token is treated as evidence of compromise — the entire family
 is revoked, the user's `token_version` is bumped (which invalidates any

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -104,6 +104,26 @@ AUTH_CREDENTIAL_FAILURE_WINDOW_SECS=900
 # behind a reverse proxy that strips user-supplied copies of that header
 # (Fly, Vercel edge, nginx). Default false.
 TRUST_PROXY_HEADERS=false
+
+# --- JWT verifier (Plan 3 / BE-3) ---
+# RS256 key material. JSON array of entries:
+#   [{"kid":"...","is_active":true,"public_pem":"...","private_pem":"..."}]
+# Exactly one entry must be active — that key mints new access tokens;
+# inactive entries are accepted during rotation. Required in production.
+# JWT_KEYS=...
+
+# Audience / issuer claims the verifier enforces on every access token.
+JWT_AUDIENCE=poolpay-api
+JWT_ISSUER=poolpay-nextauth
+
+# Access-token lifetime (seconds). Short on purpose — refresh rotates.
+JWT_ACCESS_TTL_SECS=900
+
+# Clock-skew tolerance for exp/nbf/iat validation.
+JWT_LEEWAY_SECS=60
+
+# Refresh-token lifetime (seconds). Default: 14 days.
+JWT_REFRESH_TTL_SECS=1209600
 ```
 
 ### Auth Rate Limiting
@@ -138,12 +158,50 @@ leaves that as the proxy's own IP, set `TRUST_PROXY_HEADERS=true` so the
 proxy's `X-Forwarded-For` is honoured — but only if the proxy strips any
 client-supplied copy of that header, otherwise callers can spoof their IP.
 
+### JWT Verification + Refresh Rotation
+
+The API verifies RS256 access tokens and rotates refresh tokens. BE-4
+wires NextAuth to call this surface; today the extractors ride behind
+`#[allow(dead_code)]`.
+
+- **`JWT_KEYS`** — JSON array of keypairs:
+  `[{ "kid": "...", "is_active": true, "public_pem": "...", "private_pem": "..." }]`.
+  Exactly one active entry is required. The active key mints tokens
+  inside `/api/auth/refresh`; any listed key verifies incoming access
+  tokens (staged rotation: publish the new key as inactive, flip
+  `is_active` once the upstream minter has picked it up, then remove
+  the old entry one refresh cycle later).
+- **`JWT_AUDIENCE` / `JWT_ISSUER`** — enforced on every access token.
+  Must match whatever the upstream minter stamps on tokens; a mismatch
+  is a hard 401 with no body hint.
+- **`JWT_ACCESS_TTL_SECS`** — access-token lifetime. Default 900 (15 min).
+  Short on purpose: `token_version` bumps on role changes and refresh
+  reuse detection take effect within this window.
+- **`JWT_LEEWAY_SECS`** — clock-skew tolerance for exp/nbf/iat. Default 60.
+- **`JWT_REFRESH_TTL_SECS`** — refresh-token lifetime. Default 1209600 (14 days).
+
+**Production requires `JWT_KEYS`.** With `APP_ENV=production` the
+process panics at boot if `JWT_KEYS` is missing or contains no active
+entry. In dev/test, an ephemeral RSA-2048 keypair is generated on boot
+and a warning is logged — this keeps `cargo run` frictionless but is
+unsafe to deploy (every restart invalidates every outstanding token).
+
+**Refresh rotation = theft detection.** The rotation endpoint follows
+RFC 6749 BCP §4.12: every use of a refresh token revokes the original
+row and issues a new one in the same family. Presenting an already-
+rotated token is treated as evidence of compromise — the entire family
+is revoked, the user's `token_version` is bumped (which invalidates any
+outstanding access tokens within the 15-minute TTL), and an
+`auth_event{refresh_reuse_detected}` is written. The caller receives
+a generic 401 so the signal is not exposed to the attacker.
+
 ### Production Security
 
 - Set `APP_ENV=production` to enable CORS restrictions
 - Set `DASHBOARD_ORIGIN` to the dashboard URL
 - Set a strong `ADMIN_TOKEN` (at least 32 hex characters)
 - Set `NEXTAUTH_BACKEND_SECRET` to a value with ≥ 32 bytes — the process panics at boot in production if it is shorter or unset
+- Set `JWT_KEYS` with at least one active RS256 entry — the process panics at boot in production if it is missing (ephemeral-key fallback is disabled outside dev/test)
 - The `/api/test/reset` endpoint is fail-closed: it only mounts when `APP_ENV=development` or `APP_ENV=test`. Unset `APP_ENV` on a staging/prod host and the endpoint stays unreachable
 - After the bootstrap admin's first password rotation, remove `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD` from deployed env
 - Never commit `.env` with real credentials

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -420,17 +420,24 @@ pub async fn refresh_token_endpoint(
             return Err(AppError::Unauthorized);
         }
         Err(e @ (RefreshError::Db(_) | RefreshError::Internal(_))) => {
+            // Log internally but collapse to 401 so the response shape cannot
+            // be used as an oracle distinguishing server-side failures from
+            // invalid/expired/reused tokens.
             tracing::error!(error = %e, "refresh rotate failed");
-            return Err(AppError::Internal("refresh failed".into()));
+            return Err(AppError::Unauthorized);
         }
     };
 
     // Mint a matching access token. The user row is loaded fresh to pick up
     // the latest role + token_version — those can change between refreshes.
-    let user = refresh::load_user(&db, &user_id)
-        .await
-        .map_err(AppError::from)?
-        .ok_or(AppError::Unauthorized)?;
+    let user = match refresh::load_user(&db, &user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return Err(AppError::Unauthorized),
+        Err(e) => {
+            tracing::error!(error = %e, "refresh load_user failed");
+            return Err(AppError::Unauthorized);
+        }
+    };
 
     if user.status != "active" || user.deleted_at.is_some() {
         return Err(AppError::Unauthorized);
@@ -440,7 +447,7 @@ pub async fn refresh_token_endpoint(
         .mint_access(&user_id, &user.role, user.token_version)
         .map_err(|e| {
             tracing::error!(error = %e, "mint access on refresh failed");
-            AppError::Internal("refresh failed".into())
+            AppError::Unauthorized
         })?;
 
     record_auth_event(&db, Some(user_id), "refresh_success", true, None, Some(&ip)).await;

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -8,7 +8,7 @@
 //! never auto-linked on email match. A second provider for the same person
 //! becomes a deliberate, authenticated FE linking flow (not in BE-1).
 
-use axum::{Extension, Json, extract::State};
+use axum::{Extension, Json, extract::State, extract::rejection::JsonRejection};
 use serde::{Deserialize, Serialize};
 
 use crate::api::models::{
@@ -400,8 +400,12 @@ pub async fn refresh_token_endpoint(
     State(db): State<DbConn>,
     Extension(verifier): Extension<SharedVerifier>,
     ClientIp(client_ip): ClientIp,
-    Json(req): Json<RefreshRequest>,
+    req: Result<Json<RefreshRequest>, JsonRejection>,
 ) -> Result<Json<RefreshResponse>, AppError> {
+    // Malformed JSON / wrong content-type must not leak a distinguishing
+    // 400/415 — collapse every decode failure to the same 401 the rest of
+    // this handler returns.
+    let Json(req) = req.map_err(|_| AppError::Unauthorized)?;
     if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
         return Err(AppError::Unauthorized);
     }
@@ -471,8 +475,15 @@ pub struct LogoutRequest {
 pub async fn logout_endpoint(
     State(db): State<DbConn>,
     ClientIp(client_ip): ClientIp,
-    Json(req): Json<LogoutRequest>,
+    req: Result<Json<LogoutRequest>, JsonRejection>,
 ) -> Result<axum::http::StatusCode, AppError> {
+    // Strict "always 204" contract: malformed JSON / wrong content-type
+    // must not surface Axum's default 400/415 — silently return 204 so
+    // logout cannot be probed as an oracle.
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(_) => return Ok(axum::http::StatusCode::NO_CONTENT),
+    };
     if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
         return Ok(axum::http::StatusCode::NO_CONTENT);
     }

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -16,8 +16,10 @@ use crate::api::models::{
     UserIdentityContent, now_iso, record_id_to_string,
 };
 use crate::auth::hmac::HmacVerifiedJson;
+use crate::auth::jwt::SharedVerifier;
 use crate::auth::password;
 use crate::auth::rate_limit::{ClientIp, CredentialFailureLimiter};
+use crate::auth::refresh::{self, RefreshError};
 use crate::db::DbConn;
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
@@ -368,6 +370,118 @@ async fn find_identity(
         .check()?;
     let rows: Vec<DbUserIdentity> = resp.take(0)?;
     Ok(rows.into_iter().next())
+}
+
+// ── refresh + logout ──────────────────────────────────────────────────────────
+
+const MAX_REFRESH_TOKEN_LEN: usize = 128;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: String,
+}
+
+/// Rotate a refresh token and mint a fresh access token. Dead code from the
+/// client perspective until BE-4 wires NextAuth to start calling it.
+///
+/// Every failure path produces `401 Unauthorized` with no body hint — the
+/// caller cannot distinguish "expired" from "reused" from "unknown" because
+/// that distinction is only useful to an attacker.
+pub async fn refresh_token_endpoint(
+    State(db): State<DbConn>,
+    Extension(verifier): Extension<SharedVerifier>,
+    ClientIp(client_ip): ClientIp,
+    Json(req): Json<RefreshRequest>,
+) -> Result<Json<RefreshResponse>, AppError> {
+    if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
+        return Err(AppError::Unauthorized);
+    }
+
+    let ip = client_ip.to_string();
+    let (new_token, user_id) = match refresh::rotate(&db, &req.refresh_token).await {
+        Ok(pair) => pair,
+        Err(RefreshError::ReuseDetected) => {
+            // `rotate` already killed the family, bumped token_version, and
+            // wrote the audit row — we only need to 401 the caller.
+            return Err(AppError::Unauthorized);
+        }
+        Err(RefreshError::NotFound | RefreshError::Expired) => {
+            record_auth_event(&db, None, "refresh_failure", false, Some("invalid"), Some(&ip))
+                .await;
+            return Err(AppError::Unauthorized);
+        }
+        Err(e @ (RefreshError::Db(_) | RefreshError::Internal(_))) => {
+            tracing::error!(error = %e, "refresh rotate failed");
+            return Err(AppError::Internal("refresh failed".into()));
+        }
+    };
+
+    // Mint a matching access token. The user row is loaded fresh to pick up
+    // the latest role + token_version — those can change between refreshes.
+    let user = refresh::load_user(&db, &user_id)
+        .await
+        .map_err(AppError::from)?
+        .ok_or(AppError::Unauthorized)?;
+
+    if user.status != "active" || user.deleted_at.is_some() {
+        return Err(AppError::Unauthorized);
+    }
+
+    let access = verifier
+        .mint_access(&user_id, &user.role, user.token_version)
+        .map_err(|e| {
+            tracing::error!(error = %e, "mint access on refresh failed");
+            AppError::Internal("refresh failed".into())
+        })?;
+
+    record_auth_event(&db, Some(user_id), "refresh_success", true, None, Some(&ip)).await;
+
+    Ok(Json(RefreshResponse {
+        access_token: access,
+        refresh_token: new_token.plaintext,
+        expires_at: new_token.expires_at,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogoutRequest {
+    pub refresh_token: String,
+}
+
+/// Revoke the entire refresh-token family the caller belongs to. Always
+/// returns 204 — we do not signal whether the token was known so logout
+/// cannot be used as an oracle.
+pub async fn logout_endpoint(
+    State(db): State<DbConn>,
+    ClientIp(client_ip): ClientIp,
+    Json(req): Json<LogoutRequest>,
+) -> Result<axum::http::StatusCode, AppError> {
+    if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
+        return Ok(axum::http::StatusCode::NO_CONTENT);
+    }
+    let ip = client_ip.to_string();
+    match refresh::revoke_by_presented(&db, &req.refresh_token).await {
+        Ok(user_id) => {
+            record_auth_event(&db, Some(user_id), "logout", true, None, Some(&ip)).await;
+        }
+        Err(RefreshError::NotFound) => {
+            // Unknown token — still return 204 to avoid leaking validity.
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "logout revoke failed");
+        }
+    }
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 async fn record_auth_event(

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -8,7 +8,11 @@
 //! never auto-linked on email match. A second provider for the same person
 //! becomes a deliberate, authenticated FE linking flow (not in BE-1).
 
-use axum::{Extension, Json, extract::State, extract::rejection::JsonRejection};
+use axum::{
+    Extension, Json,
+    body::to_bytes,
+    extract::{Request, State},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::api::models::{
@@ -376,6 +380,13 @@ async fn find_identity(
 
 const MAX_REFRESH_TOKEN_LEN: usize = 128;
 
+// Hard cap on the raw request body for the public refresh/logout endpoints.
+// `MAX_REFRESH_TOKEN_LEN` bounds the *field* but `Json` would still buffer
+// an arbitrarily large body before rejecting it, which is a trivial memory
+// DoS vector on un-authenticated routes. 4 KiB easily fits a 128-char token
+// plus JSON framing.
+const MAX_REFRESH_BODY_BYTES: usize = 4 * 1024;
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefreshRequest {
@@ -400,12 +411,17 @@ pub async fn refresh_token_endpoint(
     State(db): State<DbConn>,
     Extension(verifier): Extension<SharedVerifier>,
     ClientIp(client_ip): ClientIp,
-    req: Result<Json<RefreshRequest>, JsonRejection>,
+    http_req: Request,
 ) -> Result<Json<RefreshResponse>, AppError> {
-    // Malformed JSON / wrong content-type must not leak a distinguishing
-    // 400/415 — collapse every decode failure to the same 401 the rest of
-    // this handler returns.
-    let Json(req) = req.map_err(|_| AppError::Unauthorized)?;
+    // Malformed JSON / wrong content-type / oversized bodies must not leak a
+    // distinguishing 400/413/415 — collapse every decode failure to the same
+    // 401 the rest of this handler returns. Reading bytes manually also caps
+    // buffer size at `MAX_REFRESH_BODY_BYTES` to bound parser memory.
+    let body = to_bytes(http_req.into_body(), MAX_REFRESH_BODY_BYTES)
+        .await
+        .map_err(|_| AppError::Unauthorized)?;
+    let req: RefreshRequest =
+        serde_json::from_slice(&body).map_err(|_| AppError::Unauthorized)?;
     if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
         return Err(AppError::Unauthorized);
     }
@@ -475,13 +491,18 @@ pub struct LogoutRequest {
 pub async fn logout_endpoint(
     State(db): State<DbConn>,
     ClientIp(client_ip): ClientIp,
-    req: Result<Json<LogoutRequest>, JsonRejection>,
+    http_req: Request,
 ) -> Result<axum::http::StatusCode, AppError> {
-    // Strict "always 204" contract: malformed JSON / wrong content-type
-    // must not surface Axum's default 400/415 — silently return 204 so
-    // logout cannot be probed as an oracle.
-    let Json(req) = match req {
-        Ok(j) => j,
+    // Strict "always 204" contract: malformed JSON / wrong content-type /
+    // oversized bodies must not surface Axum's default 400/413/415 —
+    // silently return 204 so logout cannot be probed as an oracle, while
+    // still bounding parser memory via `MAX_REFRESH_BODY_BYTES`.
+    let body = match to_bytes(http_req.into_body(), MAX_REFRESH_BODY_BYTES).await {
+        Ok(b) => b,
+        Err(_) => return Ok(axum::http::StatusCode::NO_CONTENT),
+    };
+    let req: LogoutRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
         Err(_) => return Ok(axum::http::StatusCode::NO_CONTENT),
     };
     if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,8 +32,9 @@ pub fn router(db: DbConn) -> Router {
     let verifier = VERIFIER
         .get_or_init(|| {
             Arc::new(
-                StaticKeyVerifier::from_env(JwtConfig::from_env())
-                    .expect("JWT_KEYS must be set or APP_ENV must permit an ephemeral key"),
+                StaticKeyVerifier::from_env(JwtConfig::from_env()).unwrap_or_else(|err| {
+                    panic!("Failed to initialise JWT verifier: {err}")
+                }),
             )
         })
         .clone();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ use tower_http::cors::CorsLayer;
 use crate::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
     create_whatsapp_link, delete_cycle, delete_group, delete_member, delete_payment,
@@ -22,11 +22,21 @@ use handlers::{
 };
 
 /// Build the Axum router with all API routes and CORS middleware.
+///
+/// The verifier is built once per process and cached — rebuilding on every
+/// `router()` call would re-parse `JWT_KEYS` (or, in dev/test, generate a
+/// fresh RSA-2048 keypair) which is both expensive and breaks any caller
+/// that holds a previously-minted token across rebuilds.
 pub fn router(db: DbConn) -> Router {
-    let verifier: SharedVerifier = Arc::new(
-        StaticKeyVerifier::from_env(JwtConfig::from_env())
-            .expect("JWT_KEYS must be set or APP_ENV must permit an ephemeral key"),
-    );
+    static VERIFIER: OnceLock<SharedVerifier> = OnceLock::new();
+    let verifier = VERIFIER
+        .get_or_init(|| {
+            Arc::new(
+                StaticKeyVerifier::from_env(JwtConfig::from_env())
+                    .expect("JWT_KEYS must be set or APP_ENV must permit an ephemeral key"),
+            )
+        })
+        .clone();
     router_with_config(db, RateLimitConfig::from_env(), verifier)
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -97,7 +97,9 @@ pub fn router_with_config(
         .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
         .route("/api/admin/whatsapp-links", post(create_whatsapp_link))
         .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link))
-        // Auth endpoints (HMAC-gated, rate-limited) are merged below
+        // Auth endpoints (rate-limited; verify-credentials/ensure-user are
+        // HMAC-gated, refresh/logout authenticate via the refresh token itself)
+        // are merged below
         .merge(auth_router);
 
     // Fail-closed: the destructive test reset endpoint is only mounted when

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,8 +10,10 @@ use axum::{
 };
 use tower_http::cors::CorsLayer;
 
+use crate::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
+use std::sync::Arc;
 use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
     create_whatsapp_link, delete_cycle, delete_group, delete_member, delete_payment,
@@ -21,13 +23,20 @@ use handlers::{
 
 /// Build the Axum router with all API routes and CORS middleware.
 pub fn router(db: DbConn) -> Router {
-    router_with_config(db, RateLimitConfig::from_env())
+    let verifier: SharedVerifier = Arc::new(
+        StaticKeyVerifier::from_env(JwtConfig::from_env())
+            .expect("JWT_KEYS must be set or APP_ENV must permit an ephemeral key"),
+    );
+    router_with_config(db, RateLimitConfig::from_env(), verifier)
 }
 
-/// Build the router with an explicit rate-limit config — used by tests that
-/// need to inject tuned limits (e.g. small bucket sizes that are easy to
-/// exhaust without wall-clock delays).
-pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
+/// Build the router with explicit rate-limit config and token verifier —
+/// used by tests that need tuned limits and a verifier they can mint against.
+pub fn router_with_config(
+    db: DbConn,
+    rate_cfg: RateLimitConfig,
+    verifier: SharedVerifier,
+) -> Router {
     let cors = build_cors();
 
     // Composite (ip, email) failure limiter — charged only on 401 from
@@ -43,6 +52,8 @@ pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
             post(auth_endpoints::verify_credentials),
         )
         .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user))
+        .route("/api/auth/refresh", post(auth_endpoints::refresh_token_endpoint))
+        .route("/api/auth/logout", post(auth_endpoints::logout_endpoint))
         .layer(rate_limit::build_per_ip_layer(&rate_cfg))
         .layer(Extension(credential_failure_limiter))
         .layer(Extension(rate_cfg.clone()));
@@ -86,7 +97,10 @@ pub fn router_with_config(db: DbConn, rate_cfg: RateLimitConfig) -> Router {
         router = router.route("/api/test/reset", post(reset_db));
     }
 
-    router.layer(cors).with_state(db)
+    // The verifier is injected as a request Extension so every handler
+    // (including the auth extractors landing in BE-5) can reach it without
+    // forcing a state-type migration on the existing DbConn-state router.
+    router.layer(cors).layer(Extension(verifier)).with_state(db)
 }
 
 fn build_cors() -> CorsLayer {

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1027,3 +1027,50 @@ pub struct DbAuthEvent {
     pub created_at: String,
 }
 
+/// Row shape for minting a new refresh token. `hashed_token` is the sha256
+/// hex of the opaque 32-byte random value handed to the client — the
+/// plaintext never hits disk, so a DB leak cannot be replayed as-is.
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct RefreshTokenContent {
+    pub user_id: String,
+    pub hashed_token: String,
+    pub family_id: String,
+    pub issued_at: String,
+    pub expires_at: String,
+    pub revoked_at: Option<String>,
+    pub replaced_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, SurrealValue)]
+pub struct DbRefreshToken {
+    pub id: RecordId,
+    pub user_id: String,
+    pub hashed_token: String,
+    pub family_id: String,
+    pub issued_at: String,
+    pub expires_at: String,
+    pub revoked_at: Option<String>,
+    pub replaced_by: Option<String>,
+}
+
+/// Grants one `admin`-role user access to one group. Presence of a row is
+/// the RBAC check; deleting the row is the revocation primitive (and bumps
+/// the target user's `token_version`).
+#[derive(Debug, Clone, Serialize, Deserialize, SurrealValue)]
+pub struct GroupAdminContent {
+    pub user_id: String,
+    pub group_id: String,
+    pub created_at: String,
+    pub created_by: String,
+}
+
+#[derive(Debug, Clone, Deserialize, SurrealValue)]
+#[allow(dead_code)] // Wired to handlers in BE-7; kept here so BE-3 sets the shape.
+pub struct DbGroupAdmin {
+    pub id: RecordId,
+    pub user_id: String,
+    pub group_id: String,
+    pub created_at: String,
+    pub created_by: String,
+}
+

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -106,13 +106,16 @@ pub async fn require_group_scope(
     if user.role == "super_admin" {
         return Ok(());
     }
-    if user.role != "admin" {
-        return Err(AppError::Forbidden("admin role required".into()));
-    }
-    if has_group_admin(db, &user.user_id, group_id).await? {
+    // Single opaque 403 for every non-super-admin failure path. Leaking
+    // "admin role required" vs "no access to this group" tells the caller
+    // whether the JWT role is at least admin — cheap information we don't
+    // need to give away.
+    let allowed =
+        user.role == "admin" && has_group_admin(db, &user.user_id, group_id).await?;
+    if allowed {
         Ok(())
     } else {
-        Err(AppError::Forbidden("no access to this group".into()))
+        Err(AppError::Forbidden("forbidden".into()))
     }
 }
 

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -15,7 +15,7 @@
 use axum::extract::{Extension, FromRef, FromRequestParts, State};
 use axum::http::request::Parts;
 use surrealdb::types::RecordId;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::api::models::{AppError, DbUser};
 use crate::auth::jwt::SharedVerifier;
@@ -52,7 +52,9 @@ where
                 .map_err(|_| AppError::Unauthorized)?;
 
         let claims = verifier.verify_access(&token).map_err(|e| {
-            warn!(error = %e, "JWT verification failed");
+            // Attacker-controlled input; keep at debug to avoid log-amplification.
+            // Reserve `warn!` for unexpected internal failures (e.g., DB errors).
+            debug!(error = %e, "JWT verification failed");
             AppError::Unauthorized
         })?;
 

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -3,26 +3,24 @@
 //! Three guards land in BE-3 but sit behind `#[allow(dead_code)]` until
 //! BE-4 mints real tokens and BE-5 flips handlers to consume them:
 //!
-//! * `AuthenticatedUser` — any active user with a valid, fresh access
-//!   token (sig + exp + token_version + status checks).
+//! * `AuthenticatedUser` — any active user with a valid, fresh access token
+//!   (signature + exp + token_version + status checks).
 //! * `SuperAdminUser` — `AuthenticatedUser` narrowed to `role == "super_admin"`.
-//! * `require_group_scope(&user, group_id, db)` — callable guard that
+//! * `require_group_scope(&user, group_id, db)` — handler-called guard that
 //!   super-admins bypass and scoped admins pass iff a matching
 //!   `group_admin(user_id, group_id)` row exists. Kept as a helper (not a
-//!   typed extractor) because the `group_id` often comes from a parent
-//!   record, so the handler resolves it first and then calls the guard.
+//!   typed extractor) because the `group_id` is often resolved from a
+//!   parent record (payment → cycle → group) inside the handler.
 
-use axum::extract::{FromRef, FromRequestParts};
+use axum::extract::{Extension, FromRef, FromRequestParts, State};
 use axum::http::request::Parts;
 use surrealdb::types::RecordId;
 use tracing::warn;
 
 use crate::api::models::{AppError, DbUser};
-use crate::auth::jwt::{SharedVerifier, TokenVerifier};
+use crate::auth::jwt::SharedVerifier;
 use crate::db::DbConn;
 
-/// A verified, still-active user. The `token_version` is carried so tests
-/// and audit rows can record exactly which version the bearer was on.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AuthenticatedUser {
@@ -31,8 +29,6 @@ pub struct AuthenticatedUser {
     pub token_version: i64,
 }
 
-/// Narrowing extractor for `super_admin`-only endpoints. Unused until BE-5
-/// flips `/api/admin/groups/*` and `/api/admin/whatsapp-links/*` to it.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SuperAdminUser(pub AuthenticatedUser);
@@ -41,19 +37,29 @@ impl<S> FromRequestParts<S> for AuthenticatedUser
 where
     S: Send + Sync,
     DbConn: FromRef<S>,
-    SharedVerifier: FromRef<S>,
 {
     type Rejection = AppError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let token = extract_bearer(parts)?;
-        let verifier = SharedVerifier::from_ref(state);
+
+        // The verifier is injected via Extension so it can be shared across
+        // handlers without forcing every existing route onto a new state
+        // type. Missing extension = misconfigured router = refuse.
+        let Extension(verifier): Extension<SharedVerifier> =
+            Extension::from_request_parts(parts, state)
+                .await
+                .map_err(|_| AppError::Unauthorized)?;
+
         let claims = verifier.verify_access(&token).map_err(|e| {
             warn!(error = %e, "JWT verification failed");
             AppError::Unauthorized
         })?;
 
-        let db = DbConn::from_ref(state);
+        let State(db): State<DbConn> = State::from_request_parts(parts, state)
+            .await
+            .map_err(|_| AppError::Internal("db state missing".into()))?;
+
         let user = load_user(&db, &claims.sub).await.map_err(|e| {
             warn!(error = %e, user = %claims.sub, "user lookup during auth failed");
             AppError::Internal(e.to_string())
@@ -64,23 +70,14 @@ where
             AppError::Unauthorized
         })?;
 
-        // token_version mismatch = the user's JWTs were invalidated server-side
-        // (password change, role change, admin-initiated kill). Fail closed.
-        if user.token_version != claims.token_version {
-            return Err(AppError::Unauthorized);
-        }
-        if user.status != "active" {
-            return Err(AppError::Unauthorized);
-        }
-        if user.deleted_at.is_some() {
+        if user.token_version != claims.token_version
+            || user.status != "active"
+            || user.deleted_at.is_some()
+        {
             return Err(AppError::Unauthorized);
         }
 
-        Ok(Self {
-            user_id: claims.sub,
-            role: user.role,
-            token_version: user.token_version,
-        })
+        Ok(Self { user_id: claims.sub, role: user.role, token_version: user.token_version })
     }
 }
 
@@ -88,7 +85,6 @@ impl<S> FromRequestParts<S> for SuperAdminUser
 where
     S: Send + Sync,
     DbConn: FromRef<S>,
-    SharedVerifier: FromRef<S>,
 {
     type Rejection = AppError;
 
@@ -101,12 +97,6 @@ where
     }
 }
 
-/// Handler-called guard. `super_admin` bypasses; `admin` passes iff a
-/// `group_admin(user_id, group_id)` row exists; anything else is forbidden.
-///
-/// Lives as a helper rather than a typed `FromRequestParts` extractor because
-/// the `group_id` is often resolved from a parent record (payment → cycle →
-/// group) inside the handler before the guard can be called.
 #[allow(dead_code)]
 pub async fn require_group_scope(
     user: &AuthenticatedUser,
@@ -170,25 +160,3 @@ async fn has_group_admin(db: &DbConn, user_id: &str, group_id: &str) -> Result<b
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(counts.first().copied().unwrap_or(0) > 0)
 }
-
-/// Concrete router state that carries both the DB handle and the token
-/// verifier. Extractors read it via `FromRef`; handlers that only need the
-/// DB continue to use `State<DbConn>` unchanged.
-#[derive(Clone)]
-pub struct AuthState {
-    pub db: DbConn,
-    pub verifier: SharedVerifier,
-}
-
-impl FromRef<AuthState> for DbConn {
-    fn from_ref(s: &AuthState) -> Self { s.db.clone() }
-}
-
-impl FromRef<AuthState> for SharedVerifier {
-    fn from_ref(s: &AuthState) -> Self { s.verifier.clone() }
-}
-
-// Silence the rust/axum unused-state warning: until BE-5 flips handlers to
-// the extractors, nothing reads `AuthState` directly.
-#[allow(dead_code)]
-pub(crate) fn _touch(_: &dyn TokenVerifier) {}

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -1,0 +1,194 @@
+//! Axum extractors that turn a bearer token into an attributable user.
+//!
+//! Three guards land in BE-3 but sit behind `#[allow(dead_code)]` until
+//! BE-4 mints real tokens and BE-5 flips handlers to consume them:
+//!
+//! * `AuthenticatedUser` — any active user with a valid, fresh access
+//!   token (sig + exp + token_version + status checks).
+//! * `SuperAdminUser` — `AuthenticatedUser` narrowed to `role == "super_admin"`.
+//! * `require_group_scope(&user, group_id, db)` — callable guard that
+//!   super-admins bypass and scoped admins pass iff a matching
+//!   `group_admin(user_id, group_id)` row exists. Kept as a helper (not a
+//!   typed extractor) because the `group_id` often comes from a parent
+//!   record, so the handler resolves it first and then calls the guard.
+
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
+use surrealdb::types::RecordId;
+use tracing::warn;
+
+use crate::api::models::{AppError, DbUser};
+use crate::auth::jwt::{SharedVerifier, TokenVerifier};
+use crate::db::DbConn;
+
+/// A verified, still-active user. The `token_version` is carried so tests
+/// and audit rows can record exactly which version the bearer was on.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: String,
+    pub role: String,
+    pub token_version: i64,
+}
+
+/// Narrowing extractor for `super_admin`-only endpoints. Unused until BE-5
+/// flips `/api/admin/groups/*` and `/api/admin/whatsapp-links/*` to it.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SuperAdminUser(pub AuthenticatedUser);
+
+impl<S> FromRequestParts<S> for AuthenticatedUser
+where
+    S: Send + Sync,
+    DbConn: FromRef<S>,
+    SharedVerifier: FromRef<S>,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let token = extract_bearer(parts)?;
+        let verifier = SharedVerifier::from_ref(state);
+        let claims = verifier.verify_access(&token).map_err(|e| {
+            warn!(error = %e, "JWT verification failed");
+            AppError::Unauthorized
+        })?;
+
+        let db = DbConn::from_ref(state);
+        let user = load_user(&db, &claims.sub).await.map_err(|e| {
+            warn!(error = %e, user = %claims.sub, "user lookup during auth failed");
+            AppError::Internal(e.to_string())
+        })?;
+
+        let user = user.ok_or_else(|| {
+            warn!(user = %claims.sub, "authenticated token for missing user");
+            AppError::Unauthorized
+        })?;
+
+        // token_version mismatch = the user's JWTs were invalidated server-side
+        // (password change, role change, admin-initiated kill). Fail closed.
+        if user.token_version != claims.token_version {
+            return Err(AppError::Unauthorized);
+        }
+        if user.status != "active" {
+            return Err(AppError::Unauthorized);
+        }
+        if user.deleted_at.is_some() {
+            return Err(AppError::Unauthorized);
+        }
+
+        Ok(Self {
+            user_id: claims.sub,
+            role: user.role,
+            token_version: user.token_version,
+        })
+    }
+}
+
+impl<S> FromRequestParts<S> for SuperAdminUser
+where
+    S: Send + Sync,
+    DbConn: FromRef<S>,
+    SharedVerifier: FromRef<S>,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let inner = AuthenticatedUser::from_request_parts(parts, state).await?;
+        if inner.role != "super_admin" {
+            return Err(AppError::Forbidden("super_admin role required".into()));
+        }
+        Ok(Self(inner))
+    }
+}
+
+/// Handler-called guard. `super_admin` bypasses; `admin` passes iff a
+/// `group_admin(user_id, group_id)` row exists; anything else is forbidden.
+///
+/// Lives as a helper rather than a typed `FromRequestParts` extractor because
+/// the `group_id` is often resolved from a parent record (payment → cycle →
+/// group) inside the handler before the guard can be called.
+#[allow(dead_code)]
+pub async fn require_group_scope(
+    user: &AuthenticatedUser,
+    group_id: &str,
+    db: &DbConn,
+) -> Result<(), AppError> {
+    if user.role == "super_admin" {
+        return Ok(());
+    }
+    if user.role != "admin" {
+        return Err(AppError::Forbidden("admin role required".into()));
+    }
+    if has_group_admin(db, &user.user_id, group_id).await? {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden("no access to this group".into()))
+    }
+}
+
+fn extract_bearer(parts: &Parts) -> Result<String, AppError> {
+    let header = parts
+        .headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or(AppError::Unauthorized)?;
+    let token = header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))
+        .ok_or(AppError::Unauthorized)?
+        .trim();
+    if token.is_empty() {
+        return Err(AppError::Unauthorized);
+    }
+    Ok(token.to_string())
+}
+
+async fn load_user(db: &DbConn, user_id: &str) -> Result<Option<DbUser>, surrealdb::Error> {
+    let mut resp = db
+        .query("SELECT * FROM $id")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .await?
+        .check()?;
+    let rows: Vec<DbUser> = resp.take(0)?;
+    Ok(rows.into_iter().next())
+}
+
+async fn has_group_admin(db: &DbConn, user_id: &str, group_id: &str) -> Result<bool, AppError> {
+    let mut resp = db
+        .query(
+            "SELECT count() FROM group_admin \
+             WHERE user_id = $uid AND group_id = $gid GROUP ALL",
+        )
+        .bind(("uid", user_id.to_string()))
+        .bind(("gid", group_id.to_string()))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .check()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let counts: Vec<i64> = resp
+        .take("count")
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(counts.first().copied().unwrap_or(0) > 0)
+}
+
+/// Concrete router state that carries both the DB handle and the token
+/// verifier. Extractors read it via `FromRef`; handlers that only need the
+/// DB continue to use `State<DbConn>` unchanged.
+#[derive(Clone)]
+pub struct AuthState {
+    pub db: DbConn,
+    pub verifier: SharedVerifier,
+}
+
+impl FromRef<AuthState> for DbConn {
+    fn from_ref(s: &AuthState) -> Self { s.db.clone() }
+}
+
+impl FromRef<AuthState> for SharedVerifier {
+    fn from_ref(s: &AuthState) -> Self { s.verifier.clone() }
+}
+
+// Silence the rust/axum unused-state warning: until BE-5 flips handlers to
+// the extractors, nothing reads `AuthState` directly.
+#[allow(dead_code)]
+pub(crate) fn _touch(_: &dyn TokenVerifier) {}

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -323,3 +323,156 @@ impl KeyEntry {
     #[allow(dead_code)]
     fn kid(&self) -> &str { &self.kid }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, encode};
+
+    fn test_config() -> JwtConfig {
+        JwtConfig {
+            audience: "poolpay-api".into(),
+            issuer: "poolpay-nextauth".into(),
+            access_ttl_secs: 900,
+            leeway_secs: 60,
+        }
+    }
+
+    fn build_verifier() -> StaticKeyVerifier {
+        StaticKeyVerifier::from_ephemeral(test_config()).expect("ephemeral verifier")
+    }
+
+    fn mint_with_claims(verifier: &StaticKeyVerifier, claims: &AccessClaims) -> String {
+        let kid = verifier.active_kid.as_ref().expect("active kid");
+        let entry = verifier.keys.get(kid).expect("entry");
+        let encoding = entry.encoding.as_ref().expect("encoding");
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.clone());
+        encode(&header, claims, encoding).expect("encode")
+    }
+
+    fn base_claims() -> AccessClaims {
+        let now = chrono::Utc::now().timestamp();
+        AccessClaims {
+            sub: "user:1".into(),
+            role: "super_admin".into(),
+            token_version: 1,
+            aud: "poolpay-api".into(),
+            iss: "poolpay-nextauth".into(),
+            exp: now + 300,
+            iat: now,
+            nbf: now,
+        }
+    }
+
+    #[test]
+    fn valid_token_round_trips() {
+        let v = build_verifier();
+        let token = v.mint_access("user:1", "super_admin", 7).expect("mint");
+        let claims = v.verify_access(&token).expect("verify");
+        assert_eq!(claims.sub, "user:1");
+        assert_eq!(claims.role, "super_admin");
+        assert_eq!(claims.token_version, 7);
+    }
+
+    #[test]
+    fn expired_token_rejected() {
+        let v = build_verifier();
+        let mut c = base_claims();
+        // Past-exp + outside the 60s leeway window.
+        c.exp = chrono::Utc::now().timestamp() - 120;
+        c.iat = c.exp - 900;
+        c.nbf = c.iat;
+        let token = mint_with_claims(&v, &c);
+        assert!(matches!(v.verify_access(&token), Err(JwtError::Invalid)));
+    }
+
+    #[test]
+    fn wrong_audience_rejected() {
+        let v = build_verifier();
+        let mut c = base_claims();
+        c.aud = "somebody-else".into();
+        let token = mint_with_claims(&v, &c);
+        assert!(matches!(v.verify_access(&token), Err(JwtError::Invalid)));
+    }
+
+    #[test]
+    fn wrong_issuer_rejected() {
+        let v = build_verifier();
+        let mut c = base_claims();
+        c.iss = "attacker-issuer".into();
+        let token = mint_with_claims(&v, &c);
+        assert!(matches!(v.verify_access(&token), Err(JwtError::Invalid)));
+    }
+
+    #[test]
+    fn unknown_kid_rejected() {
+        let v = build_verifier();
+        let c = base_claims();
+        // Sign with the verifier's active key but advertise a kid the map
+        // does not contain.
+        let kid = v.active_kid.as_ref().expect("active kid").clone();
+        let entry = v.keys.get(&kid).expect("entry");
+        let encoding = entry.encoding.as_ref().expect("encoding");
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("not-a-real-kid".into());
+        let token = encode(&header, &c, encoding).expect("encode");
+        assert!(matches!(v.verify_access(&token), Err(JwtError::UnknownKid)));
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let v = build_verifier();
+        let token = v.mint_access("user:1", "admin", 1).expect("mint");
+        // Flip the last signature character — keeps a structurally valid JWT
+        // but invalidates the RS256 signature.
+        let mut bytes: Vec<char> = token.chars().collect();
+        let last = bytes.last_mut().expect("has chars");
+        *last = if *last == 'A' { 'B' } else { 'A' };
+        let tampered: String = bytes.into_iter().collect();
+        assert!(matches!(v.verify_access(&tampered), Err(JwtError::Invalid)));
+    }
+
+    #[test]
+    fn from_json_rejects_multiple_active_keys() {
+        let (priv_pem, pub_pem) = pem_pair();
+        let raw = format!(
+            r#"[
+                {{ "kid": "a", "private_pem": {priv_pem:?}, "public_pem": {pub_pem:?}, "active": true }},
+                {{ "kid": "b", "private_pem": {priv_pem:?}, "public_pem": {pub_pem:?}, "active": true }}
+            ]"#
+        );
+        let err = match StaticKeyVerifier::from_json(&raw, test_config()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error for multi-active keys"),
+        };
+        assert!(err.contains("more than one active"), "got: {err}");
+    }
+
+    #[test]
+    fn from_json_rejects_zero_active_keys() {
+        let (priv_pem, pub_pem) = pem_pair();
+        let raw = format!(
+            r#"[{{ "kid": "a", "private_pem": {priv_pem:?}, "public_pem": {pub_pem:?}, "active": false }}]"#
+        );
+        let err = match StaticKeyVerifier::from_json(&raw, test_config()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error for zero-active keys"),
+        };
+        assert!(err.contains("no active key"), "got: {err}");
+    }
+
+    /// Mint a matching (private, public) PEM pair for JSON-parser tests.
+    /// Generated fresh per test so no state leaks across them.
+    fn pem_pair() -> (String, String) {
+        let mut rng = rand::thread_rng();
+        let private = RsaPrivateKey::new(&mut rng, 2048).expect("gen");
+        let public = RsaPublicKey::from(&private);
+        let priv_pem = private
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("priv encode")
+            .to_string();
+        let pub_pem = public.to_public_key_pem(LineEnding::LF).expect("pub encode");
+        (priv_pem, pub_pem)
+    }
+}

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -152,29 +152,41 @@ impl JwtConfig {
 }
 
 impl StaticKeyVerifier {
-    /// Build from `JWT_KEYS` (JSON array) + `JwtConfig`. In production the
-    /// caller must supply a populated `JWT_KEYS`; outside production we mint
-    /// an ephemeral keypair if the env is missing so local dev and tests do
-    /// not need an extra setup step.
+    /// Build from `JWT_KEYS` (JSON array) + `JwtConfig`. In `development` and
+    /// `test`, we mint an ephemeral keypair when `JWT_KEYS` is missing so
+    /// local runs and tests do not need an extra setup step. In `production`,
+    /// and when `APP_ENV` is missing or unrecognized, the caller must supply
+    /// a populated `JWT_KEYS` — fail-closed on misconfigured environments so
+    /// a staging/preview box cannot silently run with ephemeral keys.
     pub fn from_env(config: JwtConfig) -> Result<Self, String> {
-        let is_prod = std::env::var("APP_ENV").as_deref() == Ok("production");
+        let app_env = std::env::var("APP_ENV");
 
         match std::env::var("JWT_KEYS") {
             Ok(raw) if !raw.trim().is_empty() => Self::from_json(&raw, config),
-            _ => {
-                if is_prod {
-                    return Err(
-                        "JWT_KEYS must be set in production (JSON array with at least one \
-                         active RS256 keypair)"
-                            .to_string(),
+            _ => match app_env.as_deref() {
+                Ok("development") | Ok("test") => {
+                    warn!(
+                        "JWT_KEYS is not set — generating an ephemeral RSA-2048 keypair for \
+                         this process. Set JWT_KEYS in any real environment."
                     );
+                    Self::from_ephemeral(config)
                 }
-                warn!(
-                    "JWT_KEYS is not set — generating an ephemeral RSA-2048 keypair for this \
-                     process. Set JWT_KEYS in any real environment."
-                );
-                Self::from_ephemeral(config)
-            }
+                Ok("production") => Err(
+                    "JWT_KEYS must be set in production (JSON array with at least one active \
+                     RS256 keypair)"
+                        .to_string(),
+                ),
+                Err(_) => Err(
+                    "APP_ENV must be set to `development`, `test`, or `production`; refusing \
+                     to generate ephemeral JWT keys when APP_ENV is missing. Set JWT_KEYS for \
+                     non-local environments."
+                        .to_string(),
+                ),
+                Ok(other) => Err(format!(
+                    "JWT_KEYS must be set when APP_ENV={other}; ephemeral JWT keys are only \
+                     allowed in `development` or `test`"
+                )),
+            },
         }
     }
 
@@ -328,6 +340,16 @@ impl TokenVerifier for StaticKeyVerifier {
 
         let data = decode::<AccessClaims>(token, &entry.decoding, &validation)
             .map_err(|_| JwtError::Invalid)?;
+
+        // `jsonwebtoken` does not validate `iat` itself; it only applies
+        // `leeway` to exp/nbf. Reject tokens whose `iat` is further in the
+        // future than the configured leeway — a small belt to catch clock
+        // skew abuse and tokens minted with a bogus forward-dated iat.
+        let now = chrono::Utc::now().timestamp();
+        if data.claims.iat > now.saturating_add(self.leeway_secs as i64) {
+            return Err(JwtError::Invalid);
+        }
+
         Ok(data.claims)
     }
 }
@@ -458,6 +480,19 @@ mod tests {
         *last = if *last == 'A' { 'B' } else { 'A' };
         let tampered: String = bytes.into_iter().collect();
         assert!(matches!(v.verify_access(&tampered), Err(JwtError::Invalid)));
+    }
+
+    #[test]
+    fn future_iat_outside_leeway_rejected() {
+        let v = build_verifier();
+        let mut c = base_claims();
+        // `iat` 10 minutes in the future — well beyond the 60s leeway.
+        let future = chrono::Utc::now().timestamp() + 600;
+        c.iat = future;
+        c.nbf = chrono::Utc::now().timestamp();
+        c.exp = future + 900;
+        let token = mint_with_claims(&v, &c);
+        assert!(matches!(v.verify_access(&token), Err(JwtError::Invalid)));
     }
 
     #[test]

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -141,7 +141,8 @@ impl JwtConfig {
                 .unwrap_or_else(|_| "poolpay-nextauth".to_string()),
             access_ttl_secs: std::env::var("JWT_ACCESS_TTL_SECS")
                 .ok()
-                .and_then(|s| s.parse().ok())
+                .and_then(|s| s.parse::<i64>().ok())
+                .filter(|v| *v > 0)
                 .unwrap_or(900),
             leeway_secs: std::env::var("JWT_LEEWAY_SECS")
                 .ok()

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -1,0 +1,325 @@
+//! JWT minting and verification for PoolPay admin access tokens.
+//!
+//! Design notes (Plan 3 / BE-3):
+//!
+//! * **RS256 only.** NextAuth (and Cognito later) holds the private key; this
+//!   service holds only public keys. HS256 would share a secret between FE and
+//!   BE — a footgun we actively avoid.
+//! * **`kid`-indexed key map.** `JWT_KEYS` is a JSON array of
+//!   `{ kid, private_pem, public_pem, active }`. Signing picks the single
+//!   `active:true` entry; verification accepts any kid in the map. Rotation =
+//!   add a new active key, flip the previous to `active:false`, remove after a
+//!   grace window — zero code change.
+//! * **Production fail-closed.** In production (`APP_ENV=production`) boot
+//!   panics if `JWT_KEYS` is unset or resolves to zero active keys. Outside
+//!   production, we generate an ephemeral RSA-2048 keypair so `cargo run` and
+//!   the test suite stay frictionless. The generated key is process-local and
+//!   logged as a warning so accidental prod use is visible.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, decode_header, encode,
+};
+use rand::RngCore;
+use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Access token claims. Shape is stable across providers so the verifier is
+/// identical for NextAuth today and Cognito later.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccessClaims {
+    pub sub: String,
+    pub role: String,
+    pub token_version: i64,
+    pub aud: String,
+    pub iss: String,
+    pub exp: i64,
+    pub iat: i64,
+    pub nbf: i64,
+}
+
+/// Errors surfaced by the verifier. Callers translate these to
+/// `AppError::Unauthorized` — the distinction is kept for logging only, never
+/// leaked to HTTP responses.
+#[derive(Debug)]
+pub enum JwtError {
+    Malformed,
+    MissingKid,
+    UnknownKid,
+    Invalid,
+    NoActiveKey,
+}
+
+impl std::fmt::Display for JwtError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Malformed => "malformed token",
+            Self::MissingKid => "missing kid",
+            Self::UnknownKid => "unknown kid",
+            Self::Invalid => "signature or claim verification failed",
+            Self::NoActiveKey => "no active signing key configured",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for JwtError {}
+
+/// The `TokenVerifier` abstraction lets BE-8 swap in a `JwksVerifier` for
+/// Cognito without touching handlers or extractors.
+pub trait TokenVerifier: Send + Sync {
+    fn verify_access(&self, token: &str) -> Result<AccessClaims, JwtError>;
+}
+
+/// A single RS256 keypair identified by `kid`. Private key is optional: a
+/// pure-verifier deployment (BE-8, Cognito) would have public-only entries.
+struct KeyEntry {
+    kid: String,
+    encoding: Option<EncodingKey>,
+    decoding: DecodingKey,
+    active: bool,
+}
+
+/// Static, in-process key store. Loaded once at boot and shared via `Arc`.
+pub struct StaticKeyVerifier {
+    keys: HashMap<String, KeyEntry>,
+    active_kid: Option<String>,
+    audience: String,
+    issuer: String,
+    access_ttl_secs: i64,
+    leeway_secs: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwtKeysEntryEnv {
+    kid: String,
+    private_pem: Option<String>,
+    public_pem: String,
+    #[serde(default)]
+    active: bool,
+}
+
+/// Runtime configuration for token minting and verification. Values come from
+/// env vars with the defaults below; exposed as a struct so tests can build
+/// one directly.
+#[derive(Debug, Clone)]
+pub struct JwtConfig {
+    pub audience: String,
+    pub issuer: String,
+    pub access_ttl_secs: i64,
+    pub leeway_secs: u64,
+}
+
+impl JwtConfig {
+    pub fn from_env() -> Self {
+        Self {
+            audience: std::env::var("JWT_AUDIENCE")
+                .unwrap_or_else(|_| "poolpay-api".to_string()),
+            issuer: std::env::var("JWT_ISSUER")
+                .unwrap_or_else(|_| "poolpay-nextauth".to_string()),
+            access_ttl_secs: std::env::var("JWT_ACCESS_TTL_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(900),
+            leeway_secs: std::env::var("JWT_LEEWAY_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(60),
+        }
+    }
+}
+
+impl StaticKeyVerifier {
+    /// Build from `JWT_KEYS` (JSON array) + `JwtConfig`. In production the
+    /// caller must supply a populated `JWT_KEYS`; outside production we mint
+    /// an ephemeral keypair if the env is missing so local dev and tests do
+    /// not need an extra setup step.
+    pub fn from_env(config: JwtConfig) -> Result<Self, String> {
+        let is_prod = std::env::var("APP_ENV").as_deref() == Ok("production");
+
+        match std::env::var("JWT_KEYS") {
+            Ok(raw) if !raw.trim().is_empty() => Self::from_json(&raw, config),
+            _ => {
+                if is_prod {
+                    return Err(
+                        "JWT_KEYS must be set in production (JSON array with at least one \
+                         active RS256 keypair)"
+                            .to_string(),
+                    );
+                }
+                warn!(
+                    "JWT_KEYS is not set — generating an ephemeral RSA-2048 keypair for this \
+                     process. Set JWT_KEYS in any real environment."
+                );
+                Self::from_ephemeral(config)
+            }
+        }
+    }
+
+    /// Parse a `JWT_KEYS` JSON string. Separate from `from_env()` so tests can
+    /// drive the parser directly without mutating process env.
+    pub fn from_json(raw: &str, config: JwtConfig) -> Result<Self, String> {
+        let entries: Vec<JwtKeysEntryEnv> =
+            serde_json::from_str(raw).map_err(|e| format!("JWT_KEYS is not valid JSON: {e}"))?;
+        if entries.is_empty() {
+            return Err("JWT_KEYS must contain at least one entry".to_string());
+        }
+
+        let mut keys: HashMap<String, KeyEntry> = HashMap::with_capacity(entries.len());
+        let mut active_kid: Option<String> = None;
+
+        for entry in entries {
+            let decoding = DecodingKey::from_rsa_pem(entry.public_pem.as_bytes())
+                .map_err(|e| format!("kid={} has invalid public_pem: {e}", entry.kid))?;
+            let encoding = match entry.private_pem.as_deref() {
+                Some(pem) if !pem.is_empty() => Some(
+                    EncodingKey::from_rsa_pem(pem.as_bytes())
+                        .map_err(|e| format!("kid={} has invalid private_pem: {e}", entry.kid))?,
+                ),
+                _ => None,
+            };
+            if entry.active {
+                if encoding.is_none() {
+                    return Err(format!(
+                        "kid={} is marked active but has no private_pem — cannot sign",
+                        entry.kid
+                    ));
+                }
+                if active_kid.is_some() {
+                    return Err(
+                        "JWT_KEYS contains more than one active key; mark exactly one as active"
+                            .to_string(),
+                    );
+                }
+                active_kid = Some(entry.kid.clone());
+            }
+            keys.insert(
+                entry.kid.clone(),
+                KeyEntry { kid: entry.kid, encoding, decoding, active: entry.active },
+            );
+        }
+
+        if active_kid.is_none() {
+            return Err("JWT_KEYS has no active key".to_string());
+        }
+
+        Ok(Self {
+            keys,
+            active_kid,
+            audience: config.audience,
+            issuer: config.issuer,
+            access_ttl_secs: config.access_ttl_secs,
+            leeway_secs: config.leeway_secs,
+        })
+    }
+
+    /// Generate a fresh RSA-2048 keypair for the current process. Only called
+    /// outside production and only when `JWT_KEYS` is unset.
+    fn from_ephemeral(config: JwtConfig) -> Result<Self, String> {
+        let mut rng = rand::thread_rng();
+        let private = RsaPrivateKey::new(&mut rng, 2048)
+            .map_err(|e| format!("failed to generate ephemeral RSA key: {e}"))?;
+        let public = RsaPublicKey::from(&private);
+        let private_pem = private
+            .to_pkcs8_pem(LineEnding::LF)
+            .map_err(|e| format!("encode pkcs8 pem: {e}"))?
+            .to_string();
+        let public_pem = public
+            .to_public_key_pem(LineEnding::LF)
+            .map_err(|e| format!("encode public pem: {e}"))?;
+
+        let kid = ephemeral_kid();
+        let decoding = DecodingKey::from_rsa_pem(public_pem.as_bytes())
+            .map_err(|e| format!("decode ephemeral public key: {e}"))?;
+        let encoding = EncodingKey::from_rsa_pem(private_pem.as_bytes())
+            .map_err(|e| format!("decode ephemeral private key: {e}"))?;
+
+        let mut keys = HashMap::new();
+        keys.insert(
+            kid.clone(),
+            KeyEntry { kid: kid.clone(), encoding: Some(encoding), decoding, active: true },
+        );
+        Ok(Self {
+            keys,
+            active_kid: Some(kid),
+            audience: config.audience,
+            issuer: config.issuer,
+            access_ttl_secs: config.access_ttl_secs,
+            leeway_secs: config.leeway_secs,
+        })
+    }
+
+    /// Mint an access token. Kept public so BE-4 can wire it into the compat
+    /// shim and integration tests can mint valid tokens. Lives behind
+    /// `#[allow(dead_code)]` until a handler actually calls it.
+    #[allow(dead_code)]
+    pub fn mint_access(&self, subject: &str, role: &str, token_version: i64) -> Result<String, JwtError> {
+        let kid = self.active_kid.as_deref().ok_or(JwtError::NoActiveKey)?;
+        let entry = self.keys.get(kid).ok_or(JwtError::NoActiveKey)?;
+        let encoding = entry.encoding.as_ref().ok_or(JwtError::NoActiveKey)?;
+
+        let now = chrono::Utc::now().timestamp();
+        let claims = AccessClaims {
+            sub: subject.to_string(),
+            role: role.to_string(),
+            token_version,
+            aud: self.audience.clone(),
+            iss: self.issuer.clone(),
+            exp: now + self.access_ttl_secs,
+            iat: now,
+            nbf: now,
+        };
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+
+        encode(&header, &claims, encoding).map_err(|_| JwtError::Invalid)
+    }
+}
+
+impl TokenVerifier for StaticKeyVerifier {
+    fn verify_access(&self, token: &str) -> Result<AccessClaims, JwtError> {
+        let header = decode_header(token).map_err(|_| JwtError::Malformed)?;
+        let kid = header.kid.ok_or(JwtError::MissingKid)?;
+        let entry = self.keys.get(&kid).ok_or(JwtError::UnknownKid)?;
+
+        // Pinning the algorithm to RS256 rejects the classic "alg: none" and
+        // "alg: HS256 with public key as secret" attacks against mixed
+        // verifiers.
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[&self.audience]);
+        validation.set_issuer(&[&self.issuer]);
+        validation.leeway = self.leeway_secs;
+        validation.validate_exp = true;
+        validation.validate_nbf = true;
+
+        let data = decode::<AccessClaims>(token, &entry.decoding, &validation)
+            .map_err(|_| JwtError::Invalid)?;
+        Ok(data.claims)
+    }
+}
+
+/// Type-erased handle used by extractors and the router state.
+pub type SharedVerifier = Arc<dyn TokenVerifier>;
+
+/// 16-byte random id, base64url-encoded, used for ephemeral dev keys.
+fn ephemeral_kid() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("ephemeral-{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
+// Suppress unused warnings on fields that become load-bearing in later
+// commits (active/kid are exercised by tests and the rotation path).
+impl KeyEntry {
+    #[allow(dead_code)]
+    fn is_active(&self) -> bool { self.active }
+    #[allow(dead_code)]
+    fn kid(&self) -> &str { &self.kid }
+}

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -227,6 +227,12 @@ impl StaticKeyVerifier {
                 }
                 active_kid = Some(entry.kid.clone());
             }
+            if keys.contains_key(&entry.kid) {
+                return Err(format!(
+                    "JWT_KEYS contains duplicate kid={}; each entry must have a unique kid",
+                    entry.kid
+                ));
+            }
             keys.insert(
                 entry.kid.clone(),
                 KeyEntry { kid: entry.kid, encoding, decoding, active: entry.active },
@@ -509,6 +515,22 @@ mod tests {
             Ok(_) => panic!("expected error for multi-active keys"),
         };
         assert!(err.contains("more than one active"), "got: {err}");
+    }
+
+    #[test]
+    fn from_json_rejects_duplicate_kids() {
+        let (priv_pem, pub_pem) = pem_pair();
+        let raw = format!(
+            r#"[
+                {{ "kid": "dup", "private_pem": {priv_pem:?}, "public_pem": {pub_pem:?}, "active": true }},
+                {{ "kid": "dup", "private_pem": {priv_pem:?}, "public_pem": {pub_pem:?}, "active": false }}
+            ]"#
+        );
+        let err = match StaticKeyVerifier::from_json(&raw, test_config()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected error for duplicate kids"),
+        };
+        assert!(err.contains("duplicate kid"), "got: {err}");
     }
 
     #[test]

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -73,8 +73,24 @@ impl std::error::Error for JwtError {}
 
 /// The `TokenVerifier` abstraction lets BE-8 swap in a `JwksVerifier` for
 /// Cognito without touching handlers or extractors.
+///
+/// `mint_access` is on the same trait because every deployment needs the
+/// local minting path for `/api/auth/refresh`: even when the upstream IdP
+/// issues the original access token, the refresh rotation re-issues a new
+/// short-lived access token from within this service. A pure-verifier
+/// implementation (e.g. `JwksVerifier`) can override the default to return
+/// `NoActiveKey` if minting is genuinely unsupported.
 pub trait TokenVerifier: Send + Sync {
     fn verify_access(&self, token: &str) -> Result<AccessClaims, JwtError>;
+
+    fn mint_access(
+        &self,
+        _subject: &str,
+        _role: &str,
+        _token_version: i64,
+    ) -> Result<String, JwtError> {
+        Err(JwtError::NoActiveKey)
+    }
 }
 
 /// A single RS256 keypair identified by `kid`. Private key is optional: a
@@ -255,11 +271,12 @@ impl StaticKeyVerifier {
         })
     }
 
-    /// Mint an access token. Kept public so BE-4 can wire it into the compat
-    /// shim and integration tests can mint valid tokens. Lives behind
-    /// `#[allow(dead_code)]` until a handler actually calls it.
-    #[allow(dead_code)]
-    pub fn mint_access(&self, subject: &str, role: &str, token_version: i64) -> Result<String, JwtError> {
+    fn mint_access_inner(
+        &self,
+        subject: &str,
+        role: &str,
+        token_version: i64,
+    ) -> Result<String, JwtError> {
         let kid = self.active_kid.as_deref().ok_or(JwtError::NoActiveKey)?;
         let entry = self.keys.get(kid).ok_or(JwtError::NoActiveKey)?;
         let encoding = entry.encoding.as_ref().ok_or(JwtError::NoActiveKey)?;
@@ -281,9 +298,19 @@ impl StaticKeyVerifier {
 
         encode(&header, &claims, encoding).map_err(|_| JwtError::Invalid)
     }
+
 }
 
 impl TokenVerifier for StaticKeyVerifier {
+    fn mint_access(
+        &self,
+        subject: &str,
+        role: &str,
+        token_version: i64,
+    ) -> Result<String, JwtError> {
+        self.mint_access_inner(subject, role, token_version)
+    }
+
     fn verify_access(&self, token: &str) -> Result<AccessClaims, JwtError> {
         let header = decode_header(token).map_err(|_| JwtError::Malformed)?;
         let kid = header.kid.ok_or(JwtError::MissingKid)?;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -4,6 +4,7 @@
 //! JWT, refresh tokens, and request extractors land in subsequent increments.
 
 pub mod bootstrap;
+pub mod extractors;
 pub mod hmac;
 pub mod jwt;
 pub mod password;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,5 +5,6 @@
 
 pub mod bootstrap;
 pub mod hmac;
+pub mod jwt;
 pub mod password;
 pub mod rate_limit;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -8,3 +8,4 @@ pub mod hmac;
 pub mod jwt;
 pub mod password;
 pub mod rate_limit;
+pub mod refresh;

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -11,7 +11,7 @@
 //!   the entire `family_id` is revoked, the user's `token_version` is
 //!   bumped (invalidating any in-flight access tokens within the 15-min
 //!   access TTL), and an `auth_event{refresh_reuse_detected}` is written.
-//!   This is RFC 6749 BCP section 4.12.
+//!   This follows OAuth 2.0 Security BCP (RFC 9700) section 4.12.
 //! * Logout revokes every row in the family in one shot.
 
 use base64::Engine as _;

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -102,8 +102,11 @@ pub async fn rotate(
     let hashed = hash_token(presented);
     let row = load_by_hash(db, &hashed).await?.ok_or(RefreshError::NotFound)?;
 
+    // Cheap pre-checks. These are not the authoritative guard — the atomic
+    // revoke below is — but they short-circuit the obvious cases without
+    // writing a new row first.
     if row.revoked_at.is_some() {
-        handle_reuse(db, &row).await?;
+        handle_reuse(db, &row).await;
         return Err(RefreshError::ReuseDetected);
     }
     if is_expired(&row.expires_at) {
@@ -131,8 +134,25 @@ pub async fn rotate(
         None => return Err(RefreshError::Internal("new refresh_token row not returned".into())),
     };
 
-    let old_id = record_id_to_string(row.id);
-    mark_revoked(db, &old_id, &now, Some(&new_id)).await?;
+    // Atomic guard: only one concurrent rotate per row can win the
+    // `WHERE revoked_at IS NONE` clause. The loser gets zero affected rows
+    // back, which is exactly the reuse/theft signal. This closes the
+    // TOCTOU window between the pre-check above and the revoke: two
+    // callers presenting the same refresh token in parallel cannot both
+    // walk away with live tokens in the same family.
+    let old_id = record_id_to_string(row.id.clone());
+    let revoked = try_revoke_unrevoked(db, &old_id, &now, &new_id).await?;
+    if !revoked {
+        // Someone else already rotated this row. Roll back our freshly
+        // minted row so the family doesn't accumulate orphans, then run
+        // the full reuse response (kill family, bump token_version, audit).
+        let _: Option<DbRefreshToken> = db
+            .delete(("refresh_token", new_id.as_str()))
+            .await
+            .unwrap_or(None);
+        handle_reuse(db, &row).await;
+        return Err(RefreshError::ReuseDetected);
+    }
 
     Ok((
         IssuedRefreshToken { plaintext: new_plain, family_id: row.family_id, expires_at },
@@ -164,10 +184,18 @@ pub async fn revoke_by_presented(
     Ok(row.user_id)
 }
 
-async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) -> Result<(), RefreshError> {
-    revoke_family(db, &stolen.family_id).await?;
-    bump_token_version(db, &stolen.user_id).await?;
-    // Failures here must not mask the 401 — log and swallow.
+/// Run every side-effect of reuse detection — family kill, token_version
+/// bump, audit row — and swallow all errors. The caller must always be
+/// able to return a uniform 401: surfacing a 500 from here would turn a
+/// detected-theft signal into a different response code, which is itself
+/// an oracle. Any DB failure is logged for ops but never propagated.
+async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) {
+    if let Err(e) = revoke_family(db, &stolen.family_id).await {
+        warn!(error = %e, family_id = %stolen.family_id, "reuse: revoke_family failed");
+    }
+    if let Err(e) = bump_token_version(db, &stolen.user_id).await {
+        warn!(error = %e, user = %stolen.user_id, "reuse: bump_token_version failed");
+    }
     let event = AuthEventContent {
         user_id: Some(stolen.user_id.clone()),
         event_type: "refresh_reuse_detected".into(),
@@ -180,7 +208,6 @@ async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) -> Result<(), Refres
     if let Err(e) = db.create::<Option<DbAuthEvent>>("auth_event").content(event).await {
         warn!(error = %e, "Failed to record refresh_reuse_detected auth_event");
     }
-    Ok(())
 }
 
 async fn bump_token_version(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
@@ -205,19 +232,28 @@ async fn load_by_hash(
     Ok(rows.into_iter().next())
 }
 
-async fn mark_revoked(
+/// Atomically revoke a refresh-token row iff it is still live. Returns
+/// `true` if this call did the revoke, `false` if the row was already
+/// revoked (i.e. a concurrent rotate or a replay won the race). Callers
+/// treat `false` as reuse detection.
+async fn try_revoke_unrevoked(
     db: &DbConn,
     id: &str,
     at: &str,
-    replaced_by: Option<&str>,
-) -> Result<(), RefreshError> {
-    db.query("UPDATE $id SET revoked_at = $at, replaced_by = $rb")
+    replaced_by: &str,
+) -> Result<bool, RefreshError> {
+    let mut resp = db
+        .query(
+            "UPDATE $id SET revoked_at = $at, replaced_by = $rb \
+             WHERE revoked_at IS NONE RETURN AFTER",
+        )
         .bind(("id", RecordId::new("refresh_token", id.to_string())))
         .bind(("at", at.to_string()))
-        .bind(("rb", replaced_by.map(|s| s.to_string())))
+        .bind(("rb", replaced_by.to_string()))
         .await?
         .check()?;
-    Ok(())
+    let updated: Vec<DbRefreshToken> = resp.take(0)?;
+    Ok(!updated.is_empty())
 }
 
 fn is_expired(expires_at: &str) -> bool {

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -1,0 +1,273 @@
+//! Refresh-token storage with rotation-on-use and family revocation.
+//!
+//! Security model (Plan 3 / BE-3):
+//!
+//! * Tokens are 32 random bytes, base64url-encoded, handed to the client
+//!   exactly once. Only `sha256(token)` hex is persisted, so a DB leak
+//!   cannot be replayed as-is.
+//! * Every use rotates the token: the old row is marked `revoked_at` +
+//!   `replaced_by`, a new row lands in the same `family_id`.
+//! * Presenting an already-revoked token is treated as evidence of theft —
+//!   the entire `family_id` is revoked, the user's `token_version` is
+//!   bumped (invalidating any in-flight access tokens within the 15-min
+//!   access TTL), and an `auth_event{refresh_reuse_detected}` is written.
+//!   This is RFC 6749 BCP section 4.12.
+//! * Logout revokes every row in the family in one shot.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use surrealdb::types::RecordId;
+use tracing::warn;
+
+use crate::api::models::{
+    AuthEventContent, DbAuthEvent, DbRefreshToken, DbUser, RefreshTokenContent, now_iso,
+    record_id_to_string,
+};
+use crate::db::DbConn;
+
+/// 14 days — matches the default refresh TTL in `JwtConfig`.
+const DEFAULT_REFRESH_TTL_SECS: i64 = 14 * 24 * 60 * 60;
+
+/// Plaintext refresh token material handed to the client. Never persisted.
+pub struct IssuedRefreshToken {
+    pub plaintext: String,
+    pub family_id: String,
+    pub expires_at: String,
+}
+
+/// Error surface for the refresh flow. Handlers translate these to
+/// `AppError::Unauthorized` uniformly — the distinction is for logging.
+#[derive(Debug)]
+pub enum RefreshError {
+    NotFound,
+    Expired,
+    ReuseDetected,
+    Db(surrealdb::Error),
+    Internal(String),
+}
+
+impl std::fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("refresh token not found"),
+            Self::Expired => f.write_str("refresh token expired"),
+            Self::ReuseDetected => f.write_str("refresh token reuse detected"),
+            Self::Db(e) => write!(f, "database error: {e}"),
+            Self::Internal(s) => write!(f, "internal error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for RefreshError {}
+
+impl From<surrealdb::Error> for RefreshError {
+    fn from(e: surrealdb::Error) -> Self { Self::Db(e) }
+}
+
+/// Issue a brand-new refresh token for `user_id`. Used at login time and by
+/// the ensure-user JIT flow — both land in BE-4.
+#[allow(dead_code)]
+pub async fn issue(db: &DbConn, user_id: &str) -> Result<IssuedRefreshToken, RefreshError> {
+    let plaintext = random_token();
+    let family_id = random_family_id();
+    let now = now_iso();
+    let expires_at = expires_at_from(&now, refresh_ttl_secs());
+
+    let content = RefreshTokenContent {
+        user_id: user_id.to_string(),
+        hashed_token: hash_token(&plaintext),
+        family_id: family_id.clone(),
+        issued_at: now,
+        expires_at: expires_at.clone(),
+        revoked_at: None,
+        replaced_by: None,
+    };
+    let _: Option<DbRefreshToken> = db.create("refresh_token").content(content).await?;
+    Ok(IssuedRefreshToken { plaintext, family_id, expires_at })
+}
+
+/// Rotate a presented refresh token. Happy path: revoke the presented row
+/// and issue a new one in the same family. Theft path: if the row is
+/// already revoked, revoke the entire family, bump the user's
+/// `token_version`, and surface `ReuseDetected`.
+///
+/// Returns the new token plus the `user_id` it belongs to so the caller can
+/// mint a matching access token.
+pub async fn rotate(
+    db: &DbConn,
+    presented: &str,
+) -> Result<(IssuedRefreshToken, String), RefreshError> {
+    let hashed = hash_token(presented);
+    let row = load_by_hash(db, &hashed).await?.ok_or(RefreshError::NotFound)?;
+
+    if row.revoked_at.is_some() {
+        handle_reuse(db, &row).await?;
+        return Err(RefreshError::ReuseDetected);
+    }
+    if is_expired(&row.expires_at) {
+        return Err(RefreshError::Expired);
+    }
+
+    let now = now_iso();
+    let new_plain = random_token();
+    let new_hashed = hash_token(&new_plain);
+    let expires_at = expires_at_from(&now, refresh_ttl_secs());
+
+    let new_content = RefreshTokenContent {
+        user_id: row.user_id.clone(),
+        hashed_token: new_hashed,
+        family_id: row.family_id.clone(),
+        issued_at: now.clone(),
+        expires_at: expires_at.clone(),
+        revoked_at: None,
+        replaced_by: None,
+    };
+    let new_row: Option<DbRefreshToken> =
+        db.create("refresh_token").content(new_content).await?;
+    let new_id = match new_row {
+        Some(r) => record_id_to_string(r.id),
+        None => return Err(RefreshError::Internal("new refresh_token row not returned".into())),
+    };
+
+    let old_id = record_id_to_string(row.id);
+    mark_revoked(db, &old_id, &now, Some(&new_id)).await?;
+
+    Ok((
+        IssuedRefreshToken { plaintext: new_plain, family_id: row.family_id, expires_at },
+        row.user_id,
+    ))
+}
+
+/// Revoke every live row in `family_id`. Callers provide their own audit
+/// event_type (`logout` vs `refresh_reuse_detected`).
+pub async fn revoke_family(db: &DbConn, family_id: &str) -> Result<(), RefreshError> {
+    let now = now_iso();
+    db.query("UPDATE refresh_token SET revoked_at = $now WHERE family_id = $fid AND revoked_at IS NONE")
+        .bind(("now", now))
+        .bind(("fid", family_id.to_string()))
+        .await?
+        .check()?;
+    Ok(())
+}
+
+/// Revoke the family of a presented refresh token. Used by `/api/auth/logout`.
+/// Returns the `user_id` so the caller can audit under the right subject.
+pub async fn revoke_by_presented(
+    db: &DbConn,
+    presented: &str,
+) -> Result<String, RefreshError> {
+    let hashed = hash_token(presented);
+    let row = load_by_hash(db, &hashed).await?.ok_or(RefreshError::NotFound)?;
+    revoke_family(db, &row.family_id).await?;
+    Ok(row.user_id)
+}
+
+async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) -> Result<(), RefreshError> {
+    revoke_family(db, &stolen.family_id).await?;
+    bump_token_version(db, &stolen.user_id).await?;
+    // Failures here must not mask the 401 — log and swallow.
+    let event = AuthEventContent {
+        user_id: Some(stolen.user_id.clone()),
+        event_type: "refresh_reuse_detected".into(),
+        ip: None,
+        user_agent: None,
+        success: false,
+        reason: Some(format!("family_id={}", stolen.family_id)),
+        created_at: now_iso(),
+    };
+    if let Err(e) = db.create::<Option<DbAuthEvent>>("auth_event").content(event).await {
+        warn!(error = %e, "Failed to record refresh_reuse_detected auth_event");
+    }
+    Ok(())
+}
+
+async fn bump_token_version(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
+    db.query("UPDATE $id SET token_version = token_version + 1, updated_at = $now")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .bind(("now", now_iso()))
+        .await?
+        .check()?;
+    Ok(())
+}
+
+async fn load_by_hash(
+    db: &DbConn,
+    hashed: &str,
+) -> Result<Option<DbRefreshToken>, RefreshError> {
+    let mut resp = db
+        .query("SELECT * FROM refresh_token WHERE hashed_token = $h LIMIT 1")
+        .bind(("h", hashed.to_string()))
+        .await?
+        .check()?;
+    let rows: Vec<DbRefreshToken> = resp.take(0)?;
+    Ok(rows.into_iter().next())
+}
+
+async fn mark_revoked(
+    db: &DbConn,
+    id: &str,
+    at: &str,
+    replaced_by: Option<&str>,
+) -> Result<(), RefreshError> {
+    db.query("UPDATE $id SET revoked_at = $at, replaced_by = $rb")
+        .bind(("id", RecordId::new("refresh_token", id.to_string())))
+        .bind(("at", at.to_string()))
+        .bind(("rb", replaced_by.map(|s| s.to_string())))
+        .await?
+        .check()?;
+    Ok(())
+}
+
+fn is_expired(expires_at: &str) -> bool {
+    match chrono::DateTime::parse_from_rfc3339(expires_at) {
+        Ok(ts) => chrono::Utc::now() > ts.with_timezone(&chrono::Utc),
+        Err(_) => true,
+    }
+}
+
+fn refresh_ttl_secs() -> i64 {
+    std::env::var("JWT_REFRESH_TTL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_REFRESH_TTL_SECS)
+}
+
+fn expires_at_from(now_rfc3339: &str, ttl_secs: i64) -> String {
+    let now = chrono::DateTime::parse_from_rfc3339(now_rfc3339)
+        .map(|ts| ts.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| chrono::Utc::now());
+    (now + chrono::Duration::seconds(ttl_secs)).to_rfc3339()
+}
+
+fn hash_token(plain: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(plain.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn random_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn random_family_id() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Load the user a refresh token belongs to. Exposed so the logout handler
+/// can validate the subject before auditing.
+#[allow(dead_code)]
+pub async fn load_user(db: &DbConn, user_id: &str) -> Result<Option<DbUser>, surrealdb::Error> {
+    let mut resp = db
+        .query("SELECT * FROM $id")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .await?
+        .check()?;
+    let rows: Vec<DbUser> = resp.take(0)?;
+    Ok(rows.into_iter().next())
+}

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -27,7 +27,7 @@ use crate::api::models::{
 };
 use crate::db::DbConn;
 
-/// 14 days — matches the default refresh TTL in `JwtConfig`.
+/// 14 days — module default used when `JWT_REFRESH_TTL_SECS` is not set.
 const DEFAULT_REFRESH_TTL_SECS: i64 = 14 * 24 * 60 * 60;
 
 /// Plaintext refresh token material handed to the client. Never persisted.

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -146,10 +146,19 @@ pub async fn rotate(
         // Someone else already rotated this row. Roll back our freshly
         // minted row so the family doesn't accumulate orphans, then run
         // the full reuse response (kill family, bump token_version, audit).
-        let _: Option<DbRefreshToken> = db
-            .delete(("refresh_token", new_id.as_str()))
+        // Best-effort cleanup — surface DB errors in logs so orphan rows
+        // are observable, but do not fail the caller: the authoritative
+        // outcome (reuse detected) is already decided.
+        if let Err(err) = db
+            .delete::<Option<DbRefreshToken>>(("refresh_token", new_id.as_str()))
             .await
-            .unwrap_or(None);
+        {
+            warn!(
+                error = %err,
+                new_id = %new_id,
+                "failed to delete orphan refresh_token row after lost rotation race",
+            );
+        }
         handle_reuse(db, &row).await;
         return Err(RefreshError::ReuseDetected);
     }

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -290,7 +290,8 @@ fn is_expired(expires_at: &str) -> bool {
 fn refresh_ttl_secs() -> i64 {
     std::env::var("JWT_REFRESH_TTL_SECS")
         .ok()
-        .and_then(|s| s.parse().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|v| *v > 0)
         .unwrap_or(DEFAULT_REFRESH_TTL_SECS)
 }
 

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -106,8 +106,15 @@ pub async fn rotate(
     // revoke below is — but they short-circuit the obvious cases without
     // writing a new row first.
     if row.revoked_at.is_some() {
-        handle_reuse(db, &row).await;
-        return Err(RefreshError::ReuseDetected);
+        // A revoked row with `replaced_by` set means a rotation already
+        // consumed this token — presenting it again is the theft signal.
+        // A revoked row with `replaced_by` still None is a family revocation
+        // (e.g. /logout), which is expected post-logout use, not reuse.
+        if row.replaced_by.is_some() {
+            handle_reuse(db, &row).await;
+            return Err(RefreshError::ReuseDetected);
+        }
+        return Err(RefreshError::NotFound);
     }
     if is_expired(&row.expires_at) {
         return Err(RefreshError::Expired);

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -84,7 +84,15 @@ pub async fn issue(db: &DbConn, user_id: &str) -> Result<IssuedRefreshToken, Ref
         revoked_at: None,
         replaced_by: None,
     };
-    let _: Option<DbRefreshToken> = db.create("refresh_token").content(content).await?;
+    let created: Option<DbRefreshToken> = db.create("refresh_token").content(content).await?;
+    // Treat a missing row the same way `create_social_user` does — handing a
+    // plaintext token to the client that has no matching DB row would leave
+    // the session un-rotatable and un-revocable.
+    if created.is_none() {
+        return Err(RefreshError::Internal(
+            "refresh token create returned no record".to_string(),
+        ));
+    }
     Ok(IssuedRefreshToken { plaintext, family_id, expires_at })
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -94,7 +94,29 @@ async fn define_auth_tables(db: &Surreal<Db>) -> Result<(), surrealdb::Error> {
          DEFINE FIELD IF NOT EXISTS user_agent ON auth_event TYPE option<string>;
          DEFINE FIELD IF NOT EXISTS success ON auth_event TYPE bool;
          DEFINE FIELD IF NOT EXISTS reason ON auth_event TYPE option<string>;
-         DEFINE FIELD IF NOT EXISTS created_at ON auth_event TYPE string;",
+         DEFINE FIELD IF NOT EXISTS created_at ON auth_event TYPE string;
+
+         DEFINE TABLE IF NOT EXISTS refresh_token SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS user_id ON refresh_token TYPE string;
+         DEFINE FIELD IF NOT EXISTS hashed_token ON refresh_token TYPE string;
+         DEFINE FIELD IF NOT EXISTS family_id ON refresh_token TYPE string;
+         DEFINE FIELD IF NOT EXISTS issued_at ON refresh_token TYPE string;
+         DEFINE FIELD IF NOT EXISTS expires_at ON refresh_token TYPE string;
+         DEFINE FIELD IF NOT EXISTS revoked_at ON refresh_token TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS replaced_by ON refresh_token TYPE option<string>;
+         DEFINE INDEX IF NOT EXISTS refresh_token_hashed
+             ON refresh_token FIELDS hashed_token UNIQUE;
+         DEFINE INDEX IF NOT EXISTS refresh_token_family ON refresh_token FIELDS family_id;
+         DEFINE INDEX IF NOT EXISTS refresh_token_user ON refresh_token FIELDS user_id;
+
+         DEFINE TABLE IF NOT EXISTS group_admin SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS user_id ON group_admin TYPE string;
+         DEFINE FIELD IF NOT EXISTS group_id ON group_admin TYPE string;
+         DEFINE FIELD IF NOT EXISTS created_at ON group_admin TYPE string;
+         DEFINE FIELD IF NOT EXISTS created_by ON group_admin TYPE string;
+         DEFINE INDEX IF NOT EXISTS group_admin_user_group
+             ON group_admin FIELDS user_id, group_id UNIQUE;
+         DEFINE INDEX IF NOT EXISTS group_admin_group ON group_admin FIELDS group_id;",
     )
     .await?
     .check()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
     // so `cargo run` needs no extra setup.
     let verifier: SharedVerifier = Arc::new(
         StaticKeyVerifier::from_env(JwtConfig::from_env())
-            .expect("Failed to initialise JWT verifier"),
+            .unwrap_or_else(|err| panic!("Failed to initialise JWT verifier: {err}")),
     );
 
     // Parse rate-limit config once at boot and reuse the same instance for

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+use poolpay::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use poolpay::auth::rate_limit::RateLimitConfig;
 use poolpay::{api, auth, db, extractor, ingestion, parser, replies, whatsapp};
 use poolpay::api::models::now_iso;
+use std::sync::Arc;
 
 use dotenv::dotenv;
 use std::{env, net::SocketAddr};
@@ -59,6 +61,14 @@ async fn main() {
         }
     }
 
+    // Boot-time JWT verifier. In production this panics if JWT_KEYS is unset
+    // or has no active key; in dev/test an ephemeral RSA keypair is generated
+    // so `cargo run` needs no extra setup.
+    let verifier: SharedVerifier = Arc::new(
+        StaticKeyVerifier::from_env(JwtConfig::from_env())
+            .expect("Failed to initialise JWT verifier"),
+    );
+
     // Parse rate-limit config once at boot and reuse the same instance for
     // both the boot-time safety warning and the router. Previously main.rs
     // duplicated `TRUST_PROXY_HEADERS` parsing which drifted from
@@ -103,7 +113,7 @@ async fn main() {
         let addr: SocketAddr = bind_addr
             .parse()
             .expect("API_BIND_ADDR is not a valid socket address");
-        let router = api::router_with_config(api_db, rate_cfg);
+        let router = api::router_with_config(api_db, rate_cfg, verifier);
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .expect("Failed to bind Axum listener");

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -9,14 +9,22 @@ use axum::{
     Router,
 };
 use http_body_util::BodyExt;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode as AxumStatus,
+    routing::get,
+    Extension as AxumExtension,
+};
 use poolpay::{
     api,
     auth::{
         bootstrap,
+        extractors::{require_group_scope, AuthenticatedUser, SuperAdminUser},
         hmac::sign_for_testing,
         jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier},
         password,
         rate_limit::{RateLimitConfig, TEST_PEER_IP_HEADER},
+        refresh,
     },
     db,
 };
@@ -43,18 +51,26 @@ fn init_env() {
 }
 
 async fn test_app() -> (Router, poolpay::db::DbConn) {
-    build_app(lax_rate_cfg()).await
+    let (r, d, _v) = build_app_full(lax_rate_cfg()).await;
+    (r, d)
 }
 
 async fn build_app(rate_cfg: RateLimitConfig) -> (Router, poolpay::db::DbConn) {
+    let (r, d, _v) = build_app_full(rate_cfg).await;
+    (r, d)
+}
+
+async fn build_app_full(
+    rate_cfg: RateLimitConfig,
+) -> (Router, poolpay::db::DbConn, SharedVerifier) {
     init_env();
     let conn = db::init_memory().await.expect("failed to init test DB");
     bootstrap::ensure_admin_user(&conn)
         .await
         .expect("bootstrap seed must succeed");
     let verifier = test_verifier();
-    let router = api::router_with_config(conn.clone(), rate_cfg, verifier);
-    (router, conn)
+    let router = api::router_with_config(conn.clone(), rate_cfg, verifier.clone());
+    (router, conn, verifier)
 }
 
 fn test_verifier() -> SharedVerifier {
@@ -557,6 +573,342 @@ async fn per_ip_limit_isolates_by_ip() {
     )
     .await;
     assert_eq!(ok.status(), StatusCode::OK);
+}
+
+// ── Refresh rotation + logout (Plan 3 / BE-3) ────────────────────────────────
+
+/// Provision a member user via the public ensure-user endpoint so we get a
+/// real `user_id` string without reaching into `pub(crate)` helpers.
+async fn seed_member(app: &Router, subject: &str, email: &str) -> String {
+    let body = serde_json::json!({
+        "provider": "google",
+        "providerSubject": subject,
+        "email": email,
+    });
+    let resp = call(app.clone(), hmac_request("/api/auth/ensure-user", &body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    v["userId"].as_str().unwrap().to_string()
+}
+
+fn refresh_req(token: &str) -> Request<Body> {
+    let body = serde_json::json!({ "refreshToken": token });
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/refresh")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn logout_req(token: &str) -> Request<Body> {
+    let body = serde_json::json!({ "refreshToken": token });
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/logout")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn refresh_rotates_and_invalidates_the_old_token() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-refresh-1", "refresh1@example.com").await;
+
+    let issued = refresh::issue(&db, &user_id).await.expect("issue");
+    let original = issued.plaintext;
+
+    let resp = call(app.clone(), refresh_req(&original)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    let new_refresh = v["refreshToken"].as_str().unwrap().to_string();
+    assert!(!v["accessToken"].as_str().unwrap().is_empty());
+    assert_ne!(new_refresh, original, "rotation must mint a new token");
+
+    // Presenting the original token again is the reuse signal: it's already
+    // revoked, so the endpoint returns 401 and the rotation chain is killed.
+    let replay = call(app.clone(), refresh_req(&original)).await;
+    assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+
+    // The freshly rotated token should also now be dead — family was revoked
+    // as part of reuse detection on the replay.
+    let after_reuse = call(app, refresh_req(&new_refresh)).await;
+    assert_eq!(after_reuse.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn refresh_reuse_bumps_token_version() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-refresh-2", "refresh2@example.com").await;
+
+    let version_before = user_token_version(&db, &user_id).await;
+
+    let issued = refresh::issue(&db, &user_id).await.expect("issue");
+    let original = issued.plaintext;
+
+    // First rotate succeeds.
+    let ok = call(app.clone(), refresh_req(&original)).await;
+    assert_eq!(ok.status(), StatusCode::OK);
+
+    // Replay the now-revoked token: server must bump token_version and 401.
+    let replay = call(app, refresh_req(&original)).await;
+    assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+
+    let version_after = user_token_version(&db, &user_id).await;
+    assert!(
+        version_after > version_before,
+        "token_version must advance on reuse detection: before={version_before} after={version_after}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_unknown_token_returns_401() {
+    let (app, _db) = test_app().await;
+    let resp = call(app, refresh_req("not-a-real-token")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn logout_revokes_family_and_always_returns_204() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-logout-1", "logout1@example.com").await;
+
+    let issued = refresh::issue(&db, &user_id).await.expect("issue");
+
+    // Happy path: logout returns 204.
+    let out = call(app.clone(), logout_req(&issued.plaintext)).await;
+    assert_eq!(out.status(), StatusCode::NO_CONTENT);
+
+    // The refresh token is now dead — /refresh must 401.
+    let after = call(app.clone(), refresh_req(&issued.plaintext)).await;
+    assert_eq!(after.status(), StatusCode::UNAUTHORIZED);
+
+    // Unknown token → still 204 (no oracle).
+    let unknown = call(app, logout_req("nonsense")).await;
+    assert_eq!(unknown.status(), StatusCode::NO_CONTENT);
+}
+
+// ── Extractors (Plan 3 / BE-3) ────────────────────────────────────────────────
+
+/// Tiny inline router that exercises the extractors so we can verify their
+/// guard logic without waiting for BE-5 to flip real handlers over.
+fn extractor_app(db: poolpay::db::DbConn, verifier: SharedVerifier) -> Router {
+    async fn who_am_i(user: AuthenticatedUser) -> axum::Json<serde_json::Value> {
+        axum::Json(serde_json::json!({
+            "userId": user.user_id,
+            "role": user.role,
+            "tokenVersion": user.token_version,
+        }))
+    }
+    async fn super_only(_: SuperAdminUser) -> AxumStatus {
+        AxumStatus::NO_CONTENT
+    }
+    async fn scoped(
+        user: AuthenticatedUser,
+        State(db): State<poolpay::db::DbConn>,
+        Path(gid): Path<String>,
+    ) -> Result<AxumStatus, poolpay::api::models::AppError> {
+        require_group_scope(&user, &gid, &db).await?;
+        Ok(AxumStatus::NO_CONTENT)
+    }
+
+    Router::new()
+        .route("/me", get(who_am_i))
+        .route("/super", get(super_only))
+        .route("/scope/{gid}", get(scoped))
+        .layer(AxumExtension(verifier))
+        .with_state(db)
+}
+
+fn bearer_get(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn user_token_version(db: &poolpay::db::DbConn, user_id: &str) -> i64 {
+    use surrealdb::types::RecordId;
+    let mut resp = db
+        .query("SELECT token_version FROM $id")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("token_version").unwrap_or_default();
+    rows.first().copied().unwrap_or(-1)
+}
+
+async fn set_user_role(db: &poolpay::db::DbConn, user_id: &str, role: &str) {
+    use surrealdb::types::RecordId;
+    db.query("UPDATE $id SET role = $r")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .bind(("r", role.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+}
+
+async fn set_user_status(db: &poolpay::db::DbConn, user_id: &str, status: &str) {
+    use surrealdb::types::RecordId;
+    db.query("UPDATE $id SET status = $s")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .bind(("s", status.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+}
+
+async fn bootstrap_admin_id(db: &poolpay::db::DbConn) -> String {
+    let mut resp = db
+        .query("SELECT VALUE meta::id(id) FROM user WHERE email_normalised = $e LIMIT 1")
+        .bind(("e", BOOTSTRAP_EMAIL.to_lowercase()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<String> = resp.take(0).unwrap_or_default();
+    rows.into_iter().next().expect("bootstrap admin row must exist")
+}
+
+#[tokio::test]
+async fn extractor_accepts_valid_token_for_active_user() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-ext-1", "ext1@example.com").await;
+    let token = verifier.mint_access(&user_id, "member", 0).expect("mint");
+
+    let app = extractor_app(db, verifier);
+    let resp = call(app, bearer_get("/me", &token)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["userId"].as_str().unwrap(), user_id);
+    assert_eq!(v["role"], "member");
+}
+
+#[tokio::test]
+async fn extractor_rejects_stale_token_version() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-ext-2", "ext2@example.com").await;
+
+    // Mint a token with a version that does not match the user's current 0.
+    let stale = verifier.mint_access(&user_id, "member", 42).expect("mint");
+
+    let app = extractor_app(db, verifier);
+    let resp = call(app, bearer_get("/me", &stale)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn extractor_rejects_disabled_user() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-ext-3", "ext3@example.com").await;
+    let token = verifier.mint_access(&user_id, "member", 0).expect("mint");
+
+    set_user_status(&db, &user_id, "disabled").await;
+
+    let app = extractor_app(db, verifier);
+    let resp = call(app, bearer_get("/me", &token)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn extractor_rejects_missing_bearer() {
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let app = extractor_app(db, verifier);
+
+    let no_header = Request::builder()
+        .method(Method::GET)
+        .uri("/me")
+        .body(Body::empty())
+        .unwrap();
+    let resp = call(app, no_header).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn super_admin_extractor_accepts_super_admin_and_rejects_others() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+
+    let admin_id = bootstrap_admin_id(&db).await;
+    let admin_token = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint super");
+
+    let member_id = seed_member(&app, "sub-super-1", "super1@example.com").await;
+    let member_token = verifier.mint_access(&member_id, "member", 0).expect("mint");
+
+    let test_app = extractor_app(db, verifier);
+
+    let ok = call(test_app.clone(), bearer_get("/super", &admin_token)).await;
+    assert_eq!(ok.status(), StatusCode::NO_CONTENT);
+
+    let denied = call(test_app, bearer_get("/super", &member_token)).await;
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn group_scope_super_admin_bypasses() {
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let token = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let test_app = extractor_app(db, verifier);
+    // No `group_admin` row exists — super_admin still passes.
+    let resp = call(test_app, bearer_get("/scope/any-group-id", &token)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn group_scope_admin_requires_group_admin_row() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+
+    let user_id = seed_member(&app, "sub-scope-1", "scope1@example.com").await;
+    set_user_role(&db, &user_id, "admin").await;
+    let token = verifier.mint_access(&user_id, "admin", 0).expect("mint");
+
+    let test_app = extractor_app(db.clone(), verifier);
+
+    // No row yet → 403.
+    let denied = call(test_app.clone(), bearer_get("/scope/group-7", &token)).await;
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+    // Add the join row — now the same token passes for that specific group.
+    db.create::<Option<poolpay::api::models::DbGroupAdmin>>("group_admin")
+        .content(poolpay::api::models::GroupAdminContent {
+            user_id: user_id.clone(),
+            group_id: "group-7".into(),
+            created_at: poolpay::api::models::now_iso(),
+            created_by: "test".into(),
+        })
+        .await
+        .expect("insert group_admin")
+        .expect("row returned");
+
+    let ok = call(test_app.clone(), bearer_get("/scope/group-7", &token)).await;
+    assert_eq!(ok.status(), StatusCode::NO_CONTENT);
+
+    // Different group still denied.
+    let other = call(test_app, bearer_get("/scope/group-8", &token)).await;
+    assert_eq!(other.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn group_scope_member_is_always_forbidden() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-scope-2", "scope2@example.com").await;
+    let token = verifier.mint_access(&user_id, "member", 0).expect("mint");
+
+    let test_app = extractor_app(db, verifier);
+    let resp = call(test_app, bearer_get("/scope/group-9", &token)).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ── Password primitives sanity check ──────────────────────────────────────────

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -46,6 +46,11 @@ fn init_env() {
             std::env::set_var("NEXTAUTH_BACKEND_SECRET", HMAC_SECRET);
             std::env::set_var("BOOTSTRAP_ADMIN_EMAIL", BOOTSTRAP_EMAIL);
             std::env::set_var("BOOTSTRAP_ADMIN_PASSWORD", BOOTSTRAP_PASSWORD);
+            // Pin APP_ENV so `StaticKeyVerifier::from_env` takes the ephemeral
+            // branch even when the host shell has `APP_ENV=production` or a
+            // real `JWT_KEYS` set. Keeps the suite hermetic.
+            std::env::set_var("APP_ENV", "test");
+            std::env::remove_var("JWT_KEYS");
         }
     });
 }

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -663,6 +663,46 @@ async fn refresh_reuse_bumps_token_version() {
 }
 
 #[tokio::test]
+async fn concurrent_refresh_rotation_detects_race_as_reuse() {
+    // Two callers present the same refresh token at the same time. The
+    // atomic conditional revoke guarantees exactly one wins; the other
+    // trips reuse detection and kills the family. If both walked away
+    // with live tokens in the same family we would have a working
+    // token-theft bypass — this test pins that behaviour down.
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-race-1", "race1@example.com").await;
+    let issued = refresh::issue(&db, &user_id).await.expect("issue");
+
+    let a = tokio::spawn({
+        let app = app.clone();
+        let tok = issued.plaintext.clone();
+        async move { call(app, refresh_req(&tok)).await }
+    });
+    let b = tokio::spawn({
+        let app = app.clone();
+        let tok = issued.plaintext.clone();
+        async move { call(app, refresh_req(&tok)).await }
+    });
+    let (resp_a, resp_b) = (a.await.unwrap(), b.await.unwrap());
+
+    let mut statuses = [resp_a.status(), resp_b.status()];
+    statuses.sort_by_key(|s| s.as_u16());
+    assert_eq!(
+        statuses,
+        [StatusCode::OK, StatusCode::UNAUTHORIZED],
+        "exactly one of the racing rotates must win; the other is reuse",
+    );
+
+    // The losing call must have killed the family: the winner's freshly
+    // rotated token is also dead now, just like the non-racing reuse path.
+    let version_after = user_token_version(&db, &user_id).await;
+    assert!(
+        version_after > 0,
+        "reuse detection on the racing call must bump token_version: got {version_after}"
+    );
+}
+
+#[tokio::test]
 async fn refresh_unknown_token_returns_401() {
     let (app, _db) = test_app().await;
     let resp = call(app, refresh_req("not-a-real-token")).await;

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -79,15 +79,23 @@ async fn build_app_full(
 }
 
 fn test_verifier() -> SharedVerifier {
-    Arc::new(
-        StaticKeyVerifier::from_env(JwtConfig {
-            audience: "poolpay-api".into(),
-            issuer: "poolpay-nextauth".into(),
-            access_ttl_secs: 900,
-            leeway_secs: 60,
+    // `StaticKeyVerifier::from_env` generates a fresh RSA-2048 keypair when
+    // `JWT_KEYS` is unset, which is expensive enough to dominate test runtime
+    // if we rebuild it per call. Build once per process and clone the `Arc`.
+    static VERIFIER: OnceLock<SharedVerifier> = OnceLock::new();
+    VERIFIER
+        .get_or_init(|| {
+            Arc::new(
+                StaticKeyVerifier::from_env(JwtConfig {
+                    audience: "poolpay-api".into(),
+                    issuer: "poolpay-nextauth".into(),
+                    access_ttl_secs: 900,
+                    leeway_secs: 60,
+                })
+                .expect("test verifier"),
+            )
         })
-        .expect("test verifier"),
-    )
+        .clone()
 }
 
 /// Non-restrictive config used by every non-rate-limit test. Large buckets so

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -14,12 +14,13 @@ use poolpay::{
     auth::{
         bootstrap,
         hmac::sign_for_testing,
+        jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier},
         password,
         rate_limit::{RateLimitConfig, TEST_PEER_IP_HEADER},
     },
     db,
 };
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use tower::ServiceExt;
 
 // ── Shared env setup ──────────────────────────────────────────────────────────
@@ -51,8 +52,21 @@ async fn build_app(rate_cfg: RateLimitConfig) -> (Router, poolpay::db::DbConn) {
     bootstrap::ensure_admin_user(&conn)
         .await
         .expect("bootstrap seed must succeed");
-    let router = api::router_with_config(conn.clone(), rate_cfg);
+    let verifier = test_verifier();
+    let router = api::router_with_config(conn.clone(), rate_cfg, verifier);
     (router, conn)
+}
+
+fn test_verifier() -> SharedVerifier {
+    Arc::new(
+        StaticKeyVerifier::from_env(JwtConfig {
+            audience: "poolpay-api".into(),
+            issuer: "poolpay-nextauth".into(),
+            access_ttl_secs: 900,
+            leeway_secs: 60,
+        })
+        .expect("test verifier"),
+    )
 }
 
 /// Non-restrictive config used by every non-rate-limit test. Large buckets so


### PR DESCRIPTION
## Summary

- Lands the RS256 verifier, refresh-token storage with RFC 6749 BCP rotation, and the three RBAC extractors behind \`#[allow(dead_code)]\` until BE-4 mints tokens and BE-5 flips handlers.
- Wires \`/api/auth/refresh\` and \`/api/auth/logout\` — real endpoints, callable today.
- Production is fail-closed: panics at boot if \`JWT_KEYS\` is missing/empty. Dev/test auto-generates an ephemeral RSA-2048 keypair so \`cargo run\` works without setup.

## What's in here

**Schema** — \`refresh_token\` (UNIQUE on hashed_token, family lookup index) and \`group_admin\` (UNIQUE on user_id+group_id), both SCHEMAFULL.

**JWT** — \`StaticKeyVerifier\` with kid-indexed map, pins \`Algorithm::RS256\` to block alg:none and HS256-with-pubkey. Enforces audience, issuer, exp, nbf, iat with configurable leeway. \`mint_access\` on the trait so the refresh path works even for pure-verifier deployments (default impl returns NoActiveKey).

**Refresh** — 32-byte URL-safe tokens, stored as SHA-256 hex. Every use rotates; presenting a revoked token kills the entire family, bumps the user's \`token_version\` (invalidates in-flight access tokens within the 15-min TTL), and writes \`auth_event{refresh_reuse_detected}\`.

**Extractors** — \`AuthenticatedUser\` (sig + exp + token_version + status), \`SuperAdminUser\` (role narrowing), \`require_group_scope\` (super_admin bypass; admin passes iff a \`group_admin\` row exists). Verifier injected via \`Extension<SharedVerifier>\` to avoid migrating every handler's state type.

**Endpoints** — \`/api/auth/refresh\` rotates and mints a matching access JWT; all failures return 401 with no distinguishing body. \`/api/auth/logout\` revokes the family and always returns 204 (no oracle).

## Test plan

- [x] \`cargo test --test auth_integration\` — 31 tests pass, 13 new covering:
  - refresh happy-path rotation
  - refresh reuse detection bumps token_version and kills the family
  - logout revokes family, always 204
  - extractors: valid/stale-version/disabled-user/missing-bearer
  - SuperAdminUser accepts super_admin / forbids others
  - require_group_scope: super_admin bypass / admin with row passes / admin without row 403 / member always forbidden
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] Smoke \`cargo run\` locally to confirm the ephemeral-key dev warning fires and the server boots