### PR TITLE
[TEST] Use Argon2 minimum work factor under cfg(test)

### DIFF
--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -11,9 +11,32 @@ use std::sync::OnceLock;
 use crate::api::models::AppError;
 
 /// OWASP 2024 baseline: m=19 MiB, t=2, p=1.
+///
+/// Under `cargo test` these collapse to the Argon2 minimum — a single hash
+/// at the OWASP params runs ~500 ms in debug mode, and the auth suite calls
+/// `hash`/`verify` 50+ times across bootstrap and credential-verification
+/// tests. That alone added ~30 s of pure CPU per `cargo test` cycle and
+/// dragged tower-governor's wall-clock-based rate-limit tests into flaky
+/// territory by pushing real-time refills past the assertion windows.
+///
+/// The algorithm (Argon2id), version (V0x13), salt generation and PHC
+/// encoding are unchanged — only the work factor differs — so weak-params
+/// hashes still verify correctly and still reject wrong passwords. Drift
+/// on the prod params themselves is covered by `prod_params_round_trip`
+/// in the test module below, which runs the OWASP baseline once per CI.
+#[cfg(not(test))]
 const ARGON2_M_COST_KIB: u32 = 19_456;
+#[cfg(not(test))]
 const ARGON2_T_COST: u32 = 2;
+#[cfg(not(test))]
 const ARGON2_P_COST: u32 = 1;
+
+#[cfg(test)]
+const ARGON2_M_COST_KIB: u32 = argon2::Params::MIN_M_COST;
+#[cfg(test)]
+const ARGON2_T_COST: u32 = argon2::Params::MIN_T_COST;
+#[cfg(test)]
+const ARGON2_P_COST: u32 = argon2::Params::MIN_P_COST;
 
 /// The placeholder password used to generate `dummy_hash()`. Its value is
 /// irrelevant — it only needs to produce a valid Argon2 PHC string so the
@@ -91,5 +114,24 @@ mod tests {
     #[test]
     fn verify_or_dummy_handles_missing_hash() {
         assert!(!verify_or_dummy("anything", None).unwrap());
+    }
+
+    /// Exercise the production Argon2 parameters explicitly so a typo or
+    /// out-of-range bump in the `#[cfg(not(test))]` constants is caught
+    /// even though the rest of the suite runs on weakened params for
+    /// speed. One hash + one verify; ~500 ms in debug mode.
+    #[test]
+    fn prod_params_round_trip() {
+        use password_hash::{PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
+
+        let params = Params::new(19_456, 2, 1, None).expect("prod params must be valid");
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+        let salt = SaltString::generate(&mut OsRng);
+        let hash = argon2
+            .hash_password(b"prod-params-smoke", &salt)
+            .expect("hash with prod params")
+            .to_string();
+        let parsed = PasswordHash::new(&hash).expect("parse PHC");
+        assert!(argon2.verify_password(b"prod-params-smoke", &parsed).is_ok());
     }
 }

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -10,14 +10,25 @@ use std::sync::OnceLock;
 
 use crate::api::models::AppError;
 
-/// OWASP 2024 baseline: m=19 MiB, t=2, p=1.
+/// OWASP 2024 baseline for production hashing.
+pub(crate) const ARGON2_PROD_M_COST_KIB: u32 = 19_456;
+pub(crate) const ARGON2_PROD_T_COST: u32 = 2;
+pub(crate) const ARGON2_PROD_P_COST: u32 = 1;
+
+/// When this crate is compiled with `cfg(test)` (i.e. `cargo test` unit tests
+/// and doctests *of this crate*), Argon2 work factors collapse to the library
+/// minimum. A single hash at the OWASP params runs ~500 ms in debug mode, and
+/// the auth suite calls `hash`/`verify` 50+ times across bootstrap and
+/// credential-verification tests — that alone added ~30 s of pure CPU per
+/// `cargo test` cycle and dragged tower-governor's wall-clock-based
+/// rate-limit tests into flaky territory by pushing real-time refills past
+/// the assertion windows.
 ///
-/// Under `cargo test` these collapse to the Argon2 minimum — a single hash
-/// at the OWASP params runs ~500 ms in debug mode, and the auth suite calls
-/// `hash`/`verify` 50+ times across bootstrap and credential-verification
-/// tests. That alone added ~30 s of pure CPU per `cargo test` cycle and
-/// dragged tower-governor's wall-clock-based rate-limit tests into flaky
-/// territory by pushing real-time refills past the assertion windows.
+/// Note: `#[cfg(test)]` only affects the unit-test build of *this* crate.
+/// Downstream integration-test binaries and external consumers link against
+/// the non-test build and therefore keep the full OWASP parameters. If you
+/// need the weak params in a new integration test, move the assertion into a
+/// `#[cfg(test)] mod tests` block inside this crate.
 ///
 /// The algorithm (Argon2id), version (V0x13), salt generation and PHC
 /// encoding are unchanged — only the work factor differs — so weak-params
@@ -25,11 +36,11 @@ use crate::api::models::AppError;
 /// on the prod params themselves is covered by `prod_params_round_trip`
 /// in the test module below, which runs the OWASP baseline once per CI.
 #[cfg(not(test))]
-const ARGON2_M_COST_KIB: u32 = 19_456;
+const ARGON2_M_COST_KIB: u32 = ARGON2_PROD_M_COST_KIB;
 #[cfg(not(test))]
-const ARGON2_T_COST: u32 = 2;
+const ARGON2_T_COST: u32 = ARGON2_PROD_T_COST;
 #[cfg(not(test))]
-const ARGON2_P_COST: u32 = 1;
+const ARGON2_P_COST: u32 = ARGON2_PROD_P_COST;
 
 #[cfg(test)]
 const ARGON2_M_COST_KIB: u32 = argon2::Params::MIN_M_COST;
@@ -124,7 +135,13 @@ mod tests {
     fn prod_params_round_trip() {
         use password_hash::{PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
 
-        let params = Params::new(19_456, 2, 1, None).expect("prod params must be valid");
+        let params = Params::new(
+            ARGON2_PROD_M_COST_KIB,
+            ARGON2_PROD_T_COST,
+            ARGON2_PROD_P_COST,
+            None,
+        )
+        .expect("prod params must be valid");
         let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
         let salt = SaltString::generate(&mut OsRng);
         let hash = argon2


### PR DESCRIPTION
## Summary
- Auth suite was paying ~500 ms × 50+ hashes per `cargo test` cycle in debug mode → ~30 s of pure CPU on argon2 alone, plus stretching tower-governor's wall-clock rate-limit tests past their assertion windows.
- Under `#[cfg(test)]`, argon2 collapses to `Params::MIN_*` (m=8, t=1, p=1). Algorithm, version, salt and PHC encoding are unchanged — weak-params hashes still verify correctly and still reject wrong passwords.
- Production stays on OWASP 2024 baseline (m=19 MiB, t=2, p=1); zero behaviour change in any non-test build.
- Adds `prod_params_round_trip` smoke test that explicitly hashes + verifies under the production constants, so a typo or out-of-range bump in `ARGON2_*_COST` is caught even though the rest of the suite runs weak.

## Test plan
- [x] `cargo build` — prod path uses OWASP params (cfg(not(test)) branch)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — 223/223 green
- [x] Wall-clock: ~5 min → ~1 m 16 s (4× faster)