### PR TITLE
[FEAT] BE-4: AdminOrLegacyToken compat shim + mint_admin_jwt helper

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,8 +28,16 @@ use handlers::{
 /// fresh RSA-2048 keypair) which is both expensive and breaks any caller
 /// that holds a previously-minted token across rebuilds.
 pub fn router(db: DbConn) -> Router {
+    router_with_config(db, RateLimitConfig::from_env(), shared_verifier())
+}
+
+/// Process-cached verifier used by `router()`. Exposed so the BE-4
+/// `mint_admin_jwt()` test helper can sign tokens with the same key the
+/// running app uses to verify them — without it, tests would build a
+/// fresh ephemeral keypair and the token's signature would be rejected.
+pub fn shared_verifier() -> SharedVerifier {
     static VERIFIER: OnceLock<SharedVerifier> = OnceLock::new();
-    let verifier = VERIFIER
+    VERIFIER
         .get_or_init(|| {
             Arc::new(
                 StaticKeyVerifier::from_env(JwtConfig::from_env()).unwrap_or_else(|err| {
@@ -37,8 +45,7 @@ pub fn router(db: DbConn) -> Router {
                 }),
             )
         })
-        .clone();
-    router_with_config(db, RateLimitConfig::from_env(), verifier)
+        .clone()
 }
 
 /// Build the router with explicit rate-limit config and token verifier —

--- a/src/auth/compat.rs
+++ b/src/auth/compat.rs
@@ -99,27 +99,55 @@ mod tests {
     //! exercised in `tests/auth_integration.rs`.
 
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serializes mutation of the process-global `ADMIN_TOKEN` env var so
+    /// concurrent unit tests in this module cannot race each other on the
+    /// `set_var`/`remove_var` calls (which `cargo test` runs in parallel
+    /// across threads by default).
+    static ADMIN_TOKEN_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    /// RAII guard that restores `ADMIN_TOKEN` to its pre-test value on
+    /// drop. Keeping the restore in `Drop` guarantees it runs even if the
+    /// wrapped closure panics (e.g. a failing assertion), so a flaky test
+    /// cannot leak a bogus `ADMIN_TOKEN` into subsequent tests.
+    struct AdminTokenGuard {
+        prev: Option<String>,
+    }
+
+    impl Drop for AdminTokenGuard {
+        fn drop(&mut self) {
+            // Safety: the lock held by the caller serializes all writers
+            // to `ADMIN_TOKEN`; readers outside this module set their own
+            // value before reading, so a transient restore is harmless.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("ADMIN_TOKEN", v),
+                    None => std::env::remove_var("ADMIN_TOKEN"),
+                }
+            }
+        }
+    }
 
     fn with_admin_token<F: FnOnce()>(value: Option<&str>, f: F) {
-        // Legacy env-var based config; tests run sequentially in this
-        // module to avoid clobbering each other's view of ADMIN_TOKEN.
-        let prev = std::env::var("ADMIN_TOKEN").ok();
-        // Safety: this module's tests never run in parallel with each
-        // other (single-threaded `cargo test` per module by default for
-        // the few tests here) and other suites pin their own state.
+        let _env_lock = ADMIN_TOKEN_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let _restore = AdminTokenGuard {
+            prev: std::env::var("ADMIN_TOKEN").ok(),
+        };
+
+        // Safety: serialized by `ADMIN_TOKEN_ENV_LOCK` above.
         unsafe {
             match value {
                 Some(v) => std::env::set_var("ADMIN_TOKEN", v),
                 None => std::env::remove_var("ADMIN_TOKEN"),
             }
         }
+
         f();
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("ADMIN_TOKEN", v),
-                None => std::env::remove_var("ADMIN_TOKEN"),
-            }
-        }
     }
 
     #[test]

--- a/src/auth/compat.rs
+++ b/src/auth/compat.rs
@@ -1,0 +1,156 @@
+//! Compatibility shim — BE-4.
+//!
+//! Bridges the legacy static `ADMIN_TOKEN` bearer with the new RS256 admin
+//! JWTs while BE-5 migrates handlers one resource at a time. Once every
+//! handler has been flipped to `SuperAdminUser` or `GroupScopedAdmin`
+//! (BE-6), this module — and `ADMIN_TOKEN` itself — is deleted.
+//!
+//! Acceptance rules (in order):
+//!   1. `Authorization: Bearer <token>` is parsed.
+//!   2. If `ADMIN_TOKEN` is set and matches the bearer in constant time,
+//!      the request is accepted as `Legacy` without touching the JWT
+//!      verifier or the database. Cheap, side-effect-free fast path so
+//!      operator scripts keep working unchanged.
+//!   3. Otherwise the bearer is verified as an access token. The carried
+//!      user must be `super_admin` or `admin`; `member` tokens are 403
+//!      (the legacy `AdminToken` had no equivalent of `member`, so any
+//!      member JWT reaching an admin route is a guard mismatch we want
+//!      to surface, not silently fall through to 401).
+//!   4. Anything else → 401.
+
+#![allow(dead_code)]
+
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
+use subtle::ConstantTimeEq;
+
+use crate::api::models::AppError;
+use crate::auth::extractors::{AuthenticatedUser, extract_bearer};
+use crate::db::DbConn;
+
+/// Result of an `AdminOrLegacyToken` extraction.
+///
+/// Held as an enum (rather than discarded as a unit type) so handlers
+/// migrated mid-transition can attribute mutations to the JWT user when
+/// one is present, and fall back to "legacy operator" auditing otherwise.
+#[derive(Debug, Clone)]
+pub enum AdminOrLegacyToken {
+    /// The request authenticated with the legacy `ADMIN_TOKEN` bearer.
+    Legacy,
+    /// The request authenticated with an admin-role JWT.
+    Jwt(AuthenticatedUser),
+}
+
+impl AdminOrLegacyToken {
+    /// Returns the underlying user id when the request was authenticated
+    /// via JWT. `None` for legacy bearer requests, since `ADMIN_TOKEN` is
+    /// not tied to any user record.
+    pub fn user_id(&self) -> Option<&str> {
+        match self {
+            Self::Legacy => None,
+            Self::Jwt(u) => Some(&u.user_id),
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for AdminOrLegacyToken
+where
+    S: Send + Sync,
+    DbConn: FromRef<S>,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let bearer = extract_bearer(parts)?;
+
+        if legacy_token_matches(&bearer) {
+            return Ok(Self::Legacy);
+        }
+
+        // Legacy didn't match — fall through to JWT verification. The
+        // `AuthenticatedUser` extractor handles signature, audience, exp,
+        // token_version, status and `deleted_at` checks; we only have to
+        // narrow the role here.
+        let user = AuthenticatedUser::from_request_parts(parts, state).await?;
+
+        match user.role.as_str() {
+            "super_admin" | "admin" => Ok(Self::Jwt(user)),
+            _ => Err(AppError::Forbidden("admin role required".into())),
+        }
+    }
+}
+
+/// Constant-time compare of the presented bearer against `ADMIN_TOKEN`.
+///
+/// Returns `false` when `ADMIN_TOKEN` is unset or empty so that an
+/// accidentally-blank deployment cannot be unlocked with a blank bearer.
+fn legacy_token_matches(presented: &str) -> bool {
+    let expected = std::env::var("ADMIN_TOKEN").unwrap_or_default();
+    if expected.is_empty() || expected.len() != presented.len() {
+        return false;
+    }
+    expected.as_bytes().ct_eq(presented.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit-level coverage for the legacy-vs-jwt decision logic. The full
+    //! end-to-end path (Axum extraction, DB lookup, role gating) is
+    //! exercised in `tests/auth_integration.rs`.
+
+    use super::*;
+
+    fn with_admin_token<F: FnOnce()>(value: Option<&str>, f: F) {
+        // Legacy env-var based config; tests run sequentially in this
+        // module to avoid clobbering each other's view of ADMIN_TOKEN.
+        let prev = std::env::var("ADMIN_TOKEN").ok();
+        // Safety: this module's tests never run in parallel with each
+        // other (single-threaded `cargo test` per module by default for
+        // the few tests here) and other suites pin their own state.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("ADMIN_TOKEN", v),
+                None => std::env::remove_var("ADMIN_TOKEN"),
+            }
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("ADMIN_TOKEN", v),
+                None => std::env::remove_var("ADMIN_TOKEN"),
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_match_succeeds_on_exact_token() {
+        with_admin_token(Some("the-real-token"), || {
+            assert!(legacy_token_matches("the-real-token"));
+        });
+    }
+
+    #[test]
+    fn legacy_match_rejects_wrong_token() {
+        with_admin_token(Some("the-real-token"), || {
+            assert!(!legacy_token_matches("not-it"));
+            assert!(!legacy_token_matches(""));
+            assert!(!legacy_token_matches("the-real-token-extra"));
+        });
+    }
+
+    #[test]
+    fn legacy_match_rejects_when_admin_token_unset() {
+        with_admin_token(None, || {
+            assert!(!legacy_token_matches(""));
+            assert!(!legacy_token_matches("anything"));
+        });
+    }
+
+    #[test]
+    fn legacy_match_rejects_when_admin_token_blank() {
+        with_admin_token(Some(""), || {
+            assert!(!legacy_token_matches(""));
+            assert!(!legacy_token_matches("nope"));
+        });
+    }
+}

--- a/src/auth/compat.rs
+++ b/src/auth/compat.rs
@@ -67,11 +67,13 @@ where
             return Ok(Self::Legacy);
         }
 
-        // Legacy didn't match — fall through to JWT verification. The
-        // `AuthenticatedUser` extractor handles signature, audience, exp,
+        // Legacy didn't match — fall through to JWT verification. Reuse
+        // the already-parsed bearer via `from_token` so we don't re-parse
+        // the `Authorization` header and re-allocate the token string a
+        // second time. `from_token` handles signature, audience, exp,
         // token_version, status and `deleted_at` checks; we only have to
         // narrow the role here.
-        let user = AuthenticatedUser::from_request_parts(parts, state).await?;
+        let user = AuthenticatedUser::from_token(&bearer, parts, state).await?;
 
         match user.role.as_str() {
             "super_admin" | "admin" => Ok(Self::Jwt(user)),
@@ -86,10 +88,29 @@ where
 /// accidentally-blank deployment cannot be unlocked with a blank bearer.
 fn legacy_token_matches(presented: &str) -> bool {
     let expected = std::env::var("ADMIN_TOKEN").unwrap_or_default();
-    if expected.is_empty() || expected.len() != presented.len() {
+    if expected.is_empty() {
         return false;
     }
-    expected.as_bytes().ct_eq(presented.as_bytes()).into()
+
+    // Compute both length and content checks unconditionally (mirroring the
+    // pattern in `src/api/auth.rs`) so the comparison stays constant-time
+    // with respect to the presented token — a short-circuit on length would
+    // leak the expected token length through timing. When lengths differ we
+    // hash against a zero-filled buffer sized to `expected` so `ct_eq` still
+    // sees a consistent workload.
+    let expected_bytes = expected.as_bytes();
+    let presented_bytes = presented.as_bytes();
+    let length_ok = expected_bytes.len() == presented_bytes.len();
+    let zero_pad;
+    let compare_bytes: &[u8] = if length_ok {
+        presented_bytes
+    } else {
+        zero_pad = vec![0u8; expected_bytes.len()];
+        &zero_pad
+    };
+    let content_ok: bool = expected_bytes.ct_eq(compare_bytes).into();
+
+    length_ok && content_ok
 }
 
 #[cfg(test)]

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -33,16 +33,22 @@ pub struct AuthenticatedUser {
 #[derive(Debug, Clone)]
 pub struct SuperAdminUser(pub AuthenticatedUser);
 
-impl<S> FromRequestParts<S> for AuthenticatedUser
-where
-    S: Send + Sync,
-    DbConn: FromRef<S>,
-{
-    type Rejection = AppError;
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let token = extract_bearer(parts)?;
-
+impl AuthenticatedUser {
+    /// Build an `AuthenticatedUser` from an already-parsed bearer token.
+    ///
+    /// Factored out of `from_request_parts` so extractors that need to make
+    /// a legacy-vs-JWT decision (see `auth::compat::AdminOrLegacyToken`) can
+    /// parse the `Authorization` header once and reuse the token string
+    /// rather than re-parsing and re-allocating it.
+    pub(crate) async fn from_token<S>(
+        token: &str,
+        parts: &mut Parts,
+        state: &S,
+    ) -> Result<Self, AppError>
+    where
+        S: Send + Sync,
+        DbConn: FromRef<S>,
+    {
         // The verifier is injected via Extension so it can be shared across
         // handlers without forcing every existing route onto a new state
         // type. Missing extension = misconfigured router = refuse.
@@ -51,7 +57,7 @@ where
                 .await
                 .map_err(|_| AppError::Unauthorized)?;
 
-        let claims = verifier.verify_access(&token).map_err(|e| {
+        let claims = verifier.verify_access(token).map_err(|e| {
             // Attacker-controlled input; keep at debug to avoid log-amplification.
             // Reserve `warn!` for unexpected internal failures (e.g., DB errors).
             debug!(error = %e, "JWT verification failed");
@@ -80,6 +86,19 @@ where
         }
 
         Ok(Self { user_id: claims.sub, role: user.role, token_version: user.token_version })
+    }
+}
+
+impl<S> FromRequestParts<S> for AuthenticatedUser
+where
+    S: Send + Sync,
+    DbConn: FromRef<S>,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let token = extract_bearer(parts)?;
+        Self::from_token(&token, parts, state).await
     }
 }
 

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -121,7 +121,7 @@ pub async fn require_group_scope(
     }
 }
 
-fn extract_bearer(parts: &Parts) -> Result<String, AppError> {
+pub(crate) fn extract_bearer(parts: &Parts) -> Result<String, AppError> {
     let header = parts
         .headers
         .get(axum::http::header::AUTHORIZATION)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -4,6 +4,7 @@
 //! JWT, refresh tokens, and request extractors land in subsequent increments.
 
 pub mod bootstrap;
+pub mod compat;
 pub mod extractors;
 pub mod hmac;
 pub mod jwt;

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -101,6 +101,16 @@ fn mint_admin_jwt(role: &str) -> String {
         matches!(role, "super_admin" | "admin"),
         "mint_admin_jwt only mints admin-tier roles; got {role}"
     );
+    // `shared_verifier()` fails closed if `APP_ENV` is not `test` /
+    // `development` and `JWT_KEYS` is absent. Callers in BE-5 may use
+    // this helper without going through `test_app()` first, so mirror
+    // the env init here to keep ordering-independent.
+    static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INIT.get_or_init(|| {
+        // Safety: called once before any caller reads APP_ENV through
+        // the verifier; other suite helpers set the same value.
+        unsafe { std::env::set_var("APP_ENV", "test") };
+    });
     poolpay::api::shared_verifier()
         .mint_access("test-admin-user", role, 0)
         .expect("shared verifier must mint")

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -83,6 +83,29 @@ fn post_json_authed(uri: &str, body: serde_json::Value) -> Request<Body> {
         .unwrap()
 }
 
+/// Mint an admin access token signed by the same verifier the app uses,
+/// for the requested role (`super_admin` or `admin`). Per Plan 3 / BE-4:
+/// the helper is here so that BE-5's per-resource swap PRs can migrate
+/// tests off the legacy `Bearer test-secret-token` one resource at a
+/// time without having to thread the verifier through every call site.
+///
+/// The minted token references a synthetic `test-admin-user` subject with
+/// `token_version=0`. BE-5 sub-PRs that exercise the JWT path through the
+/// real `SuperAdminUser` / `GroupScopedAdmin` extractors are responsible
+/// for seeding a matching `user` row before calling this helper —
+/// `AdminOrLegacyToken` is the only consumer in BE-4 itself, and its
+/// integration coverage seeds its own users.
+#[allow(dead_code)]
+fn mint_admin_jwt(role: &str) -> String {
+    assert!(
+        matches!(role, "super_admin" | "admin"),
+        "mint_admin_jwt only mints admin-tier roles; got {role}"
+    );
+    poolpay::api::shared_verifier()
+        .mint_access("test-admin-user", role, 0)
+        .expect("shared verifier must mint")
+}
+
 fn patch_json_authed(uri: &str, body: serde_json::Value) -> Request<Body> {
     Request::builder()
         .method(Method::PATCH)

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -20,13 +20,26 @@ use tower::ServiceExt;
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
+/// Single global lock serializing every `std::env::set_var`/`remove_var`
+/// call in this integration binary. Per-helper `OnceLock`s stop each helper
+/// from mutating the env more than once, but distinct helpers' first-time
+/// initializers can still race under parallel tests — which violates
+/// `set_var`'s safety precondition. Taking this mutex before any mutation
+/// makes the writer window mutually exclusive across helpers.
+fn env_lock() -> &'static std::sync::Mutex<()> {
+    static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    ENV_LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
 /// Build a fresh app backed by an isolated in-memory DB.
 async fn test_app() -> Router {
     // The /api/test/reset endpoint is only mounted when APP_ENV is "test" or
     // "development" (fail-closed). Set it once for the whole suite.
     static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INIT.get_or_init(|| {
-        // Safety: called once before any test reads APP_ENV.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: serialized by `env_lock()`; called once before any test
+        // reads APP_ENV.
         unsafe { std::env::set_var("APP_ENV", "test") };
     });
     let conn = db::init_memory().await.expect("failed to init test DB");
@@ -41,7 +54,9 @@ async fn test_app() -> Router {
 async fn test_app_with_auth() -> Router {
     static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INIT.get_or_init(|| {
-        // Safety: called once before any test that reads ADMIN_TOKEN runs.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: serialized by `env_lock()`; called once before any test
+        // that reads ADMIN_TOKEN runs.
         unsafe { std::env::set_var("ADMIN_TOKEN", "test-secret-token") };
     });
     test_app().await
@@ -107,8 +122,10 @@ fn mint_admin_jwt(role: &str) -> String {
     // the env init here to keep ordering-independent.
     static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INIT.get_or_init(|| {
-        // Safety: called once before any caller reads APP_ENV through
-        // the verifier; other suite helpers set the same value.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: serialized by `env_lock()` with every other env mutator
+        // in this binary; called once before any caller reads APP_ENV
+        // through the verifier; other suite helpers set the same value.
         unsafe { std::env::set_var("APP_ENV", "test") };
     });
     poolpay::api::shared_verifier()

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1093,13 +1093,13 @@ async fn shim_rejects_stale_token_version_jwt() {
     init_legacy_admin_token();
     let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let admin_id = bootstrap_admin_id(&db).await;
-    // Bootstrap user has token_version=0; mint with a stale version.
-    let stale = verifier
+    // Bootstrap user has token_version=0; mint with a mismatched version.
+    let mismatched = verifier
         .mint_access(&admin_id, "super_admin", 99)
-        .expect("mint stale");
+        .expect("mint mismatched token version");
 
     let app = shim_app(db, verifier);
-    let resp = call(app, bearer_get("/admin", &stale)).await;
+    let resp = call(app, bearer_get("/admin", &mismatched)).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -19,6 +19,7 @@ use poolpay::{
     api,
     auth::{
         bootstrap,
+        compat::AdminOrLegacyToken,
         extractors::{require_group_scope, AuthenticatedUser, SuperAdminUser},
         hmac::sign_for_testing,
         jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier},
@@ -962,6 +963,144 @@ async fn group_scope_member_is_always_forbidden() {
     let test_app = extractor_app(db, verifier);
     let resp = call(test_app, bearer_get("/scope/group-9", &token)).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── AdminOrLegacyToken compat shim (Plan 3 / BE-4) ───────────────────────────
+
+const LEGACY_ADMIN_TOKEN: &str = "legacy-admin-token-for-shim-tests";
+
+/// Set `ADMIN_TOKEN` once for the suite so the shim's legacy path has a
+/// stable expected value. Tests that exercise the unset/blank branches
+/// live in the unit-test module under `src/auth/compat.rs`.
+fn init_legacy_admin_token() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        // Safety: written once before any shim test reads ADMIN_TOKEN.
+        unsafe {
+            std::env::set_var("ADMIN_TOKEN", LEGACY_ADMIN_TOKEN);
+        }
+    });
+}
+
+fn shim_app(db: poolpay::db::DbConn, verifier: SharedVerifier) -> Router {
+    async fn admin_only(token: AdminOrLegacyToken) -> axum::Json<serde_json::Value> {
+        let kind = match &token {
+            AdminOrLegacyToken::Legacy => "legacy",
+            AdminOrLegacyToken::Jwt(_) => "jwt",
+        };
+        axum::Json(serde_json::json!({
+            "kind": kind,
+            "userId": token.user_id(),
+        }))
+    }
+
+    Router::new()
+        .route("/admin", get(admin_only))
+        .layer(AxumExtension(verifier))
+        .with_state(db)
+}
+
+#[tokio::test]
+async fn shim_accepts_legacy_admin_token() {
+    init_legacy_admin_token();
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let app = shim_app(db, verifier);
+
+    let resp = call(app, bearer_get("/admin", LEGACY_ADMIN_TOKEN)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["kind"], "legacy");
+    assert!(v["userId"].is_null(), "legacy path is not tied to a user");
+}
+
+#[tokio::test]
+async fn shim_accepts_super_admin_jwt() {
+    init_legacy_admin_token();
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let token = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint super_admin");
+
+    let app = shim_app(db, verifier);
+    let resp = call(app, bearer_get("/admin", &token)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["kind"], "jwt");
+    assert_eq!(v["userId"].as_str().unwrap(), admin_id);
+}
+
+#[tokio::test]
+async fn shim_accepts_admin_jwt() {
+    init_legacy_admin_token();
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-shim-admin-1", "shim-admin@example.com").await;
+    set_user_role(&db, &user_id, "admin").await;
+    let token = verifier
+        .mint_access(&user_id, "admin", 0)
+        .expect("mint admin");
+
+    let shim = shim_app(db, verifier);
+    let resp = call(shim, bearer_get("/admin", &token)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["kind"], "jwt");
+    assert_eq!(v["userId"].as_str().unwrap(), user_id);
+}
+
+#[tokio::test]
+async fn shim_rejects_member_jwt_with_403() {
+    // A `member` JWT is structurally valid but has no admin authority —
+    // the shim must surface this as 403, not pass and not fall through to
+    // a generic 401, so a misrouted member token is debuggable.
+    init_legacy_admin_token();
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-shim-mem-1", "shim-mem@example.com").await;
+    let token = verifier
+        .mint_access(&user_id, "member", 0)
+        .expect("mint member");
+
+    let shim = shim_app(db, verifier);
+    let resp = call(shim, bearer_get("/admin", &token)).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn shim_rejects_garbage_bearer_with_401() {
+    init_legacy_admin_token();
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let app = shim_app(db, verifier);
+    let resp = call(app, bearer_get("/admin", "neither-legacy-nor-jwt")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn shim_rejects_missing_authorization_header() {
+    init_legacy_admin_token();
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let app = shim_app(db, verifier);
+    let no_header = Request::builder()
+        .method(Method::GET)
+        .uri("/admin")
+        .body(Body::empty())
+        .unwrap();
+    let resp = call(app, no_header).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn shim_rejects_stale_token_version_jwt() {
+    init_legacy_admin_token();
+    let (_app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    // Bootstrap user has token_version=0; mint with a stale version.
+    let stale = verifier
+        .mint_access(&admin_id, "super_admin", 99)
+        .expect("mint stale");
+
+    let app = shim_app(db, verifier);
+    let resp = call(app, bearer_get("/admin", &stale)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 // ── Password primitives sanity check ──────────────────────────────────────────

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -29,7 +29,7 @@ use poolpay::{
     },
     db,
 };
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use tower::ServiceExt;
 
 // ── Shared env setup ──────────────────────────────────────────────────────────
@@ -38,11 +38,23 @@ const HMAC_SECRET: &str = "test-hmac-secret-for-integration-only";
 const BOOTSTRAP_EMAIL: &str = "seed-admin@example.com";
 const BOOTSTRAP_PASSWORD: &str = "correct-horse-battery-staple";
 
+/// Single global lock serializing every `std::env::set_var`/`remove_var`
+/// call in this integration binary. Each test helper has its own `OnceLock`
+/// so it only mutates the env once, but those first-time initializers can
+/// still execute concurrently across helpers under parallel tests — which
+/// violates `set_var`'s safety precondition. Taking this mutex before any
+/// mutation makes the writer window mutually exclusive across helpers.
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn init_env() {
     static INIT: OnceLock<()> = OnceLock::new();
     INIT.get_or_init(|| {
-        // Safety: written once before any test reads these vars. Parallel
-        // tests may then read them freely.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: serialized by `env_lock()` above; written once before any
+        // test reads these vars. Parallel tests may then read them freely.
         unsafe {
             std::env::set_var("NEXTAUTH_BACKEND_SECRET", HMAC_SECRET);
             std::env::set_var("BOOTSTRAP_ADMIN_EMAIL", BOOTSTRAP_EMAIL);
@@ -975,7 +987,9 @@ const LEGACY_ADMIN_TOKEN: &str = "legacy-admin-token-for-shim-tests";
 fn init_legacy_admin_token() {
     static INIT: OnceLock<()> = OnceLock::new();
     INIT.get_or_init(|| {
-        // Safety: written once before any shim test reads ADMIN_TOKEN.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // Safety: serialized by `env_lock()` with every other env mutator
+        // in this binary; written once before any shim test reads ADMIN_TOKEN.
         unsafe {
             std::env::set_var("ADMIN_TOKEN", LEGACY_ADMIN_TOKEN);
         }


### PR DESCRIPTION
## Summary
- Plan 3 / BE-4 — bridges legacy `ADMIN_TOKEN` bearer with new RS256 admin JWTs while BE-5 migrates handlers per-resource.
- `AdminOrLegacyToken` extractor: legacy bearer matched constant-time, otherwise JWT verified and role narrowed to `super_admin`/`admin` (member tokens → 403 so a misrouted token is debuggable).
- `mint_admin_jwt(role)` test helper added alongside `post_json_authed()`; `api::shared_verifier()` exposed so helpers sign with the same key the app verifies with.
- Shim sits behind `#[allow(dead_code)]` until BE-5 wires it to handlers — nothing wired yet.

## Test plan
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 233/233 green (4 new compat unit tests + 7 new shim integration tests)
- [ ] BE-5 sub-PRs will exercise the JWT path through real handlers