### PR TITLE
[FEAT] - BE-8 PR 2: POST /api/auth/change-password

### DIFF
--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -19,12 +19,14 @@ use crate::api::models::{
     AppError, AuthEventContent, DbAuthEvent, DbUser, DbUserIdentity, UserContent,
     UserIdentityContent, now_iso, record_id_to_string,
 };
+use crate::auth::extractors::AuthenticatedUser;
 use crate::auth::hmac::HmacVerifiedJson;
 use crate::auth::jwt::SharedVerifier;
 use crate::auth::password;
 use crate::auth::rate_limit::{ClientIp, CredentialFailureLimiter};
 use crate::auth::refresh::{self, RefreshError};
 use crate::db::DbConn;
+use surrealdb::types::RecordId;
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
 
@@ -349,6 +351,155 @@ async fn create_social_user(
     let created: Option<DbUser> = db.create("user").content(content).await?;
     let created = created.ok_or_else(|| AppError::Internal("user insert returned none".into()))?;
     Ok((record_id_to_string(created.id), created.email, created.role))
+}
+
+// ── change-password ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangePasswordRequest {
+    #[serde(default)]
+    pub current_password: Option<String>,
+    pub new_password: String,
+}
+
+/// Bearer-authenticated password change. Two branches keyed on whether the
+/// user currently has a credentials hash:
+///
+/// * **Change** (hash present): requires `currentPassword`, verifies it,
+///   rotates the hash, bumps `token_version`, and revokes every live
+///   refresh token for the user so any sibling session dies — the classic
+///   re-auth trigger after a credential rotation.
+/// * **Set** (hash is `None`): a social-only user adding a password as a
+///   second sign-in method. Accepts without `currentPassword`, inserts a
+///   `credentials` identity row, bumps `token_version`. Does NOT revoke
+///   refresh tokens: this is additive, not a re-auth event.
+///
+/// Returns `204 No Content` on success. Mounted outside the HMAC
+/// sub-router so `AuthenticatedUser` is the sole gate — per-IP limiting
+/// is not doubled-charged against already-authenticated callers.
+pub async fn change_password(
+    user: AuthenticatedUser,
+    State(db): State<DbConn>,
+    ClientIp(client_ip): ClientIp,
+    Json(req): Json<ChangePasswordRequest>,
+) -> Result<axum::http::StatusCode, AppError> {
+    if req.new_password.is_empty() {
+        return Err(AppError::BadRequest("newPassword required".into()));
+    }
+    if req.new_password.len() > MAX_PASSWORD_LEN {
+        return Err(AppError::BadRequest("newPassword too long".into()));
+    }
+
+    let db_user = find_user_by_id(&db, &user.user_id)
+        .await?
+        .ok_or_else(|| AppError::Internal("authenticated user not found".into()))?;
+
+    let ip = client_ip.to_string();
+    let new_hash = password::hash(&req.new_password)?;
+    let now = now_iso();
+
+    match db_user.password_hash.as_deref() {
+        Some(existing_hash) => {
+            // Change path: verify current then rotate. Every failure path
+            // writes an audit row before returning so brute-force probes are
+            // observable even when the client keeps receiving 401s.
+            let Some(current) = req.current_password.as_deref() else {
+                return Err(AppError::BadRequest(
+                    "currentPassword required to change an existing password".into(),
+                ));
+            };
+            if !password::verify(current, existing_hash)? {
+                record_auth_event(
+                    &db,
+                    Some(user.user_id.clone()),
+                    "password_change_failure",
+                    false,
+                    Some("bad_current"),
+                    Some(&ip),
+                )
+                .await;
+                return Err(AppError::Unauthorized);
+            }
+
+            update_password_hash(&db, &user.user_id, Some(&new_hash), &now).await?;
+            refresh::bump_token_version(&db, &user.user_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("token_version bump failed: {e}")))?;
+            refresh::revoke_all_for_user(&db, &user.user_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("refresh revoke failed: {e}")))?;
+
+            record_auth_event(
+                &db,
+                Some(user.user_id),
+                "password_changed",
+                true,
+                None,
+                Some(&ip),
+            )
+            .await;
+        }
+        None => {
+            // Set path: social user adding a credentials identity. No
+            // currentPassword required by design (there is none to verify).
+            update_password_hash(&db, &user.user_id, Some(&new_hash), &now).await?;
+
+            let identity = UserIdentityContent {
+                user_id: user.user_id.clone(),
+                provider: CREDENTIALS_PROVIDER.into(),
+                provider_subject: db_user.email_normalised.clone(),
+                email_at_link: db_user.email.clone(),
+                created_at: now.clone(),
+            };
+            match db
+                .create::<Option<DbUserIdentity>>("user_identity")
+                .content(identity)
+                .await
+            {
+                Ok(_) => {}
+                Err(err) if is_unique_constraint_error(&err.to_string()) => {
+                    // A prior set attempt already inserted the identity —
+                    // rotating the hash alone is the correct idempotent
+                    // outcome, no error to surface.
+                }
+                Err(err) => return Err(err.into()),
+            }
+
+            refresh::bump_token_version(&db, &user.user_id)
+                .await
+                .map_err(|e| AppError::Internal(format!("token_version bump failed: {e}")))?;
+
+            record_auth_event(
+                &db,
+                Some(user.user_id),
+                "password_changed",
+                true,
+                Some("set"),
+                Some(&ip),
+            )
+            .await;
+        }
+    }
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+async fn update_password_hash(
+    db: &DbConn,
+    user_id: &str,
+    new_hash: Option<&str>,
+    now_rfc3339: &str,
+) -> Result<(), AppError> {
+    db.query(
+        "UPDATE $id SET password_hash = $h, must_reset_password = false, updated_at = $now",
+    )
+    .bind(("id", RecordId::new("user", user_id.to_string())))
+    .bind(("h", new_hash.map(str::to_string)))
+    .bind(("now", now_rfc3339.to_string()))
+    .await?
+    .check()?;
+    Ok(())
 }
 
 // ── DB helpers ────────────────────────────────────────────────────────────────

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -363,6 +363,12 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
+// Two bounded string fields (each capped at `MAX_PASSWORD_LEN` = 1 KiB) plus
+// JSON framing comfortably fit inside 4 KiB. Bound the buffer before
+// deserialisation so an authenticated caller cannot force the server to hold
+// an arbitrarily large body in memory just because the route is bearer-gated.
+const MAX_CHANGE_PASSWORD_BODY_BYTES: usize = 4 * 1024;
+
 /// Bearer-authenticated password change. Two branches keyed on whether the
 /// user currently has a credentials hash:
 ///
@@ -382,8 +388,16 @@ pub async fn change_password(
     user: AuthenticatedUser,
     State(db): State<DbConn>,
     ClientIp(client_ip): ClientIp,
-    Json(req): Json<ChangePasswordRequest>,
+    http_req: Request,
 ) -> Result<axum::http::StatusCode, AppError> {
+    // Cap the body before deserialising so a malicious authenticated caller
+    // cannot buffer a multi-MB payload behind the bearer gate.
+    let body = to_bytes(http_req.into_body(), MAX_CHANGE_PASSWORD_BODY_BYTES)
+        .await
+        .map_err(|_| AppError::BadRequest("request body too large".into()))?;
+    let req: ChangePasswordRequest =
+        serde_json::from_slice(&body).map_err(|_| AppError::BadRequest("invalid JSON body".into()))?;
+
     if req.new_password.is_empty() {
         return Err(AppError::BadRequest("newPassword required".into()));
     }
@@ -396,7 +410,6 @@ pub async fn change_password(
         .ok_or_else(|| AppError::Internal("authenticated user not found".into()))?;
 
     let ip = client_ip.to_string();
-    let new_hash = password::hash(&req.new_password)?;
     let now = now_iso();
 
     match db_user.password_hash.as_deref() {
@@ -422,6 +435,11 @@ pub async fn change_password(
                 return Err(AppError::Unauthorized);
             }
 
+            // Only hash the new password once the current one is verified —
+            // keeps Argon2 CPU off the failure path so bad-currentPassword
+            // probes cannot be used as a DoS amplifier.
+            let new_hash = password::hash(&req.new_password)?;
+
             update_password_hash(&db, &user.user_id, Some(&new_hash), &now).await?;
             refresh::bump_token_version(&db, &user.user_id)
                 .await
@@ -443,8 +461,11 @@ pub async fn change_password(
         None => {
             // Set path: social user adding a credentials identity. No
             // currentPassword required by design (there is none to verify).
-            update_password_hash(&db, &user.user_id, Some(&new_hash), &now).await?;
-
+            //
+            // Insert the identity row *before* touching `password_hash` so a
+            // transient DB failure on the identity write cannot leave the
+            // user with a hash but no credentials identity — which would make
+            // `/api/auth/verify-credentials` unable to locate them by email.
             let identity = UserIdentityContent {
                 user_id: user.user_id.clone(),
                 provider: CREDENTIALS_PROVIDER.into(),
@@ -465,6 +486,9 @@ pub async fn change_password(
                 }
                 Err(err) => return Err(err.into()),
             }
+
+            let new_hash = password::hash(&req.new_password)?;
+            update_password_hash(&db, &user.user_id, Some(&new_hash), &now).await?;
 
             refresh::bump_token_version(&db, &user.user_id)
                 .await

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -405,18 +405,23 @@ pub async fn change_password(
         return Err(AppError::BadRequest("newPassword too long".into()));
     }
 
+    // `AuthenticatedUser` already proved the user exists when this request was
+    // extracted. If the row is missing here the session is effectively invalid
+    // (hard-deleted between extraction and handler), so fall back to 401
+    // rather than leaking a 500 for what is really an auth failure.
     let db_user = find_user_by_id(&db, &user.user_id)
         .await?
-        .ok_or_else(|| AppError::Internal("authenticated user not found".into()))?;
+        .ok_or(AppError::Unauthorized)?;
 
     let ip = client_ip.to_string();
     let now = now_iso();
 
     match db_user.password_hash.as_deref() {
         Some(existing_hash) => {
-            // Change path: verify current then rotate. Every failure path
-            // writes an audit row before returning so brute-force probes are
-            // observable even when the client keeps receiving 401s.
+            // Change path: verify current then rotate. Bad-current-password
+            // failures write an audit row before returning 401 so brute-force
+            // probes remain observable (shape-level 400s from missing fields
+            // or policy violations are intentionally not audited).
             let Some(current) = req.current_password.as_deref() else {
                 return Err(AppError::BadRequest(
                     "currentPassword required to change an existing password".into(),
@@ -480,9 +485,33 @@ pub async fn change_password(
             {
                 Ok(_) => {}
                 Err(err) if is_unique_constraint_error(&err.to_string()) => {
-                    // A prior set attempt already inserted the identity —
-                    // rotating the hash alone is the correct idempotent
-                    // outcome, no error to surface.
+                    // UNIQUE here is idempotent only if the existing
+                    // credentials identity already belongs to this user.
+                    // `user.email_normalised` is not unique across users, so
+                    // the conflicting row may belong to a different account
+                    // that already linked credentials for this email. In that
+                    // case, rotating the hash on this user would leave them
+                    // with a password hash but no credentials identity while
+                    // `/api/auth/verify-credentials` continues to resolve the
+                    // email to the other account — refuse instead.
+                    let existing =
+                        find_identity(&db, CREDENTIALS_PROVIDER, &db_user.email_normalised)
+                            .await?
+                            .ok_or_else(|| {
+                                AppError::Internal(
+                                    "credentials identity insert reported a unique conflict, \
+                                     but no existing identity could be loaded"
+                                        .into(),
+                                )
+                            })?;
+                    if existing.user_id != user.user_id {
+                        return Err(AppError::Conflict(
+                            "email already has credentials on another account".into(),
+                        ));
+                    }
+                    // Same user — prior set attempt already inserted the
+                    // identity, so rotating the hash below is the correct
+                    // idempotent outcome.
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -363,11 +363,14 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
-// Two bounded string fields (each capped at `MAX_PASSWORD_LEN` = 1 KiB) plus
-// JSON framing comfortably fit inside 4 KiB. Bound the buffer before
-// deserialisation so an authenticated caller cannot force the server to hold
-// an arbitrarily large body in memory just because the route is bearer-gated.
-const MAX_CHANGE_PASSWORD_BODY_BYTES: usize = 4 * 1024;
+// Two bounded string fields (each capped at `MAX_PASSWORD_LEN` = 1 KiB) can
+// still exceed 4 KiB once encoded as JSON because `\` and `"` are escaped —
+// each of those characters doubles on the wire, so a fully-escaped password
+// roughly doubles its per-field length. Allow enough room for two fully
+// escaped passwords plus JSON object/key framing while still bounding the
+// buffer before deserialisation, so a bearer-authenticated caller cannot
+// force the server to buffer an arbitrarily large body.
+const MAX_CHANGE_PASSWORD_BODY_BYTES: usize = 5 * 1024;
 
 /// Bearer-authenticated password change. Two branches keyed on whether the
 /// user currently has a credentials hash:

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -104,6 +104,14 @@ pub fn router_with_config(
         .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
         .route("/api/admin/whatsapp-links", post(create_whatsapp_link))
         .route("/api/admin/whatsapp-links/{id}", delete(delete_whatsapp_link))
+        // Bearer-authenticated auth endpoints. Change-password is gated by
+        // the `AuthenticatedUser` extractor — mounting it on the unrestricted
+        // router avoids double-charging tower-governor's per-IP bucket for
+        // callers who already hold a valid JWT.
+        .route(
+            "/api/auth/change-password",
+            post(auth_endpoints::change_password),
+        )
         // Auth endpoints (rate-limited; verify-credentials/ensure-user are
         // HMAC-gated, refresh/logout authenticate via the refresh token itself)
         // are merged below

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -128,7 +128,17 @@ pub fn router_with_config(
     // The verifier is injected as a request Extension so every handler
     // (including the auth extractors landing in BE-5) can reach it without
     // forcing a state-type migration on the existing DbConn-state router.
-    router.layer(cors).layer(Extension(verifier)).with_state(db)
+    //
+    // `RateLimitConfig` is also layered at the top level (without the
+    // tower-governor layer) so the `ClientIp` extractor used by bearer-gated
+    // handlers like `change_password` picks up the injected config instead of
+    // falling back to `RateLimitConfig::from_env` — otherwise tests and any
+    // non-env configuration would key IP resolution on the wrong flags.
+    router
+        .layer(cors)
+        .layer(Extension(verifier))
+        .layer(Extension(rate_cfg))
+        .with_state(db)
 }
 
 fn build_cors() -> CorsLayer {

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -196,6 +196,21 @@ pub async fn revoke_family(db: &DbConn, family_id: &str) -> Result<(), RefreshEr
     Ok(())
 }
 
+/// Revoke every live refresh token owned by `user_id`, across all families.
+/// Used when a security-relevant event (password change, role downgrade,
+/// soft-delete) must terminate every active session for the user. Pairs
+/// with a `token_version` bump so in-flight access tokens die within one
+/// access-TTL and holders of old refresh tokens cannot mint replacements.
+pub async fn revoke_all_for_user(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
+    let now = now_iso();
+    db.query("UPDATE refresh_token SET revoked_at = $now WHERE user_id = $uid AND revoked_at IS NONE")
+        .bind(("now", now))
+        .bind(("uid", user_id.to_string()))
+        .await?
+        .check()?;
+    Ok(())
+}
+
 /// Revoke the family of a presented refresh token. Used by `/api/auth/logout`.
 /// Returns the `user_id` so the caller can audit under the right subject.
 pub async fn revoke_by_presented(
@@ -234,7 +249,11 @@ async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) {
     }
 }
 
-async fn bump_token_version(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
+/// Atomically increment a user's `token_version` and stamp `updated_at`.
+/// Any in-flight access token minted against the previous version will be
+/// rejected by `AuthenticatedUser` on its next load. Callers that also
+/// need to kill refresh tokens should pair this with `revoke_all_for_user`.
+pub async fn bump_token_version(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
     db.query("UPDATE $id SET token_version = token_version + 1, updated_at = $now")
         .bind(("id", RecordId::new("user", user_id.to_string())))
         .bind(("now", now_iso()))

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1462,3 +1462,51 @@ async fn change_password_writes_password_changed_auth_event() {
     let after = count_auth_events(&db, &admin_id, "password_changed").await;
     assert_eq!(after, before + 1, "expected exactly one password_changed event");
 }
+
+/// `user.email_normalised` is intentionally non-unique, so two social users
+/// can share an email. Only one of them may own the
+/// (`provider='credentials'`, `provider_subject=email_normalised`) identity —
+/// the second user attempting to set a password must be refused with 409,
+/// and critically must not end up with a `password_hash` that lets them pass
+/// `/api/auth/verify-credentials` even though the credentials identity is
+/// resolved to a *different* account.
+#[tokio::test]
+async fn change_password_set_path_refuses_when_another_user_owns_credentials_identity() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+
+    let shared_email = "shared-credentials@example.com";
+    let user_a = seed_member(&app, "sub-shared-a", shared_email).await;
+    let user_b = seed_member(&app, "sub-shared-b", shared_email).await;
+    assert_ne!(user_a, user_b, "distinct providerSubjects must produce distinct users");
+
+    // User A sets a password first — this inserts the single credentials
+    // identity row for `shared_email`.
+    let access_a = verifier.mint_access(&user_a, "member", 0).expect("mint");
+    let body_a = serde_json::json!({ "newPassword": "owner-password" });
+    let resp_a = call(app.clone(), change_password_req(&access_a, &body_a)).await;
+    assert_eq!(resp_a.status(), StatusCode::NO_CONTENT);
+
+    // User B now tries to set a password for the same email — the credentials
+    // identity already exists and belongs to someone else.
+    let access_b = verifier.mint_access(&user_b, "member", 0).expect("mint");
+    let body_b = serde_json::json!({ "newPassword": "interloper-password" });
+    let resp_b = call(app.clone(), change_password_req(&access_b, &body_b)).await;
+    assert_eq!(resp_b.status(), StatusCode::CONFLICT);
+
+    // User B must NOT have a password hash — otherwise future refactors could
+    // silently let B authenticate through credentials even though the
+    // identity resolves to A.
+    assert!(
+        user_password_hash(&db, &user_b).await.is_none(),
+        "conflicting set attempt must not write a password_hash for the losing user"
+    );
+
+    // The owning user's password must still work via verify-credentials —
+    // the identity row was not rewired.
+    let verify_body = serde_json::json!({
+        "email": shared_email,
+        "password": "owner-password",
+    });
+    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    assert_eq!(verify_resp.status(), StatusCode::OK);
+}

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1186,3 +1186,279 @@ fn argon2_hash_is_phc_formatted() {
     assert!(h.starts_with("$argon2id$"), "expected PHC format, got: {h}");
     assert!(password::verify("some password", &h).unwrap());
 }
+
+// ── Change-password (Plan 3 / BE-8 PR 2) ─────────────────────────────────────
+
+fn change_password_req(token: &str, body: &serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/change-password")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap()
+}
+
+async fn user_password_hash(db: &poolpay::db::DbConn, user_id: &str) -> Option<String> {
+    use surrealdb::types::RecordId;
+    let mut resp = db
+        .query("SELECT password_hash FROM $id")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<Option<String>> = resp.take("password_hash").unwrap_or_default();
+    rows.into_iter().next().flatten()
+}
+
+async fn user_must_reset_password(db: &poolpay::db::DbConn, user_id: &str) -> bool {
+    use surrealdb::types::RecordId;
+    let mut resp = db
+        .query("SELECT must_reset_password FROM $id")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<bool> = resp.take("must_reset_password").unwrap_or_default();
+    rows.into_iter().next().unwrap_or(false)
+}
+
+async fn credentials_identity_exists(db: &poolpay::db::DbConn, email_normalised: &str) -> bool {
+    let mut resp = db
+        .query(
+            "SELECT count() FROM user_identity \
+             WHERE provider = 'credentials' AND provider_subject = $e GROUP ALL",
+        )
+        .bind(("e", email_normalised.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0) > 0
+}
+
+#[tokio::test]
+async fn change_password_rotates_hash_bumps_token_version_and_clears_must_reset() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let version_before = user_token_version(&db, &admin_id).await;
+    let hash_before = user_password_hash(&db, &admin_id)
+        .await
+        .expect("bootstrap admin must have a hash");
+    assert!(user_must_reset_password(&db, &admin_id).await);
+
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": "brand-new-secret-passphrase",
+    });
+    let resp = call(app.clone(), change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let version_after = user_token_version(&db, &admin_id).await;
+    assert!(
+        version_after > version_before,
+        "change_password must bump token_version: before={version_before} after={version_after}"
+    );
+
+    let hash_after = user_password_hash(&db, &admin_id)
+        .await
+        .expect("hash must still be set after change");
+    assert_ne!(hash_after, hash_before, "password hash must rotate");
+
+    assert!(
+        !user_must_reset_password(&db, &admin_id).await,
+        "must_reset_password should clear on successful change"
+    );
+
+    // Old bearer now rejects — token_version bump invalidates in-flight access.
+    let replay = call(app.clone(), change_password_req(&access, &body)).await;
+    assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+
+    // New password verifies via the public credentials endpoint.
+    let verify_body = serde_json::json!({
+        "email": BOOTSTRAP_EMAIL,
+        "password": "brand-new-secret-passphrase",
+    });
+    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    assert_eq!(verify_resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn change_password_wrong_current_returns_401_and_does_not_mutate() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let hash_before = user_password_hash(&db, &admin_id).await;
+    let version_before = user_token_version(&db, &admin_id).await;
+
+    let body = serde_json::json!({
+        "currentPassword": "this-is-not-the-real-password",
+        "newPassword": "some-new-password",
+    });
+    let resp = call(app, change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    assert_eq!(user_password_hash(&db, &admin_id).await, hash_before);
+    assert_eq!(user_token_version(&db, &admin_id).await, version_before);
+}
+
+#[tokio::test]
+async fn change_password_missing_current_when_hash_exists_returns_400() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({ "newPassword": "some-new-password" });
+    let resp = call(app, change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn change_password_rejects_empty_new_password() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": "",
+    });
+    let resp = call(app, change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn change_password_rejects_oversized_new_password() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let huge = "a".repeat(1025);
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": huge,
+    });
+    let resp = call(app, change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn change_password_sets_hash_for_social_upgrade_without_current_password() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-change-social", "social1@example.com").await;
+    let access = verifier.mint_access(&user_id, "member", 0).expect("mint");
+
+    assert!(user_password_hash(&db, &user_id).await.is_none());
+    assert!(
+        !credentials_identity_exists(&db, "social1@example.com").await,
+        "social user must not have a credentials identity before upgrade"
+    );
+
+    let body = serde_json::json!({ "newPassword": "first-time-password-set" });
+    let resp = call(app.clone(), change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    assert!(user_password_hash(&db, &user_id).await.is_some());
+    assert!(
+        credentials_identity_exists(&db, "social1@example.com").await,
+        "set path must insert a credentials user_identity row"
+    );
+
+    // Verify-credentials now works with the new password + the user's email.
+    let verify_body = serde_json::json!({
+        "email": "social1@example.com",
+        "password": "first-time-password-set",
+    });
+    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    assert_eq!(verify_resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn change_password_revokes_refresh_tokens_on_change() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    // Issue a refresh token before the password change.
+    let issued = refresh::issue(&db, &admin_id).await.expect("issue");
+
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": "rotation-secret-passphrase",
+    });
+    let resp = call(app.clone(), change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Pre-existing refresh token must now be dead.
+    let after = call(app, refresh_req(&issued.plaintext)).await;
+    assert_eq!(after.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn change_password_does_not_revoke_refresh_tokens_on_set_path() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let user_id = seed_member(&app, "sub-change-set", "set1@example.com").await;
+    let access = verifier.mint_access(&user_id, "member", 0).expect("mint");
+
+    let issued = refresh::issue(&db, &user_id).await.expect("issue");
+
+    let body = serde_json::json!({ "newPassword": "set-path-password" });
+    let resp = call(app.clone(), change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Set path is a social upgrade, not a re-auth trigger — refresh stays live.
+    let after = call(app, refresh_req(&issued.plaintext)).await;
+    assert_eq!(after.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn change_password_without_bearer_returns_401() {
+    let (app, _db, _v) = build_app_full(lax_rate_cfg()).await;
+    let body = serde_json::json!({ "newPassword": "whatever" });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/change-password")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn change_password_writes_password_changed_auth_event() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let admin_id = bootstrap_admin_id(&db).await;
+    let access = verifier
+        .mint_access(&admin_id, "super_admin", 0)
+        .expect("mint");
+
+    let before = count_auth_events(&db, &admin_id, "password_changed").await;
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": "audit-trail-passphrase",
+    });
+    let resp = call(app, change_password_req(&access, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let after = count_auth_events(&db, &admin_id, "password_changed").await;
+    assert_eq!(after, before + 1, "expected exactly one password_changed event");
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/auth/change-password` — bearer-authenticated, branches on whether the user already has a `password_hash`
- Change path (hash exists): verifies `currentPassword`, rotates hash, bumps `token_version`, revokes **all live refresh tokens** for the user, writes `auth_event{password_changed}`
- Set path (hash is NULL, e.g. social-only user upgrading): accepts without `currentPassword`, rotates hash, inserts `user_identity{provider:"credentials"}`, bumps `token_version`, does **not** revoke refresh tokens; `auth_event{password_changed, reason:"set"}`
- Mounted on the unrestricted router (outside the HMAC sub-router) — the `AuthenticatedUser` extractor is the sole gate, avoiding double-charging tower-governor's per-IP bucket for callers already holding a valid JWT

## Why refresh tokens are revoked only on the change path
`refresh::rotate` only checks `user.status` + `user.deleted_at` — it does not verify `token_version`. Without explicit revocation, an attacker holding a stolen refresh token could keep minting access tokens after the legitimate user changed their password. The set path has no compromise scenario (no prior password existed), so refresh tokens are preserved to avoid logging the user out of other devices.

## Commits
- `f15679a [REFACTOR] - Promote token_version + refresh revocation helpers` — promotes `bump_token_version` to `pub`, adds `revoke_all_for_user`
- `8ccc088 [FEAT] - Add POST /api/auth/change-password endpoint` — endpoint + 10 tests

## Test plan
- [x] `cargo check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 265/265 passing (up from 255; +10 new)
- [x] rotates_hash_bumps_token_version_and_clears_must_reset
- [x] wrong_current_returns_401_and_does_not_mutate
- [x] missing_current_when_hash_exists_returns_400
- [x] rejects_empty_new_password
- [x] rejects_oversized_new_password (> MAX_PASSWORD_LEN)
- [x] sets_hash_for_social_upgrade_without_current_password
- [x] revokes_refresh_tokens_on_change
- [x] does_not_revoke_refresh_tokens_on_set_path
- [x] without_bearer_returns_401
- [x] writes_password_changed_auth_event