### PR TITLE
[DOCS] - Note FE REFRESH_SKEW_SECS coupling on JWT_ACCESS_TTL_SECS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,9 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # JWT_ISSUER=poolpay-nextauth
 
 # Access-token lifetime in seconds. Short on purpose — refresh rotates.
+# Keep comfortably above 360: the FE proactively rotates at 360s remaining
+# (poolpay-app auth.ts REFRESH_SKEW_SECS) and any TTL ≤ 360 causes every
+# jwt() callback to hit /api/auth/refresh.
 # JWT_ACCESS_TTL_SECS=900
 
 # Clock-skew tolerance when validating exp/nbf/iat.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -177,8 +177,8 @@ wires NextAuth to call this surface; today the extractors ride behind
   Short on purpose: `token_version` bumps on role changes and refresh
   reuse detection take effect within this window. Keep comfortably above
   360; the FE proactively refreshes at 360s remaining (see poolpay-app
-  `auth.ts` `REFRESH_SKEW_SECS`) and a shorter TTL causes every session
-  read to hit `/api/auth/refresh`.
+  `auth.ts` `REFRESH_SKEW_SECS`), and a TTL at or below 360s causes every
+  session read to hit `/api/auth/refresh`.
 - **`JWT_LEEWAY_SECS`** — clock-skew tolerance for exp/nbf/iat. Default 60.
 - **`JWT_REFRESH_TTL_SECS`** — refresh-token lifetime. Default 1209600 (14 days).
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -175,7 +175,10 @@ wires NextAuth to call this surface; today the extractors ride behind
   is a hard 401 with no body hint.
 - **`JWT_ACCESS_TTL_SECS`** — access-token lifetime. Default 900 (15 min).
   Short on purpose: `token_version` bumps on role changes and refresh
-  reuse detection take effect within this window.
+  reuse detection take effect within this window. Keep comfortably above
+  360; the FE proactively refreshes at 360s remaining (see poolpay-app
+  `auth.ts` `REFRESH_SKEW_SECS`) and a shorter TTL causes every session
+  read to hit `/api/auth/refresh`.
 - **`JWT_LEEWAY_SECS`** — clock-skew tolerance for exp/nbf/iat. Default 60.
 - **`JWT_REFRESH_TTL_SECS`** — refresh-token lifetime. Default 1209600 (14 days).
 

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -139,6 +139,10 @@ impl JwtConfig {
                 .unwrap_or_else(|_| "poolpay-api".to_string()),
             issuer: std::env::var("JWT_ISSUER")
                 .unwrap_or_else(|_| "poolpay-nextauth".to_string()),
+            // FE-side silent-refresh window is 360s (poolpay-app `auth.ts`
+            // REFRESH_SKEW_SECS) — the FE proactively rotates when a token has
+            // ≤360s of life left. Values at or below 360 cause the FE to refresh
+            // on every jwt() callback — keep this well above 360 (default 900 is fine).
             access_ttl_secs: std::env::var("JWT_ACCESS_TTL_SECS")
                 .ok()
                 .and_then(|s| s.parse::<i64>().ok())


### PR DESCRIPTION
## Summary
Leave a load-bearing note in three places so a future dev can't shrink `JWT_ACCESS_TTL_SECS` at or below 360 without understanding the blast radius.

## Why
FE-2 (poolpay-app PR #22) landed silent-refresh inside NextAuth's `jwt()` callback with `REFRESH_SKEW_SECS = 360` — the FE proactively rotates when a token has ≤360s of life left. If `JWT_ACCESS_TTL_SECS` drops to 360 or below, every `jwt()` call triggers a refresh round-trip: wasted DB writes, wasted mints, and hot-loop risk if anything goes wrong on the refresh path.

## Where the note lives
- `src/auth/jwt.rs` — next to the env parse
- `.env.example` — above the `JWT_ACCESS_TTL_SECS` line
- `docs/RUNBOOK.md` — appended to the `JWT_ACCESS_TTL_SECS` description

No behaviour change. `cargo check` clean.

## Test plan
- [x] `cargo check` passes — no behaviour change, pure comments/docs