### PR TITLE
BE-8 PR 4.5: Harden group-admin grant/revoke audit + token kick

### DIFF
--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -750,23 +750,54 @@ pub async fn revoke_group_admin(
     }
 
     // Bump target's `token_version` so in-flight access tokens
-    // reject on the next verify cycle. The bump is relative to the
-    // current DB value (not a stale snapshot) so a concurrent
-    // refresh-reuse detection or PATCH role change cannot be
-    // clobbered into a lower counter.
-    let _ = db
+    // reject on the next verify cycle. Relative to the current DB
+    // value (not a stale snapshot) so a concurrent refresh-reuse
+    // detection or PATCH role change cannot be clobbered into a
+    // lower counter.
+    //
+    // Revoke is a two-step mutation — the `group_admin` row is
+    // already gone when this runs. A bump failure here means scope
+    // was dropped but in-flight JWTs still hold it until the
+    // access-token TTL expires: audit the partial outcome and
+    // surface 500 so operators can retry, rather than hide the
+    // inconsistency behind a 204. Mirrors the partial-failure
+    // handling in `update_admin_user` / `delete_admin_user` when a
+    // refresh-revoke step fails after a status commit.
+    //
+    // The bump is unconditional — no `deleted_at IS NONE` guard.
+    // If the user row is soft-deleted, the DELETE path has already
+    // bumped `token_version`, so a further bump here is idempotent
+    // from a security standpoint. If the row was hard-deleted
+    // out-of-band, the UPDATE matches zero rows and the query
+    // still returns Ok — acceptable, since there is no live
+    // session to invalidate anyway.
+    let ip = client_ip.to_string();
+    let bump = db
         .query(
             "UPDATE $id SET \
                  token_version = token_version + 1, \
-                 updated_at = $now \
-             WHERE deleted_at IS NONE",
+                 updated_at = $now",
         )
         .bind(("id", RecordId::new("user", user_id.clone())))
         .bind(("now", now_iso()))
-        .await?
-        .check()?;
+        .await
+        .and_then(|r| r.check().map(|_| ()));
+    if let Err(e) = bump {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_revoked",
+            false,
+            Some("token_version_bump_failed"),
+            Some(&ip),
+        )
+        .await;
+        return Err(AppError::Internal(format!(
+            "token_version bump failed after group_admin revoke: {e}"
+        )));
+    }
 
-    let ip = client_ip.to_string();
     record_auth_event(
         &db,
         Some(user_id.clone()),

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -631,18 +631,60 @@ pub async fn grant_group_admin(
     ClientIp(client_ip): ClientIp,
     Path((user_id, group_id)): Path<(EntityId, EntityId)>,
 ) -> Result<(StatusCode, Json<GroupAdminGrantResponse>), AppError> {
+    // `ip` is bound up-front so each failure branch can emit a
+    // `success: false` audit row — incident review should see
+    // rejected grant attempts with the same attribution fidelity
+    // as successful ones (mirrors the `create_admin_user` flow
+    // added in PR 3.5).
+    let ip = client_ip.to_string();
+
     let user: Option<DbUser> = db.select(("user", user_id.as_str())).await?;
-    let user = user
-        .filter(|u| u.deleted_at.is_none())
-        .ok_or_else(|| AppError::NotFound(format!("user {user_id} does not exist")))?;
+    let user = match user.filter(|u| u.deleted_at.is_none()) {
+        Some(u) => u,
+        None => {
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                Some(caller.user_id.clone()),
+                "group_admin_granted",
+                false,
+                Some("unknown_user"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::NotFound(format!(
+                "user {user_id} does not exist"
+            )));
+        }
+    };
 
     if user.status != "active" {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_granted",
+            false,
+            Some("target_not_active"),
+            Some(&ip),
+        )
+        .await;
         return Err(AppError::Conflict(format!(
             "user {user_id} is not active (status: {})",
             user.status
         )));
     }
     if user.role != "admin" {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_granted",
+            false,
+            Some("target_not_admin"),
+            Some(&ip),
+        )
+        .await;
         return Err(AppError::Conflict(format!(
             "group-admin grants only apply to admin-role users (target role: {})",
             user.role
@@ -650,9 +692,21 @@ pub async fn grant_group_admin(
     }
 
     let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
-    group
-        .filter(|g| g.deleted_at.is_none())
-        .ok_or_else(|| AppError::NotFound(format!("group {group_id} does not exist")))?;
+    if group.filter(|g| g.deleted_at.is_none()).is_none() {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_granted",
+            false,
+            Some("unknown_group"),
+            Some(&ip),
+        )
+        .await;
+        return Err(AppError::NotFound(format!(
+            "group {group_id} does not exist"
+        )));
+    }
 
     let now = now_iso();
     let content = GroupAdminContent {
@@ -666,21 +720,50 @@ pub async fn grant_group_admin(
     match insert {
         Ok(Some(_)) => {}
         Ok(None) => {
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                Some(caller.user_id.clone()),
+                "group_admin_granted",
+                false,
+                Some("insert_returned_none"),
+                Some(&ip),
+            )
+            .await;
             return Err(AppError::Internal(
                 "group_admin insert returned no row".into(),
             ));
         }
         Err(e) => {
             if is_unique_constraint_error(&e.to_string()) {
+                record_auth_event(
+                    &db,
+                    Some(user_id.clone()),
+                    Some(caller.user_id.clone()),
+                    "group_admin_granted",
+                    false,
+                    Some("duplicate_grant"),
+                    Some(&ip),
+                )
+                .await;
                 return Err(AppError::Conflict(format!(
                     "user {user_id} already has group-admin on group {group_id}"
                 )));
             }
+            record_auth_event(
+                &db,
+                Some(user_id.clone()),
+                Some(caller.user_id.clone()),
+                "group_admin_granted",
+                false,
+                Some("insert_failed"),
+                Some(&ip),
+            )
+            .await;
             return Err(e.into());
         }
     }
 
-    let ip = client_ip.to_string();
     record_auth_event(
         &db,
         Some(user_id.clone()),
@@ -728,6 +811,11 @@ pub async fn revoke_group_admin(
     ClientIp(client_ip): ClientIp,
     Path((user_id, group_id)): Path<(EntityId, EntityId)>,
 ) -> Result<StatusCode, AppError> {
+    // `ip` is bound up-front so the 404 branch can emit a
+    // `success: false` audit row — matches the symmetry PR 3.5
+    // established for admin-user mutations.
+    let ip = client_ip.to_string();
+
     // Delete the join row via a guarded query so we can distinguish
     // "row did not exist" (→ 404) from a permission/connectivity
     // failure. `DELETE ... RETURN BEFORE` echoes the matched rows so
@@ -744,6 +832,16 @@ pub async fn revoke_group_admin(
         .check()?;
     let deleted: Vec<DbGroupAdmin> = resp.take(0)?;
     if deleted.is_empty() {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_revoked",
+            false,
+            Some("unknown_grant"),
+            Some(&ip),
+        )
+        .await;
         return Err(AppError::NotFound(format!(
             "user {user_id} has no group-admin grant on group {group_id}"
         )));
@@ -771,7 +869,6 @@ pub async fn revoke_group_admin(
     // out-of-band, the UPDATE matches zero rows and the query
     // still returns Ok — acceptable, since there is no live
     // session to invalidate anyway.
-    let ip = client_ip.to_string();
     let bump = db
         .query(
             "UPDATE $id SET \

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2546,6 +2546,58 @@ async fn revoke_group_admin_bumps_target_token_version() {
     );
 }
 
+/// The bump only matters if an in-flight token minted *before* the
+/// revoke actually gets rejected on the next verify. This is a
+/// regression test for the end-to-end guarantee, not just the DB
+/// counter delta: mint a target access token at `tokenVersion=0`,
+/// grant + revoke, then hit a bearer-gated route with the same
+/// stale token and expect 401 (not 403 — the whole session is
+/// invalidated, not just the group scope).
+#[tokio::test]
+async fn revoke_group_admin_invalidates_pre_revoke_access_token() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "kick-after-revoke@example.com", "admin").await;
+    seed_test_group(&db, "kick-group").await;
+    let grant = call(
+        app.clone(),
+        group_admin_post_req(&target_id, "kick-group", &super_token),
+    )
+    .await;
+    assert_eq!(grant.status(), StatusCode::CREATED);
+
+    // Mint the target's access token *before* revoke with the
+    // current DB token_version (0 — grant does not bump).
+    let target_token = verifier.mint_access(&target_id, "admin", 0).expect("mint");
+
+    // Sanity check: the fresh token passes for the granted group
+    // through the AuthenticatedUser + require_group_scope pipeline
+    // on a router that only mounts the extractor route.
+    let test_app = extractor_app(db.clone(), verifier);
+    let before = call(test_app.clone(), bearer_get("/scope/kick-group", &target_token)).await;
+    assert_eq!(before.status(), StatusCode::NO_CONTENT);
+
+    let revoke = call(
+        app,
+        group_admin_delete_req(&target_id, "kick-group", &super_token),
+    )
+    .await;
+    assert_eq!(revoke.status(), StatusCode::NO_CONTENT);
+
+    // The pre-revoke token must now 401 — `AuthenticatedUser`
+    // re-reads token_version from the DB on every call and
+    // rejects the mismatch before group-scope evaluation runs.
+    let after = call(test_app, bearer_get("/scope/kick-group", &target_token)).await;
+    assert_eq!(
+        after.status(),
+        StatusCode::UNAUTHORIZED,
+        "pre-revoke token must be rejected once token_version is bumped"
+    );
+}
+
 #[tokio::test]
 async fn revoke_group_admin_without_bearer_returns_401() {
     let (app, db, _verifier) = build_app_full(lax_rate_cfg()).await;


### PR DESCRIPTION
## Summary

Follow-up hardening on the BE-8 group-admin endpoints landed in PR #36. Review surfaced three issues the initial PR left open; this PR closes all three in atomic commits.

1. **Bump `token_version` unconditionally on revoke (commit 1)** — the UPDATE result was discarded with `let _ =` and a `WHERE deleted_at IS NONE` guard silently skipped the bump on soft-deleted users. A bump failure now emits a `group_admin_revoked` audit row with `success:false reason:token_version_bump_failed` and returns 500 so ops can retry, mirroring the partial-failure handling already used by `update_admin_user` / `delete_admin_user`.
2. **Audit failure branches on grant/revoke (commit 2)** — matches the pattern PR 3.5 established for `create_admin_user`: every rejection now emits a `success:false` audit row with a specific reason (`unknown_user`, `target_not_active`, `target_not_admin`, `unknown_group`, `duplicate_grant`, `insert_returned_none`, `insert_failed`, `unknown_grant`). Incident review now sees probe attempts that previously left no trail.
3. **Live-token kick regression test (commit 3)** — the existing revoke test only asserted the DB counter delta. The new test mints an access token *before* revoke, calls a bearer-gated route, revokes, then asserts the stale token is rejected with 401 — guarding the end-to-end guarantee, not just the counter.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 311 / 311 passing (was 310 before the new test)
- [x] `cargo test --test auth_integration group_admin` — 17 / 17 passing
- [x] `cargo test --test auth_integration revoke_group_admin_invalidates_pre_revoke_access_token` — new regression test