### PR TITLE
[BE-8 PR 4] Group-admin grants

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -466,7 +466,7 @@ Returns `204 No Content`.
 
 ### Admin User Management
 
-All routes under `/api/admin/users` require `role: super_admin` on the caller's access token. Mutations that change role, status, or scope bump the target's `token_version`, which invalidates in-flight access tokens within one TTL.
+All routes under `/api/admin/users` require the caller to be a `super_admin`, enforced from the caller's persisted DB role rather than the JWT `role` claim — the access token is only trusted for `sub` and `token_version`. Mutations only invalidate in-flight access tokens when they explicitly bump the target's `token_version`: `PATCH` bumps on role or status change, `DELETE` always bumps, `revoke` bumps (scope shrinks), and `grant` does not (scope grows, existing tokens already fail the group-scope check).
 
 #### POST /api/admin/users
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -464,6 +464,75 @@ Soft-delete all payments for a member in a cycle. Requires admin auth.
 
 Returns `204 No Content`.
 
+### Admin User Management
+
+All routes under `/api/admin/users` require `role: super_admin` on the caller's access token. Mutations that change role, status, or scope bump the target's `token_version`, which invalidates in-flight access tokens within one TTL.
+
+#### POST /api/admin/users
+
+Provision a new admin-tier user (role must be `admin` or `super_admin`). Member users are minted via the social/credentials sign-in path, not this surface. `mustResetPassword` is forced to `true` on the new row so the user is pushed onto the change-password flow on first login.
+
+**Request:**
+```json
+{
+  "email": "new-admin@example.com",
+  "initialPassword": "temporary-strong-passphrase",
+  "role": "admin"
+}
+```
+
+Returns `201 Created` with the user record. `409 Conflict` if the email is already in use (both the pre-check and the post-insert UNIQUE race paths collapse to 409).
+
+#### PATCH /api/admin/users/{id}
+
+Flip `role` and/or `status` on an existing user. Requires `version` for optimistic concurrency. Self-mutation is refused (`403`) — another super-admin must act.
+
+**Request:**
+```json
+{
+  "role": "super_admin",
+  "status": "active",
+  "version": 3
+}
+```
+
+Both `role` and `status` are optional; at least one field should change for the patch to be meaningful (a no-op still bumps `version` but not `token_version`). Status transitions `active ↔ disabled`; `disabled` revokes every live refresh token for the target and emits `user_disabled`. `active` (re-enable) emits `user_enabled`. Role changes emit `role_changed` with the `before -> after` transition as the reason.
+
+Returns `409 Conflict` on version mismatch or on a concurrent update between SELECT and guarded UPDATE.
+
+#### DELETE /api/admin/users/{id}
+
+Soft-delete (sets `deleted_at`, bumps `token_version`, revokes every refresh token). Self-delete is refused (`403`). The user row and all grants persist for audit. Replaying a delete on an already-deleted row returns `404`.
+
+Returns `204 No Content`.
+
+#### POST /api/admin/users/{id}/groups/{group_id}
+
+Grant `admin`-role user scope over one group. A row in `group_admin` is the RBAC primitive the group-scope extractor looks up — super-admins bypass the extractor, so granting on a super-admin returns `409`. Granting on a member also returns `409` (grants are admin-tier only). Target must be active.
+
+Path-only — no request body. Returns `201 Created`:
+
+```json
+{
+  "userId": "abc123",
+  "groupId": "xyz789",
+  "createdAt": "2026-04-22T01:45:00Z",
+  "createdBy": "super-admin-id"
+}
+```
+
+`404` if the target user or group does not exist (or is soft-deleted). `409` if the grant already exists (duplicate `(user_id, group_id)`), if the target is disabled, or if the target role is not `admin`.
+
+Audit: `group_admin_granted` row with `actor_id = caller`, `user_id = target`, `reason = "group:<group_id>"`.
+
+#### DELETE /api/admin/users/{id}/groups/{group_id}
+
+Revoke a previously-issued grant. Two-part mutation: drops the `group_admin` row and bumps the target's `token_version` so in-flight access tokens re-verify on the next call (scope shrank, so cached tokens would otherwise let the user act on the revoked group for up to one access-token TTL). Refresh tokens intentionally survive — the target still has a valid session, they just lost scope on this group.
+
+Returns `204 No Content`. `404` if no matching grant exists (including replay after a successful revoke) — the handler does not silently swallow missing rows because an out-of-band manual revoke is exactly the signal ops should see.
+
+Audit: `group_admin_revoked` row with `actor_id = caller`, `user_id = target`, `reason = "group:<group_id>"`.
+
 ### HMAC-Gated Auth Endpoints (NextAuth)
 
 All requests must carry `x-timestamp` (unix seconds, within ±60s) and

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -30,8 +30,8 @@ use serde::{Deserialize, Serialize};
 use surrealdb::types::RecordId;
 
 use crate::api::models::{
-    AppError, DbUser, DbUserIdentity, EntityId, UserContent, UserIdentityContent, now_iso,
-    record_id_to_string,
+    AppError, DbGroup, DbGroupAdmin, DbUser, DbUserIdentity, EntityId, GroupAdminContent,
+    UserContent, UserIdentityContent, now_iso, record_id_to_string,
 };
 use crate::auth::audit::record_auth_event;
 use crate::auth::extractors::SuperAdminUser;
@@ -592,5 +592,114 @@ async fn rollback_user(db: &DbConn, user_id: &str) {
             "rollback_user failed after identity insert error — orphan user row"
         );
     }
+}
+
+// ── POST /api/admin/users/:id/groups/:group_id (BE-8 PR 4) ────────────────────
+
+/// Response echoed on successful grant. Small on purpose — the grant
+/// is fully identified by the path, and the audit row carries the
+/// canonical record. The response exists mainly so the client can
+/// confirm `createdBy` and `createdAt` without a follow-up read.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupAdminGrantResponse {
+    pub user_id: String,
+    pub group_id: String,
+    pub created_at: String,
+    pub created_by: String,
+}
+
+/// Super-admin grants one `admin`-role user access to one group.
+///
+/// Granting to a `super_admin` returns 409 — super-admins bypass the
+/// group-scope extractor entirely (see `src/auth/extractors.rs`), so
+/// the row would be dead weight. Granting to a `member` also returns
+/// 409: group-admin rows are the admin-tier scope primitive, not a
+/// membership indicator, and a member row here would silently widen
+/// RBAC if the user were later promoted. Granting on a disabled or
+/// soft-deleted user returns 409 / 404 for the same reason — the
+/// target must be a live admin to receive scope.
+///
+/// Duplicate grants collide on the `group_admin(user_id, group_id)`
+/// unique index and surface as 409 so a retry is safely idempotent.
+/// The `group_admin_granted` audit row records the caller as
+/// `actor_id` and the target as `user_id` so incident review can
+/// answer "who granted scope on this group to this admin?" later.
+pub async fn grant_group_admin(
+    SuperAdminUser(caller): SuperAdminUser,
+    State(db): State<DbConn>,
+    ClientIp(client_ip): ClientIp,
+    Path((user_id, group_id)): Path<(EntityId, EntityId)>,
+) -> Result<(StatusCode, Json<GroupAdminGrantResponse>), AppError> {
+    let user: Option<DbUser> = db.select(("user", user_id.as_str())).await?;
+    let user = user
+        .filter(|u| u.deleted_at.is_none())
+        .ok_or_else(|| AppError::NotFound(format!("user {user_id} does not exist")))?;
+
+    if user.status != "active" {
+        return Err(AppError::Conflict(format!(
+            "user {user_id} is not active (status: {})",
+            user.status
+        )));
+    }
+    if user.role != "admin" {
+        return Err(AppError::Conflict(format!(
+            "group-admin grants only apply to admin-role users (target role: {})",
+            user.role
+        )));
+    }
+
+    let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
+    group
+        .filter(|g| g.deleted_at.is_none())
+        .ok_or_else(|| AppError::NotFound(format!("group {group_id} does not exist")))?;
+
+    let now = now_iso();
+    let content = GroupAdminContent {
+        user_id: user_id.clone(),
+        group_id: group_id.clone(),
+        created_at: now.clone(),
+        created_by: caller.user_id.clone(),
+    };
+    let insert: Result<Option<DbGroupAdmin>, _> =
+        db.create("group_admin").content(content).await;
+    match insert {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Err(AppError::Internal(
+                "group_admin insert returned no row".into(),
+            ));
+        }
+        Err(e) => {
+            if is_unique_constraint_error(&e.to_string()) {
+                return Err(AppError::Conflict(format!(
+                    "user {user_id} already has group-admin on group {group_id}"
+                )));
+            }
+            return Err(e.into());
+        }
+    }
+
+    let ip = client_ip.to_string();
+    record_auth_event(
+        &db,
+        Some(user_id.clone()),
+        Some(caller.user_id.clone()),
+        "group_admin_granted",
+        true,
+        Some(&format!("group:{group_id}")),
+        Some(&ip),
+    )
+    .await;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(GroupAdminGrantResponse {
+            user_id,
+            group_id,
+            created_at: now,
+            created_by: caller.user_id,
+        }),
+    ))
 }
 

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -703,3 +703,81 @@ pub async fn grant_group_admin(
     ))
 }
 
+// ── DELETE /api/admin/users/:id/groups/:group_id (BE-8 PR 4) ──────────────────
+
+/// Super-admin revokes a group-admin grant previously issued on this
+/// target user. The mutation is two-part: remove the `group_admin`
+/// row, then bump the target's `token_version`.
+///
+/// The token-version bump is load-bearing. Scope shrank — any
+/// in-flight access token the target still holds would otherwise let
+/// them act on the newly-revoked group for up to one access-token
+/// TTL. Bumping forces re-verification against the fresh DB state
+/// on the next call. This endpoint does **not** revoke refresh
+/// tokens; the user still has a valid session, they just can't
+/// operate on this group anymore.
+///
+/// Returns 404 if no matching grant exists — the deletion is
+/// idempotent from the caller's perspective but the handler doesn't
+/// silently swallow unknown rows, because a missing row in the audit
+/// trail later would be the signature of an out-of-band manual
+/// revoke that ops should see, not something we paper over here.
+pub async fn revoke_group_admin(
+    SuperAdminUser(caller): SuperAdminUser,
+    State(db): State<DbConn>,
+    ClientIp(client_ip): ClientIp,
+    Path((user_id, group_id)): Path<(EntityId, EntityId)>,
+) -> Result<StatusCode, AppError> {
+    // Delete the join row via a guarded query so we can distinguish
+    // "row did not exist" (→ 404) from a permission/connectivity
+    // failure. `DELETE ... RETURN BEFORE` echoes the matched rows so
+    // `rows.is_empty()` is the unambiguous 404 signal.
+    let mut resp = db
+        .query(
+            "DELETE FROM group_admin \
+             WHERE user_id = $uid AND group_id = $gid \
+             RETURN BEFORE",
+        )
+        .bind(("uid", user_id.clone()))
+        .bind(("gid", group_id.clone()))
+        .await?
+        .check()?;
+    let deleted: Vec<DbGroupAdmin> = resp.take(0)?;
+    if deleted.is_empty() {
+        return Err(AppError::NotFound(format!(
+            "user {user_id} has no group-admin grant on group {group_id}"
+        )));
+    }
+
+    // Bump target's `token_version` so in-flight access tokens
+    // reject on the next verify cycle. The bump is relative to the
+    // current DB value (not a stale snapshot) so a concurrent
+    // refresh-reuse detection or PATCH role change cannot be
+    // clobbered into a lower counter.
+    let _ = db
+        .query(
+            "UPDATE $id SET \
+                 token_version = token_version + 1, \
+                 updated_at = $now \
+             WHERE deleted_at IS NONE",
+        )
+        .bind(("id", RecordId::new("user", user_id.clone())))
+        .bind(("now", now_iso()))
+        .await?
+        .check()?;
+
+    let ip = client_ip.to_string();
+    record_auth_event(
+        &db,
+        Some(user_id.clone()),
+        Some(caller.user_id.clone()),
+        "group_admin_revoked",
+        true,
+        Some(&format!("group:{group_id}")),
+        Some(&ip),
+    )
+    .await;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -112,6 +112,10 @@ pub fn router_with_config(
         .route("/api/admin/users", post(admin_users::create_admin_user))
         .route("/api/admin/users/{id}", patch(admin_users::update_admin_user))
         .route("/api/admin/users/{id}", delete(admin_users::delete_admin_user))
+        .route(
+            "/api/admin/users/{id}/groups/{group_id}",
+            post(admin_users::grant_group_admin),
+        )
         // Bearer-authenticated auth endpoints. Change-password is gated by
         // the `AuthenticatedUser` extractor — mounting it on the unrestricted
         // router avoids double-charging tower-governor's per-IP bucket for

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -116,6 +116,10 @@ pub fn router_with_config(
             "/api/admin/users/{id}/groups/{group_id}",
             post(admin_users::grant_group_admin),
         )
+        .route(
+            "/api/admin/users/{id}/groups/{group_id}",
+            delete(admin_users::revoke_group_admin),
+        )
         // Bearer-authenticated auth endpoints. Change-password is gated by
         // the `AuthenticatedUser` extractor — mounting it on the unrestricted
         // router avoids double-charging tower-governor's per-IP bucket for

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2470,3 +2470,175 @@ async fn grant_group_admin_duplicate_returns_409() {
     );
 }
 
+fn group_admin_delete_req(user_id: &str, group_id: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::DELETE)
+        .uri(format!("/api/admin/users/{user_id}/groups/{group_id}"))
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[tokio::test]
+async fn revoke_group_admin_happy_path_returns_204_and_removes_row() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "revoke-hp@example.com", "admin").await;
+    seed_test_group(&db, "revoke-hp-group").await;
+
+    let grant = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "revoke-hp-group", &super_token),
+    )
+    .await;
+    assert_eq!(grant.status(), StatusCode::CREATED);
+
+    let resp = call(
+        app,
+        group_admin_delete_req(&target_id, "revoke-hp-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    assert_eq!(
+        count_group_admin_rows(&db, &target_id, "revoke-hp-group").await,
+        0
+    );
+    assert_eq!(
+        count_auth_events(&db, &target_id, "group_admin_revoked").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn revoke_group_admin_bumps_target_token_version() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "revoke-tv@example.com", "admin").await;
+    seed_test_group(&db, "revoke-tv-group").await;
+
+    let grant = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "revoke-tv-group", &super_token),
+    )
+    .await;
+    assert_eq!(grant.status(), StatusCode::CREATED);
+
+    let tv_before = user_token_version(&db, &target_id).await;
+
+    let resp = call(
+        app,
+        group_admin_delete_req(&target_id, "revoke-tv-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let tv_after = user_token_version(&db, &target_id).await;
+    assert!(
+        tv_after > tv_before,
+        "revoke must bump target's token_version: before={tv_before} after={tv_after}"
+    );
+}
+
+#[tokio::test]
+async fn revoke_group_admin_without_bearer_returns_401() {
+    let (app, db, _verifier) = build_app_full(lax_rate_cfg()).await;
+    seed_test_group(&db, "revoke-no-bearer").await;
+
+    let resp = call(
+        app,
+        Request::builder()
+            .method(Method::DELETE)
+            .uri("/api/admin/users/any/groups/revoke-no-bearer")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn revoke_group_admin_rejects_non_super_admin_with_403() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "revoke-forbid@example.com", "admin").await;
+    let admin_token = verifier.mint_access(&target_id, "admin", 0).expect("mint");
+    seed_test_group(&db, "revoke-forbid-group").await;
+    let grant = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "revoke-forbid-group", &super_token),
+    )
+    .await;
+    assert_eq!(grant.status(), StatusCode::CREATED);
+
+    let resp = call(
+        app,
+        group_admin_delete_req(&target_id, "revoke-forbid-group", &admin_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // Grant must still exist — the 403 exited before the delete query.
+    assert_eq!(
+        count_group_admin_rows(&db, &target_id, "revoke-forbid-group").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn revoke_group_admin_unknown_grant_returns_404() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "revoke-unknown@example.com", "admin").await;
+
+    let resp = call(
+        app,
+        group_admin_delete_req(&target_id, "never-granted-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn revoke_group_admin_replay_after_success_returns_404() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "revoke-replay@example.com", "admin").await;
+    seed_test_group(&db, "revoke-replay-group").await;
+    let grant = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "revoke-replay-group", &super_token),
+    )
+    .await;
+    assert_eq!(grant.status(), StatusCode::CREATED);
+
+    let first = call(
+        app.clone(),
+        group_admin_delete_req(&target_id, "revoke-replay-group", &super_token),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+
+    let second = call(
+        app,
+        group_admin_delete_req(&target_id, "revoke-replay-group", &super_token),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}
+

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2228,3 +2228,245 @@ async fn delete_admin_user_rejects_non_super_admin_with_403() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
+// ── Group-admin grants (Plan 3 / BE-8 PR 4) ──────────────────────────────────
+
+fn group_admin_post_req(user_id: &str, group_id: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(format!("/api/admin/users/{user_id}/groups/{group_id}"))
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn seed_test_group(db: &poolpay::db::DbConn, id: &str) {
+    let now = poolpay::api::models::now_iso();
+    db.upsert::<Option<poolpay::api::models::DbGroup>>(("group", id.to_string()))
+        .content(poolpay::api::models::GroupContent {
+            name: format!("Test group {id}"),
+            status: "active".into(),
+            description: None,
+            created_at: now.clone(),
+            updated_at: now,
+            deleted_at: None,
+            version: 1,
+        })
+        .await
+        .expect("seed group")
+        .expect("group row returned");
+}
+
+async fn count_group_admin_rows(
+    db: &poolpay::db::DbConn,
+    user_id: &str,
+    group_id: &str,
+) -> i64 {
+    let mut resp = db
+        .query(
+            "SELECT count() FROM group_admin \
+             WHERE user_id = $uid AND group_id = $gid GROUP ALL",
+        )
+        .bind(("uid", user_id.to_string()))
+        .bind(("gid", group_id.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0)
+}
+
+#[tokio::test]
+async fn grant_group_admin_happy_path_returns_201_and_inserts_row() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-hp@example.com", "admin").await;
+    seed_test_group(&db, "grant-hp-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&target_id, "grant-hp-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["userId"], target_id);
+    assert_eq!(v["groupId"], "grant-hp-group");
+    assert_eq!(v["createdBy"], super_id);
+    assert!(v["createdAt"].as_str().is_some());
+
+    assert_eq!(
+        count_group_admin_rows(&db, &target_id, "grant-hp-group").await,
+        1
+    );
+    assert_eq!(
+        count_auth_events(&db, &target_id, "group_admin_granted").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn grant_group_admin_without_bearer_returns_401() {
+    let (app, db, _verifier) = build_app_full(lax_rate_cfg()).await;
+    seed_test_group(&db, "grant-no-bearer").await;
+
+    let resp = call(
+        app,
+        Request::builder()
+            .method(Method::POST)
+            .uri("/api/admin/users/any-user/groups/grant-no-bearer")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn grant_group_admin_rejects_non_super_admin_with_403() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-forbid@example.com", "admin").await;
+    let admin_token = verifier.mint_access(&target_id, "admin", 0).expect("mint");
+    seed_test_group(&db, "grant-forbid-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&target_id, "grant-forbid-group", &admin_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn grant_group_admin_on_unknown_user_returns_404() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    seed_test_group(&db, "grant-unknown-user-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req("ghost-user", "grant-unknown-user-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn grant_group_admin_on_disabled_user_returns_409() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-disabled@example.com", "admin").await;
+    set_user_status(&db, &target_id, "disabled").await;
+    seed_test_group(&db, "grant-disabled-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&target_id, "grant-disabled-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        count_group_admin_rows(&db, &target_id, "grant-disabled-group").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn grant_group_admin_on_super_admin_target_returns_409() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) = seed_admin_user(
+        &app,
+        &super_token,
+        "grant-super@example.com",
+        "super_admin",
+    )
+    .await;
+    seed_test_group(&db, "grant-super-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&target_id, "grant-super-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn grant_group_admin_on_member_target_returns_409() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let member_id = seed_member(&app, "sub-grant-member", "grant-member@example.com").await;
+    seed_test_group(&db, "grant-member-group").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&member_id, "grant-member-group", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn grant_group_admin_on_unknown_group_returns_404() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-ghost-group@example.com", "admin").await;
+
+    let resp = call(
+        app,
+        group_admin_post_req(&target_id, "ghost-group-id", &super_token),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn grant_group_admin_duplicate_returns_409() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-dup@example.com", "admin").await;
+    seed_test_group(&db, "grant-dup-group").await;
+
+    let first = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "grant-dup-group", &super_token),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let second = call(
+        app,
+        group_admin_post_req(&target_id, "grant-dup-group", &super_token),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+
+    assert_eq!(
+        count_group_admin_rows(&db, &target_id, "grant-dup-group").await,
+        1
+    );
+}
+


### PR DESCRIPTION
## Summary

Final PR in the BE-8 track. Adds the group-admin grant/revoke surface so super-admins can hand scope over a group to an admin-role user — a row in `group_admin(user_id, group_id)` is the RBAC primitive the group-scope extractor already checks (see `src/auth/extractors.rs`).

## Endpoints

### POST /api/admin/users/{id}/groups/{group_id}
- Path-only, no body. Returns 201 with `{ userId, groupId, createdAt, createdBy }`.
- Guards: target must exist (404), be active (409 if disabled), hold role `admin` (409 on `super_admin` target — bypass path makes the row dead weight — and 409 on `member` target — grants are admin-tier only).
- 409 on duplicate via the `(user_id, group_id)` unique index.
- Audit: `group_admin_granted` with `actor_id = caller`, `user_id = target`.

### DELETE /api/admin/users/{id}/groups/{group_id}
- Drops the `group_admin` row and **bumps the target's `token_version`** — scope shrank, so cached access tokens would otherwise let them act on the revoked group for up to one access-token TTL.
- Refresh tokens intentionally survive (session still valid, just scope narrower).
- 404 on unknown grant (including replay after successful revoke) — the handler does not swallow missing rows because an out-of-band manual revoke is exactly the signal ops should see.
- Audit: `group_admin_revoked` with `actor_id = caller`, `user_id = target`.

## Commits

1. `[FEAT] - Add group-admin grant endpoint` — POST handler + route wiring + 9 integration tests.
2. `[FEAT] - Add group-admin revoke endpoint` — DELETE handler + route wiring + 6 integration tests (happy path, 401, 403, token_version bump, unknown grant → 404, replay → 404).
3. `[DOCS] - Document admin-user management endpoints` — backfill the whole admin-user surface in RUNBOOK (create/patch/delete/grant/revoke). PR 3 and PR 3.5 shipped without docs; this captures all five endpoints in one pass.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 310 tests pass across all suites (295 before + 15 new)
- [x] Grant tests: happy path, 401 (no bearer), 403 (admin caller), 404 (unknown user), 404 (unknown group), 409 (disabled target), 409 (super_admin target), 409 (member target), 409 (duplicate)
- [x] Revoke tests: happy path, token_version bump assertion, 401, 403, 404 (unknown grant), 404 (replay after success)
- [ ] Manual: grant, confirm admin can now POST to a group-scoped route; revoke, confirm cached access token is rejected on the next call (token_version drift)

## Parent plan

Closes the final sub-piece of [[plan-3-auth-rbac]] §BE-8. FE-6 (change-password page) and FE-7 (admin dashboard) are now fully unblocked on the BE side.