### PR TITLE
[FEAT] - BE-8 PR 1: populate receipt/payment audit columns

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -647,6 +647,8 @@ pub async fn create_payment(
         created_at: now.clone(),
         updated_at: now,
         deleted_at: None,
+        rejected_by: None,
+        deleted_by: None,
     };
 
     let db_payment: Option<DbPayment> = db.create("payment").content(content).await?;
@@ -668,7 +670,7 @@ pub async fn delete_payment(
     // return an opaque 403 to non-super-admins to avoid leaking which
     // cycle ids exist across groups.
     let cycle: Option<DbCycle> = db.select(("cycle", cycle_id.as_str())).await?;
-    let _auth = GroupScopedAdmin::ensure_or_deny(
+    let auth = GroupScopedAdmin::ensure_or_deny(
         user,
         cycle.as_ref().map(|c| c.group_id.as_str()),
         &db,
@@ -705,6 +707,8 @@ pub async fn delete_payment(
             created_at: row.created_at,
             updated_at: now.clone(),
             deleted_at: Some(now.clone()),
+            rejected_by: row.rejected_by,
+            deleted_by: Some(auth.0.user_id.clone()),
         };
         let _: Option<DbPayment> = db.upsert(("payment", id.as_str())).content(content).await?;
     }
@@ -720,7 +724,13 @@ async fn load_active_receipt_opt(db: &DbConn, id: &str) -> Result<Option<DbRecei
     Ok(row.filter(|r| r.deleted_at.is_none()))
 }
 
-fn receipt_content_from(row: &DbReceipt, status: &str, updated_at: String) -> ReceiptContent {
+fn receipt_content_from(
+    row: &DbReceipt,
+    status: &str,
+    updated_at: String,
+    confirmed_by: Option<String>,
+    rejected_by: Option<String>,
+) -> ReceiptContent {
     ReceiptContent {
         whatsapp_message_id: row.whatsapp_message_id.clone(),
         group_id: row.group_id.clone(),
@@ -739,6 +749,9 @@ fn receipt_content_from(row: &DbReceipt, status: &str, updated_at: String) -> Re
         created_at: row.created_at.clone(),
         updated_at,
         deleted_at: row.deleted_at.clone(),
+        confirmed_by,
+        rejected_by,
+        deleted_by: row.deleted_by.clone(),
     }
 }
 
@@ -748,7 +761,7 @@ pub async fn confirm_receipt(
     Path(id): Path<EntityId>,
 ) -> Result<Json<Receipt>, AppError> {
     let receipt = load_active_receipt_opt(&db, id.as_str()).await?;
-    let _auth = GroupScopedAdmin::ensure_or_deny(
+    let auth = GroupScopedAdmin::ensure_or_deny(
         user,
         receipt.as_ref().map(|r| r.group_id.as_str()),
         &db,
@@ -823,6 +836,7 @@ pub async fn confirm_receipt(
             ))
         })?;
 
+    let actor_id = auth.0.user_id.clone();
     let payment_content = PaymentContent {
         member_id: member_id.clone(),
         cycle_id: cycle_id.clone(),
@@ -832,16 +846,24 @@ pub async fn confirm_receipt(
         payment_method: Some("whatsapp_receipt".into()),
         reference: Some(receipt.whatsapp_message_id.clone()),
         confirmed_at: Some(now.clone()),
-        confirmed_by: None,
+        confirmed_by: Some(actor_id.clone()),
         created_at: now.clone(),
         updated_at: now.clone(),
         deleted_at: None,
+        rejected_by: None,
+        deleted_by: None,
     };
 
     let created: Option<DbPayment> = db.create("payment").content(payment_content).await?;
     created.ok_or_else(|| AppError::Internal("payment was not created".into()))?;
 
-    let content = receipt_content_from(&receipt, "confirmed", now);
+    let content = receipt_content_from(
+        &receipt,
+        "confirmed",
+        now,
+        Some(actor_id),
+        receipt.rejected_by.clone(),
+    );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;
 
@@ -854,7 +876,7 @@ pub async fn reject_receipt(
     Path(id): Path<EntityId>,
 ) -> Result<Json<Receipt>, AppError> {
     let receipt = load_active_receipt_opt(&db, id.as_str()).await?;
-    let _auth = GroupScopedAdmin::ensure_or_deny(
+    let auth = GroupScopedAdmin::ensure_or_deny(
         user,
         receipt.as_ref().map(|r| r.group_id.as_str()),
         &db,
@@ -870,7 +892,13 @@ pub async fn reject_receipt(
         )));
     }
 
-    let content = receipt_content_from(&receipt, "rejected", now_iso());
+    let content = receipt_content_from(
+        &receipt,
+        "rejected",
+        now_iso(),
+        receipt.confirmed_by.clone(),
+        Some(auth.0.user_id.clone()),
+    );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;
 

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -241,6 +241,9 @@ pub struct DbReceipt {
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
+    pub confirmed_by: Option<String>,
+    pub rejected_by: Option<String>,
+    pub deleted_by: Option<String>,
 }
 
 #[derive(Debug, Deserialize, SurrealValue)]
@@ -268,6 +271,8 @@ pub struct DbPayment {
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
+    pub rejected_by: Option<String>,
+    pub deleted_by: Option<String>,
 }
 
 // ── API response structs (serialized to JSON for the frontend) ──────────────
@@ -364,6 +369,10 @@ pub struct Payment {
     pub updated_at: String,
     #[serde(rename = "deletedAt", skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<String>,
+    #[serde(rename = "rejectedBy", skip_serializing_if = "Option::is_none")]
+    pub rejected_by: Option<String>,
+    #[serde(rename = "deletedBy", skip_serializing_if = "Option::is_none")]
+    pub deleted_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -402,6 +411,12 @@ pub struct Receipt {
     pub updated_at: String,
     #[serde(rename = "deletedAt", skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<String>,
+    #[serde(rename = "confirmedBy", skip_serializing_if = "Option::is_none")]
+    pub confirmed_by: Option<String>,
+    #[serde(rename = "rejectedBy", skip_serializing_if = "Option::is_none")]
+    pub rejected_by: Option<String>,
+    #[serde(rename = "deletedBy", skip_serializing_if = "Option::is_none")]
+    pub deleted_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -504,6 +519,8 @@ impl TryFrom<DbPayment> for Payment {
             created_at: db.created_at,
             updated_at: db.updated_at,
             deleted_at: db.deleted_at,
+            rejected_by: db.rejected_by,
+            deleted_by: db.deleted_by,
         })
     }
 }
@@ -530,6 +547,9 @@ impl TryFrom<DbReceipt> for Receipt {
             created_at: db.created_at,
             updated_at: db.updated_at,
             deleted_at: db.deleted_at,
+            confirmed_by: db.confirmed_by,
+            rejected_by: db.rejected_by,
+            deleted_by: db.deleted_by,
         })
     }
 }
@@ -605,6 +625,8 @@ pub struct PaymentContent {
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
+    pub rejected_by: Option<String>,
+    pub deleted_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, SurrealValue)]
@@ -626,6 +648,9 @@ pub struct ReceiptContent {
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
+    pub confirmed_by: Option<String>,
+    pub rejected_by: Option<String>,
+    pub deleted_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, SurrealValue)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -324,6 +324,7 @@ fn fixture_payments() -> Vec<(&'static str, PaymentContent)> {
         payment_method: None, reference: None,
         confirmed_at: None, confirmed_by: None,
         created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None,
+        rejected_by: None, deleted_by: None,
     };
     vec![
         // Cycle 3 — March 2026 (Ngozi excluded as recipient; 3 of 5 contributing paid)
@@ -415,6 +416,9 @@ fn fixture_receipts() -> Vec<(&'static str, ReceiptContent)> {
                 created_at: created_at.into(),
                 updated_at: created_at.into(),
                 deleted_at: None,
+                confirmed_by: None,
+                rejected_by: None,
+                deleted_by: None,
             },
         ),
         (
@@ -437,6 +441,9 @@ fn fixture_receipts() -> Vec<(&'static str, ReceiptContent)> {
                 created_at: "2026-03-03T14:15:30+00:00".into(),
                 updated_at: "2026-03-03T16:00:00+00:00".into(),
                 deleted_at: Some("2026-03-03T16:00:00+00:00".into()),
+                confirmed_by: None,
+                rejected_by: None,
+                deleted_by: None,
             },
         ),
     ]

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -115,6 +115,9 @@ pub async fn ingest_receipt(
         created_at: now.clone(),
         updated_at: now,
         deleted_at: None,
+        confirmed_by: None,
+        rejected_by: None,
+        deleted_by: None,
     };
 
     // `create` returns the inserted row(s) so we can surface the generated id.

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -60,6 +60,13 @@ async fn test_app() -> Router {
 /// `OnceLock` keeps `set_var` to a single mutation per process; `env_lock()`
 /// serialises that mutation against every other env writer in this binary.
 async fn test_app_with_auth() -> Router {
+    test_app_with_auth_and_db().await.0
+}
+
+/// Same setup as `test_app_with_auth`, but also returns the shared `DbConn`
+/// so tests can inspect rows the public API hides (e.g. soft-deleted
+/// payments that get filtered out of `/api/payments`).
+async fn test_app_with_auth_and_db() -> (Router, db::DbConn) {
     static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     INIT.get_or_init(|| {
         let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -71,7 +78,8 @@ async fn test_app_with_auth() -> Router {
     });
     let conn = db::init_memory().await.expect("failed to init test DB");
     seed_test_admin_users(&conn).await;
-    api::router(conn)
+    let router = api::router(conn.clone());
+    (router, conn)
 }
 
 const TEST_SUPER_ADMIN_SUB: &str = "test-super-admin";
@@ -1268,6 +1276,32 @@ async fn delete_payment_soft_deletes_record() {
 }
 
 #[tokio::test]
+async fn delete_payment_populates_deleted_by() {
+    // The public list filters soft-deleted rows out, so reach into the DB
+    // directly to confirm the audit column was populated from the caller's
+    // JWT subject.
+    use poolpay::api::models::DbPayment;
+
+    let (app, conn) = test_app_with_auth_and_db().await;
+    let resp = call(app, delete_req_jwt("/api/payments/1/3")).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let rows: Vec<DbPayment> = conn
+        .query("SELECT * FROM payment WHERE member_id = $mid AND cycle_id = $cid")
+        .bind(("mid", "1".to_string()))
+        .bind(("cid", "3".to_string()))
+        .await
+        .expect("select payment")
+        .take(0)
+        .expect("decode payments");
+    let deleted = rows
+        .into_iter()
+        .find(|p| p.deleted_at.is_some())
+        .expect("soft-deleted payment row should exist");
+    assert_eq!(deleted.deleted_by.as_deref(), Some(TEST_SUPER_ADMIN_SUB));
+}
+
+#[tokio::test]
 async fn delete_payment_unknown_member_returns_404() {
     let app = test_app_with_auth().await;
     let resp = call(app, delete_req_jwt("/api/payments/999/3")).await;
@@ -1792,6 +1826,8 @@ async fn confirm_receipt_marks_status_and_creates_payment() {
     let updated: serde_json::Value = json_body(resp).await;
     assert_eq!(updated["status"], "confirmed");
     assert_eq!(updated["id"], "1");
+    // Audit: the confirming admin is recorded on the receipt row itself.
+    assert_eq!(updated["confirmedBy"], TEST_SUPER_ADMIN_SUB);
 
     let payments_after: Vec<serde_json::Value> =
         json_body(call(app, get("/api/payments")).await).await;
@@ -1806,6 +1842,8 @@ async fn confirm_receipt_marks_status_and_creates_payment() {
     assert_eq!(new_payment["amount"], 1_000_000);
     assert_eq!(new_payment["currency"], "NGN");
     assert!(new_payment["confirmedAt"].is_string());
+    // Audit: same admin is attributed on the payment created from the receipt.
+    assert_eq!(new_payment["confirmedBy"], TEST_SUPER_ADMIN_SUB);
 }
 
 #[tokio::test]
@@ -1867,6 +1905,8 @@ async fn reject_receipt_marks_status_and_creates_no_payment() {
     assert_eq!(resp.status(), StatusCode::OK);
     let updated: serde_json::Value = json_body(resp).await;
     assert_eq!(updated["status"], "rejected");
+    // Audit: rejecting admin is recorded so later reviewers can attribute the decision.
+    assert_eq!(updated["rejectedBy"], TEST_SUPER_ADMIN_SUB);
 
     let payments_after: Vec<serde_json::Value> =
         json_body(call(app, get("/api/payments")).await).await;


### PR DESCRIPTION
## Summary
- Extend `DbReceipt` / `ReceiptContent` / `Receipt` and `DbPayment` / `PaymentContent` / `Payment` with `confirmed_by`, `rejected_by`, `deleted_by` (plus the matching camelCase JSON on the response types, `skip_serializing_if=Option::is_none`).
- Wire `AuthenticatedUser.user_id` into `confirm_receipt`, `reject_receipt`, and `delete_payment` so every status-changing write stamps an actor.
- Tables are SCHEMALESS — no DDL migration; pre-existing rows serialise the new columns as `None`.

First of four TDD-split PRs carved off [[be-8-implementation-plan]]. No new routes; no `auth_event` writes on business rows (plan decision 5).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (all 255 tests green)
- [x] Extended `confirm_receipt_marks_status_and_creates_payment` and `reject_receipt_marks_status_and_creates_no_payment` to assert JWT-subject stamps on the updated row.
- [x] Added `delete_payment_populates_deleted_by` which selects the soft-deleted row directly and asserts `deleted_by` matches the caller.