### PR TITLE
[FEAT] - POST /api/auth/issue — mint initial token pair (BE-7)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -87,7 +87,8 @@ RECEIPT_DOWNLOAD_DIR=/tmp/receipts
 RUST_LOG=info
 
 # --- Auth rate limiting (Plan 3 / BE-2) ---
-# Per-IP limiter on /api/auth/verify-credentials, /api/auth/ensure-user, and /api/auth/issue.
+# Per-IP limiter on the full /api/auth/* sub-router — /api/auth/verify-credentials,
+# /api/auth/ensure-user, /api/auth/issue, /api/auth/refresh, and /api/auth/logout.
 AUTH_RATE_LIMIT_PER_MINUTE=60
 AUTH_RATE_LIMIT_BURST=10
 
@@ -127,9 +128,11 @@ JWT_REFRESH_TTL_SECS=1209600
 Two layers protect the HMAC-gated auth surface:
 
 - **Per-IP (`tower_governor`)** — a steady quota of `AUTH_RATE_LIMIT_PER_MINUTE`
-  requests per minute with a burst of `AUTH_RATE_LIMIT_BURST`, applied to
-  both `/api/auth/verify-credentials`, `/api/auth/ensure-user`, and `/api/auth/issue`. Runs
-  before HMAC verification so anonymous floods are dropped cheaply.
+  requests per minute with a burst of `AUTH_RATE_LIMIT_BURST`, applied to the
+  entire `/api/auth/*` sub-router: `/api/auth/verify-credentials`,
+  `/api/auth/ensure-user`, `/api/auth/issue`, `/api/auth/refresh`, and
+  `/api/auth/logout`. Runs before HMAC / refresh-token verification so
+  anonymous floods are dropped cheaply.
 - **Composite `(ip, email_normalised)`** — in-handler limiter on
   `/api/auth/verify-credentials`. Token-bucket with burst
   `AUTH_CREDENTIAL_FAILURE_LIMIT` that refills one slot every

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -512,8 +512,12 @@ callback on first sign-in so subsequent requests can silent-refresh.
 **Response (200):** same shape as `/api/auth/refresh` (`accessToken`,
 `refreshToken`, `expiresAt`).
 
-Returns `401` on HMAC failure, unknown user, disabled user, or soft-deleted
-user (writes a `token_issue_failure` audit event). `400` on empty or
+Returns `401` on HMAC failure (rejected inside `HmacVerifiedJson` before
+the handler runs — no audit event) and on unknown, disabled, or
+soft-deleted users (handler writes a `token_issue_failure` audit event
+with `reason` in `{unknown_user, disabled, soft_deleted}`). `500` on DB
+or signing failure, also with a `token_issue_failure` audit row
+(`reason` in `{db_error, mint_access_failed}`). `400` on empty or
 oversized `userId` (>128 chars).
 
 ### Dev-Only Endpoint

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -128,7 +128,7 @@ Two layers protect the HMAC-gated auth surface:
 
 - **Per-IP (`tower_governor`)** — a steady quota of `AUTH_RATE_LIMIT_PER_MINUTE`
   requests per minute with a burst of `AUTH_RATE_LIMIT_BURST`, applied to
-  both `/api/auth/verify-credentials` and `/api/auth/ensure-user`. Runs
+  both `/api/auth/verify-credentials`, `/api/auth/ensure-user`, and `/api/auth/issue`. Runs
   before HMAC verification so anonymous floods are dropped cheaply.
 - **Composite `(ip, email_normalised)`** — in-handler limiter on
   `/api/auth/verify-credentials`. Token-bucket with burst
@@ -496,6 +496,24 @@ a new `(provider, providerSubject)` always creates a fresh user.
 ```json
 { "userId": "abc123", "email": "user@example.com", "role": "member", "created": true }
 ```
+
+#### POST /api/auth/issue
+
+HMAC-gated. Mints the initial `(accessToken, refreshToken)` pair for a user
+just authenticated via `/api/auth/verify-credentials`. Used by the NextAuth
+`jwt` callback on first sign-in so subsequent requests can silent-refresh.
+
+**Request:**
+```json
+{ "userId": "abc123" }
+```
+
+**Response (200):** same shape as `/api/auth/refresh` (`accessToken`,
+`refreshToken`, `expiresAt`).
+
+Returns `401` on HMAC failure, unknown user, disabled user, or soft-deleted
+user (writes a `token_issue_failure` audit event). `400` on empty or
+oversized `userId` (>128 chars).
 
 ### Dev-Only Endpoint
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -87,7 +87,7 @@ RECEIPT_DOWNLOAD_DIR=/tmp/receipts
 RUST_LOG=info
 
 # --- Auth rate limiting (Plan 3 / BE-2) ---
-# Per-IP limiter on /api/auth/verify-credentials and /api/auth/ensure-user.
+# Per-IP limiter on /api/auth/verify-credentials, /api/auth/ensure-user, and /api/auth/issue.
 AUTH_RATE_LIMIT_PER_MINUTE=60
 AUTH_RATE_LIMIT_BURST=10
 
@@ -220,7 +220,7 @@ The service runs two concurrent tasks:
 - Serves HTTP API on port 8080
 - Public read endpoints for groups, members, cycles, and payments
 - Admin write endpoints guarded by RS256 admin JWTs — `SuperAdminUser` for group/WhatsApp-link CRUD, `GroupScopedAdmin` for member/cycle/payment/receipt CRUD
-- HMAC-gated auth endpoints (`/api/auth/verify-credentials`, `/api/auth/ensure-user`) called by NextAuth — signed with `NEXTAUTH_BACKEND_SECRET`
+- HMAC-gated auth endpoints (`/api/auth/verify-credentials`, `/api/auth/ensure-user`, `/api/auth/issue`) called by NextAuth — signed with `NEXTAUTH_BACKEND_SECRET`
 - Dev/test-only `/api/test/reset` endpoint (fail-closed gate on `APP_ENV`)
 - CORS configured based on `APP_ENV`
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -500,8 +500,9 @@ a new `(provider, providerSubject)` always creates a fresh user.
 #### POST /api/auth/issue
 
 HMAC-gated. Mints the initial `(accessToken, refreshToken)` pair for a user
-just authenticated via `/api/auth/verify-credentials`. Used by the NextAuth
-`jwt` callback on first sign-in so subsequent requests can silent-refresh.
+just authenticated via `/api/auth/verify-credentials` (credentials sign-in)
+or `/api/auth/ensure-user` (social sign-in). Used by the NextAuth `jwt`
+callback on first sign-in so subsequent requests can silent-refresh.
 
 **Request:**
 ```json

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -125,7 +125,7 @@ JWT_REFRESH_TTL_SECS=1209600
 
 ### Auth Rate Limiting
 
-Two layers protect the HMAC-gated auth surface:
+Two layers protect the `/api/auth/*` surface (per-IP covers the full sub-router; the composite limiter covers only `verify-credentials`):
 
 - **Per-IP (`tower_governor`)** — a steady quota of `AUTH_RATE_LIMIT_PER_MINUTE`
   requests per minute with a burst of `AUTH_RATE_LIMIT_BURST`, applied to the

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -379,8 +379,10 @@ async fn find_identity(
 // ── issue (initial token pair) ────────────────────────────────────────────────
 
 /// Upper bound on the user-id field accepted by `/api/auth/issue`. Matches the
-/// 128-char cap used on the refresh-token field below so the body-size budget
-/// is symmetric and a single `MAX_REFRESH_BODY_BYTES` covers both handlers.
+/// 128-char cap used on the refresh-token field below to keep the field-level
+/// budget symmetric across both token-minting handlers. The raw body cap for
+/// `/api/auth/issue` is enforced upstream by `HmacVerifiedJson`
+/// (`MAX_BODY_BYTES` = 1 MiB in `auth::hmac`), not by `MAX_REFRESH_BODY_BYTES`.
 const MAX_USER_ID_LEN: usize = 128;
 
 #[derive(Debug, Deserialize)]
@@ -390,8 +392,9 @@ pub struct IssueTokenRequest {
 }
 
 /// Mint the initial `(access_token, refresh_token)` pair for a user that the
-/// NextAuth layer has just authenticated via `/api/auth/verify-credentials`
-/// or `/api/auth/ensure-user`. HMAC-gated at the sub-router so only NextAuth
+/// NextAuth layer has just authenticated — either via
+/// `/api/auth/verify-credentials` (credentials sign-in) or
+/// `/api/auth/ensure-user` (social sign-in). HMAC-gated at the sub-router so only NextAuth
 /// can call it — the `user_id` in the body is server-trusted after the HMAC
 /// check, there is no password re-verification here by design.
 ///
@@ -433,11 +436,32 @@ pub async fn issue_token_endpoint(
         }
         Err(e) => {
             tracing::error!(error = %e, "issue load_user failed");
-            return Err(AppError::Unauthorized);
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                "token_issue_failure",
+                false,
+                Some("db_error"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::Internal("token issue failed".into()));
         }
     };
 
-    if user.status != "active" || user.deleted_at.is_some() {
+    if user.deleted_at.is_some() {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            "token_issue_failure",
+            false,
+            Some("soft_deleted"),
+            Some(&ip),
+        )
+        .await;
+        return Err(AppError::Unauthorized);
+    }
+    if user.status != "active" {
         record_auth_event(
             &db,
             Some(user_id.clone()),

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -394,9 +394,10 @@ pub struct IssueTokenRequest {
 /// Mint the initial `(access_token, refresh_token)` pair for a user that the
 /// NextAuth layer has just authenticated — either via
 /// `/api/auth/verify-credentials` (credentials sign-in) or
-/// `/api/auth/ensure-user` (social sign-in). HMAC-gated at the sub-router so only NextAuth
-/// can call it — the `user_id` in the body is server-trusted after the HMAC
-/// check, there is no password re-verification here by design.
+/// `/api/auth/ensure-user` (social sign-in). HMAC-gated by the
+/// `HmacVerifiedJson` extractor on this handler so only NextAuth can call it —
+/// the `user_id` in the body is server-trusted after the HMAC check, there is
+/// no password re-verification here by design.
 ///
 /// Response shape mirrors `/api/auth/refresh` so the FE can reuse a single
 /// typed client for both the initial issue and subsequent rotations.
@@ -474,17 +475,42 @@ pub async fn issue_token_endpoint(
         return Err(AppError::Unauthorized);
     }
 
-    let issued = refresh::issue(&db, &user_id).await.map_err(|e| {
-        tracing::error!(error = %e, "issue refresh failed");
-        AppError::Internal("token issue failed".into())
-    })?;
-
-    let access = verifier
-        .mint_access(&user_id, &user.role, user.token_version)
-        .map_err(|e| {
+    // Mint the access token *before* persisting a refresh row so a signing
+    // failure (misconfigured keys, etc.) cannot leave an orphan refresh token
+    // in the DB that no client ever received.
+    let access = match verifier.mint_access(&user_id, &user.role, user.token_version) {
+        Ok(a) => a,
+        Err(e) => {
             tracing::error!(error = %e, "mint access on issue failed");
-            AppError::Internal("token issue failed".into())
-        })?;
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                "token_issue_failure",
+                false,
+                Some("mint_access_failed"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::Internal("token issue failed".into()));
+        }
+    };
+
+    let issued = match refresh::issue(&db, &user_id).await {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::error!(error = %e, "issue refresh failed");
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                "token_issue_failure",
+                false,
+                Some("db_error"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::Internal("token issue failed".into()));
+        }
+    };
 
     record_auth_event(&db, Some(user_id), "token_issued", true, None, Some(&ip)).await;
 

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -387,8 +387,8 @@ const MAX_USER_ID_LEN: usize = 128;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct IssueTokenRequest {
-    pub user_id: String,
+pub(crate) struct IssueTokenRequest {
+    pub(crate) user_id: String,
 }
 
 /// Mint the initial `(access_token, refresh_token)` pair for a user that the
@@ -401,7 +401,7 @@ pub struct IssueTokenRequest {
 ///
 /// Response shape mirrors `/api/auth/refresh` so the FE can reuse a single
 /// typed client for both the initial issue and subsequent rotations.
-pub async fn issue_token_endpoint(
+pub(crate) async fn issue_token_endpoint(
     State(db): State<DbConn>,
     Extension(verifier): Extension<SharedVerifier>,
     ClientIp(client_ip): ClientIp,

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -376,6 +376,101 @@ async fn find_identity(
     Ok(rows.into_iter().next())
 }
 
+// ── issue (initial token pair) ────────────────────────────────────────────────
+
+/// Upper bound on the user-id field accepted by `/api/auth/issue`. Matches the
+/// 128-char cap used on the refresh-token field below so the body-size budget
+/// is symmetric and a single `MAX_REFRESH_BODY_BYTES` covers both handlers.
+const MAX_USER_ID_LEN: usize = 128;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueTokenRequest {
+    pub user_id: String,
+}
+
+/// Mint the initial `(access_token, refresh_token)` pair for a user that the
+/// NextAuth layer has just authenticated via `/api/auth/verify-credentials`
+/// or `/api/auth/ensure-user`. HMAC-gated at the sub-router so only NextAuth
+/// can call it — the `user_id` in the body is server-trusted after the HMAC
+/// check, there is no password re-verification here by design.
+///
+/// Response shape mirrors `/api/auth/refresh` so the FE can reuse a single
+/// typed client for both the initial issue and subsequent rotations.
+pub async fn issue_token_endpoint(
+    State(db): State<DbConn>,
+    Extension(verifier): Extension<SharedVerifier>,
+    ClientIp(client_ip): ClientIp,
+    HmacVerifiedJson(req): HmacVerifiedJson<IssueTokenRequest>,
+) -> Result<Json<RefreshResponse>, AppError> {
+    let user_id = req.user_id.trim().to_string();
+    if user_id.is_empty() {
+        return Err(AppError::BadRequest("userId required".into()));
+    }
+    if user_id.len() > MAX_USER_ID_LEN {
+        return Err(AppError::BadRequest("userId too long".into()));
+    }
+
+    let ip = client_ip.to_string();
+
+    // Load fresh — role and token_version are authoritative only at load time.
+    let user = match refresh::load_user(&db, &user_id).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            // Mirror the `/refresh` precedent: write a single failure audit
+            // row for unknown subject so ops can alert on credential-spray
+            // patterns against this endpoint, then 401 uniformly.
+            record_auth_event(
+                &db,
+                None,
+                "token_issue_failure",
+                false,
+                Some("unknown_user"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::Unauthorized);
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "issue load_user failed");
+            return Err(AppError::Unauthorized);
+        }
+    };
+
+    if user.status != "active" || user.deleted_at.is_some() {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            "token_issue_failure",
+            false,
+            Some("disabled"),
+            Some(&ip),
+        )
+        .await;
+        return Err(AppError::Unauthorized);
+    }
+
+    let issued = refresh::issue(&db, &user_id).await.map_err(|e| {
+        tracing::error!(error = %e, "issue refresh failed");
+        AppError::Internal("token issue failed".into())
+    })?;
+
+    let access = verifier
+        .mint_access(&user_id, &user.role, user.token_version)
+        .map_err(|e| {
+            tracing::error!(error = %e, "mint access on issue failed");
+            AppError::Internal("token issue failed".into())
+        })?;
+
+    record_auth_event(&db, Some(user_id), "token_issued", true, None, Some(&ip)).await;
+
+    Ok(Json(RefreshResponse {
+        access_token: access,
+        refresh_token: issued.plaintext,
+        expires_at: issued.expires_at,
+    }))
+}
+
 // ── refresh + logout ──────────────────────────────────────────────────────────
 
 const MAX_REFRESH_TOKEN_LEN: usize = 128;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -69,6 +69,7 @@ pub fn router_with_config(
             post(auth_endpoints::verify_credentials),
         )
         .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user))
+        .route("/api/auth/issue", post(auth_endpoints::issue_token_endpoint))
         .route("/api/auth/refresh", post(auth_endpoints::refresh_token_endpoint))
         .route("/api/auth/logout", post(auth_endpoints::logout_endpoint))
         .layer(rate_limit::build_per_ip_layer(&rate_cfg))

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -915,6 +915,12 @@ async fn issue_soft_deleted_user_returns_401() {
 
     let resp = call(app, issue_req(&user_id)).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let failures =
+        count_auth_events(&db, &user_id, "token_issue_failure").await;
+    assert_eq!(failures, 1);
+    let successes = count_auth_events(&db, &user_id, "token_issued").await;
+    assert_eq!(successes, 0);
 }
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -880,7 +880,9 @@ async fn issue_unknown_user_returns_401_and_writes_failure_event() {
         .unwrap()
         .check()
         .unwrap();
-    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    let rows: Vec<i64> = resp
+        .take("count")
+        .expect("auth_event count query returned unexpected shape");
     assert_eq!(rows.first().copied().unwrap_or(0), 1);
 }
 

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -777,7 +777,9 @@ async fn count_auth_events(
         .unwrap()
         .check()
         .unwrap();
-    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    let rows: Vec<i64> = resp
+        .take("count")
+        .expect("auth_event count query returned unexpected shape");
     rows.first().copied().unwrap_or(0)
 }
 

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -754,6 +754,198 @@ async fn logout_revokes_family_and_always_returns_204() {
     assert_eq!(unknown.status(), StatusCode::NO_CONTENT);
 }
 
+// ── Issue endpoint (Plan 3 / BE-7) ────────────────────────────────────────────
+
+fn issue_req(user_id: &str) -> Request<Body> {
+    let body = serde_json::json!({ "userId": user_id });
+    hmac_request("/api/auth/issue", &body)
+}
+
+async fn count_auth_events(
+    db: &poolpay::db::DbConn,
+    user_id: &str,
+    event_type: &str,
+) -> i64 {
+    let mut resp = db
+        .query(
+            "SELECT count() FROM auth_event \
+             WHERE user_id = $uid AND event_type = $t GROUP ALL",
+        )
+        .bind(("uid", user_id.to_string()))
+        .bind(("t", event_type.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0)
+}
+
+#[tokio::test]
+async fn issue_returns_tokens_that_round_trip_through_refresh() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-issue-1", "issue1@example.com").await;
+
+    let resp = call(app.clone(), issue_req(&user_id)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    let access = v["accessToken"].as_str().unwrap().to_string();
+    let refresh_tok = v["refreshToken"].as_str().unwrap().to_string();
+    let expires_at = v["expiresAt"].as_str().unwrap().to_string();
+    assert!(!access.is_empty());
+    assert!(!refresh_tok.is_empty());
+    // ISO-8601 with timezone — chrono can parse it.
+    assert!(chrono::DateTime::parse_from_rfc3339(&expires_at).is_ok());
+
+    // Round-trip proves the refresh row was persisted correctly.
+    let rotate = call(app, refresh_req(&refresh_tok)).await;
+    assert_eq!(rotate.status(), StatusCode::OK);
+
+    let issued_count = count_auth_events(&db, &user_id, "token_issued").await;
+    assert_eq!(issued_count, 1, "exactly one token_issued row on success");
+}
+
+#[tokio::test]
+async fn issue_access_token_carries_users_token_version() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-issue-tv", "issuetv@example.com").await;
+
+    // Bump the user's token_version so the default 0 isn't incidentally correct.
+    use surrealdb::types::RecordId;
+    db.query("UPDATE $id SET token_version = 9")
+        .bind(("id", RecordId::new("user", user_id.clone())))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+
+    let resp = call(app, issue_req(&user_id)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    let access = v["accessToken"].as_str().unwrap();
+
+    let claims = verifier.verify_access(access).expect("verify");
+    assert_eq!(claims.token_version, 9);
+    assert_eq!(claims.sub, user_id);
+    assert_eq!(claims.role, "member");
+}
+
+#[tokio::test]
+async fn issue_access_token_carries_role_for_super_admin() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+
+    let resp = call(app, issue_req(&admin_id)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    let claims = verifier
+        .verify_access(v["accessToken"].as_str().unwrap())
+        .expect("verify");
+    assert_eq!(claims.role, "super_admin");
+}
+
+#[tokio::test]
+async fn issue_access_token_carries_role_for_admin() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-issue-admin", "issueadmin@example.com").await;
+    set_user_role(&db, &user_id, "admin").await;
+
+    let resp = call(app, issue_req(&user_id)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    let claims = verifier
+        .verify_access(v["accessToken"].as_str().unwrap())
+        .expect("verify");
+    assert_eq!(claims.role, "admin");
+}
+
+#[tokio::test]
+async fn issue_unknown_user_returns_401_and_writes_failure_event() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+
+    let resp = call(app, issue_req("nonexistent-user-id")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    // Unknown user: failure audit row is written with user_id = NONE, so we
+    // cannot filter by user_id — scan for the event_type directly.
+    let mut resp = db
+        .query(
+            "SELECT count() FROM auth_event \
+             WHERE event_type = 'token_issue_failure' \
+               AND reason = 'unknown_user' GROUP ALL",
+        )
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    assert_eq!(rows.first().copied().unwrap_or(0), 1);
+}
+
+#[tokio::test]
+async fn issue_disabled_user_returns_401_and_writes_failure_event() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-issue-dis", "issuedis@example.com").await;
+    set_user_status(&db, &user_id, "disabled").await;
+
+    let resp = call(app, issue_req(&user_id)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let failures =
+        count_auth_events(&db, &user_id, "token_issue_failure").await;
+    assert_eq!(failures, 1);
+    // And no success row was written.
+    let successes = count_auth_events(&db, &user_id, "token_issued").await;
+    assert_eq!(successes, 0);
+}
+
+#[tokio::test]
+async fn issue_soft_deleted_user_returns_401() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-issue-del", "issuedel@example.com").await;
+
+    use surrealdb::types::RecordId;
+    db.query("UPDATE $id SET deleted_at = $n")
+        .bind(("id", RecordId::new("user", user_id.clone())))
+        .bind(("n", poolpay::api::models::now_iso()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+
+    let resp = call(app, issue_req(&user_id)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn issue_without_hmac_headers_returns_401() {
+    let (app, _db, _v) = build_app_full(lax_rate_cfg()).await;
+    let body = serde_json::json!({ "userId": "anything" });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/issue")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn issue_empty_user_id_returns_400() {
+    let (app, _db, _v) = build_app_full(lax_rate_cfg()).await;
+    let resp = call(app, issue_req("")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn issue_oversized_user_id_returns_400() {
+    let (app, _db, _v) = build_app_full(lax_rate_cfg()).await;
+    let huge = "x".repeat(200);
+    let resp = call(app, issue_req(&huge)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 // ── Extractors (Plan 3 / BE-3) ────────────────────────────────────────────────
 
 /// Tiny inline router that exercises the extractors so we can verify their


### PR DESCRIPTION
## Summary
- New HMAC-gated `POST /api/auth/issue` endpoint that mints the initial `(accessToken, refreshToken)` pair for a user who has just passed `verify-credentials`. Closes the chicken-and-egg so the FE never has to call `/refresh` with a fabricated token on first sign-in.
- Writes `token_issued` / `token_issue_failure` audit events; uniform 401 on HMAC failure / unknown / disabled / soft-deleted users.
- Integration-test coverage for happy path, all failure modes, and audit-log writes (10 tests).

## Plan 3 — BE-7
This is a new increment inserted ahead of the existing audit/change-password work (which shifts to BE-8; Cognito shifts to BE-9). Plan doc and auth API contract updated in the Digital Brain wiki.

## Test plan
- [x] `cargo test` — 254 passing (244 + 10 new)
- [x] Happy path: token pair round-trips through `/refresh`
- [x] Access token carries current `role` and `token_version`
- [x] Unknown / disabled / soft-deleted user → 401 + `token_issue_failure` audit event
- [x] Missing HMAC → 401
- [x] Empty / oversized `userId` → 400