### PR TITLE
feat: seed dev-only admin1/admin2 fixtures on SEED_ON_EMPTY boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,10 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # Also seeds two dev-only admin-role users so the admin-management UI has
 # clickable targets: `admin1@poolpay.test` (granted group-admin on fixture
 # group 1) and `admin2@poolpay.test` (no grants). Both use the password
-# `PoolPayQA2026!` and have `must_reset_password=false`. Never set this
-# flag in production — the fixture credentials are public by design.
+# `PoolPayQA2026!` and have `must_reset_password=false`. The dummy-admin
+# path is fail-closed: it additionally requires `APP_ENV=development` or
+# `APP_ENV=test`, so an unset or production `APP_ENV` keeps the fixture
+# credentials out of the DB even if this flag is on.
 # SEED_ON_EMPTY=true
 
 # Log verbosity: debug | info | warn | error (default: info)

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,12 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # Bind address for the API server (default: 0.0.0.0:8080)
 # API_BIND_ADDR=0.0.0.0:8080
 
-# Set to "true" to seed the database with fixture data when all tables are empty
+# Set to "true" to seed the database with fixture data when all tables are empty.
+# Also seeds two dev-only admin-role users so the admin-management UI has
+# clickable targets: `admin1@poolpay.test` (granted group-admin on fixture
+# group 1) and `admin2@poolpay.test` (no grants). Both use the password
+# `PoolPayQA2026!` and have `must_reset_password=false`. Never set this
+# flag in production — the fixture credentials are public by design.
 # SEED_ON_EMPTY=true
 
 # Log verbosity: debug | info | warn | error (default: info)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -241,6 +241,12 @@ The service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`
 **Initialization:**
 - On startup, creates namespace `circle` and database `main`
 - If `SEED_ON_EMPTY=true` and all tables are empty, seeds with fixture data (groups, members, cycles, payments)
+- If `SEED_ON_EMPTY=true`, also seeds two dev-only admin users after the bootstrap super-admin runs:
+  - `admin1@poolpay.test` — active admin, granted group-admin on fixture group `1`
+  - `admin2@poolpay.test` — active admin, no group grants (use this one to exercise grant creation from the dashboard)
+  - Both use password `PoolPayQA2026!` and `must_reset_password=false` so login is one-shot
+  - Idempotent across restarts; rows are skipped if `user_identity` already has them
+  - Guard is fail-closed: production boots with the flag unset execute zero writes on this path
 
 **Resetting the Database (Development Only):**
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -241,12 +241,12 @@ The service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`
 **Initialization:**
 - On startup, creates namespace `circle` and database `main`
 - If `SEED_ON_EMPTY=true` and all tables are empty, seeds with fixture data (groups, members, cycles, payments)
-- If `SEED_ON_EMPTY=true`, also seeds two dev-only admin users after the bootstrap super-admin runs:
+- If `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, also seeds two dev-only admin users after the bootstrap super-admin runs:
   - `admin1@poolpay.test` — active admin, granted group-admin on fixture group `1`
   - `admin2@poolpay.test` — active admin, no group grants (use this one to exercise grant creation from the dashboard)
   - Both use password `PoolPayQA2026!` and `must_reset_password=false` so login is one-shot
-  - Idempotent across restarts; rows are skipped if `user_identity` already has them
-  - Guard is fail-closed: production boots with the flag unset execute zero writes on this path
+  - Idempotent across restarts; existing users are re-used and admin1's fixture grant is re-asserted if it was manually removed
+  - Guard is fail-closed on two axes: either an unset/misconfigured `APP_ENV` **or** `SEED_ON_EMPTY!=true` prevents any writes on this path. Both must be satisfied.
 
 **Resetting the Database (Development Only):**
 

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -16,7 +16,8 @@ const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
 const CREDENTIALS_PROVIDER: &str = "credentials";
 
 /// Dev-only fixture password for `seed_dummy_admins`. Only applied when
-/// `SEED_ON_EMPTY=true`, so production boots cannot accidentally plant it.
+/// `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, so
+/// production boots cannot accidentally plant it.
 const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
 const DUMMY_ADMIN_EMAILS: [&str; 2] = ["admin1@poolpay.test", "admin2@poolpay.test"];
 /// Fixture group id mirrors `db::FIXTURE_GROUP_ID` — kept in sync manually

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -138,10 +138,31 @@ fn redact(email: &str) -> String {
 ///
 /// Both use `must_reset_password: false` so login is one-shot, unlike the
 /// bootstrap super-admin. Idempotent on every email: a restart re-checks
-/// `user_identity` and skips anything already present. Gated on
-/// `SEED_ON_EMPTY=true` so production boots never execute this path.
+/// `user_identity`, skips already-present rows, and re-asserts admin1's
+/// fixture grant even when the user already existed (so a manual
+/// `group_admin` delete is restored by a restart). Gated on
+/// `SEED_ON_EMPTY=true` **and** `APP_ENV` ∈ {`development`, `test`} so any
+/// other deploy — including unset `APP_ENV` — fails closed. This mirrors
+/// the `/api/test/reset` gate in `src/api/mod.rs`.
 pub async fn seed_dummy_admins(db: &DbConn) -> Result<(), surrealdb::Error> {
-    if std::env::var("SEED_ON_EMPTY").as_deref() != Ok("true") {
+    let flag_enabled = std::env::var("SEED_ON_EMPTY").as_deref() == Ok("true");
+    let env_allows_fixtures = matches!(
+        std::env::var("APP_ENV").as_deref(),
+        Ok("development" | "test")
+    );
+    seed_dummy_admins_with_flag(db, flag_enabled && env_allows_fixtures).await
+}
+
+/// Internal entry point that takes an explicit boolean instead of reading
+/// process env. `seed_dummy_admins` calls this after evaluating the
+/// `SEED_ON_EMPTY` + `APP_ENV` gates; tests call it directly so they never
+/// have to mutate env vars at runtime (which would race with concurrent
+/// `std::env::var` reads elsewhere in the suite).
+pub async fn seed_dummy_admins_with_flag(
+    db: &DbConn,
+    enabled: bool,
+) -> Result<(), surrealdb::Error> {
+    if !enabled {
         return Ok(());
     }
 
@@ -158,12 +179,15 @@ pub async fn seed_dummy_admins(db: &DbConn) -> Result<(), surrealdb::Error> {
     };
 
     for (idx, email) in DUMMY_ADMIN_EMAILS.iter().enumerate() {
-        let created =
-            ensure_admin_fixture(db, email, DUMMY_ADMIN_PASSWORD, &super_admin_id).await?;
+        let user_id = ensure_admin_fixture(db, email, DUMMY_ADMIN_PASSWORD, &super_admin_id)
+            .await?;
         // Only admin1 (index 0) gets the group grant — admin2 stays
         // ungranted so the dashboard has a target for testing grant creation.
+        // Re-asserting the grant on every run (not just when the user was
+        // created this run) restores it after manual cleanup / partial prior
+        // runs; `ensure_group_admin_grant` is idempotent on unique conflict.
         if idx == 0 {
-            if let Some(user_id) = created {
+            if let Some(user_id) = user_id {
                 ensure_group_admin_grant(
                     db,
                     &user_id,
@@ -190,9 +214,12 @@ async fn find_super_admin_id(db: &DbConn) -> Result<Option<String>, surrealdb::E
     Ok(users.into_iter().next().map(|u| record_id_to_string(u.id)))
 }
 
-/// Returns the newly-created user id if the fixture row was inserted; `None`
-/// if the email already existed (so the caller can skip follow-up writes
-/// like group grants and know this run was a no-op for that email).
+/// Returns the fixture admin's user id whether the row was inserted this
+/// run or already existed. Callers use this id to re-assert follow-up
+/// writes (like admin1's `group_admin` grant) so idempotency holds even
+/// when the user row survived but a grant was manually deleted. `Ok(None)`
+/// is reserved for skip cases where we could not produce a usable id
+/// (e.g. password hash failed, `create` returned no record).
 async fn ensure_admin_fixture(
     db: &DbConn,
     email: &str,
@@ -211,12 +238,12 @@ async fn ensure_admin_fixture(
         .await?
         .check()?;
     let existing: Vec<DbUserIdentity> = resp.take(0).unwrap_or_default();
-    if !existing.is_empty() {
+    if let Some(identity) = existing.into_iter().next() {
         info!(
             email_redacted = redact(email),
-            "fixture admin already seeded — skipping"
+            "fixture admin already seeded — reusing user_id"
         );
-        return Ok(None);
+        return Ok(Some(identity.user_id));
     }
 
     let password_hash = match password::hash(password_plain) {
@@ -260,6 +287,10 @@ async fn ensure_admin_fixture(
         }
     };
 
+    // Mirror `admin_users::create_admin_user`: if the identity insert fails
+    // or returns no record, roll back the user row we just created so we
+    // don't leave an orphan that a subsequent run would skip past (or
+    // worse, duplicate via non-unique `email_normalised`).
     let identity = UserIdentityContent {
         user_id: user_id.clone(),
         provider: CREDENTIALS_PROVIDER.into(),
@@ -267,7 +298,30 @@ async fn ensure_admin_fixture(
         email_at_link: email.to_string(),
         created_at: now.clone(),
     };
-    let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
+    let identity_result: Result<Option<DbUserIdentity>, _> =
+        db.create("user_identity").content(identity).await;
+    match identity_result {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            warn!(
+                email_redacted = redact(email),
+                user_id = user_id.as_str(),
+                "fixture admin identity create returned no record — rolling back user"
+            );
+            rollback_fixture_user(db, &user_id).await;
+            return Ok(None);
+        }
+        Err(e) => {
+            warn!(
+                email_redacted = redact(email),
+                user_id = user_id.as_str(),
+                error = %e,
+                "fixture admin identity create failed — rolling back user"
+            );
+            rollback_fixture_user(db, &user_id).await;
+            return Err(e);
+        }
+    }
 
     let event = AuthEventContent {
         user_id: Some(user_id.clone()),
@@ -286,6 +340,21 @@ async fn ensure_admin_fixture(
         "fixture admin created"
     );
     Ok(Some(user_id))
+}
+
+/// Best-effort cleanup for an orphan user row left behind when
+/// `user_identity` fails to insert. Mirrors `admin_users::rollback_user`:
+/// the caller has already decided to bail, so a secondary failure is
+/// logged but not surfaced.
+async fn rollback_fixture_user(db: &DbConn, user_id: &str) {
+    let cleanup: Result<Option<DbUser>, _> = db.delete(("user", user_id)).await;
+    if let Err(e) = cleanup {
+        warn!(
+            error = %e,
+            user_id,
+            "fixture admin rollback failed after identity error — orphan user row"
+        );
+    }
 }
 
 async fn ensure_group_admin_grant(
@@ -314,7 +383,7 @@ async fn ensure_group_admin_grant(
     };
     let insert: Result<Option<DbGroupAdmin>, _> = db.create("group_admin").content(content).await;
     match insert {
-        Ok(_) => {
+        Ok(Some(_)) => {
             let event = AuthEventContent {
                 user_id: Some(user_id.to_string()),
                 actor_id: Some(super_admin_id.to_string()),
@@ -327,6 +396,18 @@ async fn ensure_group_admin_grant(
             };
             let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
             info!(user_id, group_id, "fixture group_admin grant created");
+            Ok(())
+        }
+        // `create(...).content(...)` returning `Ok(None)` with no error is
+        // treated as an internal anomaly elsewhere in the codebase — log
+        // loudly so ops can spot it, but don't emit a `group_admin_granted`
+        // audit event or fail the boot; the fixture seed is best-effort.
+        Ok(None) => {
+            warn!(
+                user_id,
+                group_id,
+                "fixture group_admin grant returned no record — skipping audit event"
+            );
             Ok(())
         }
         Err(e) if is_unique_constraint_error(&e.to_string()) => {

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -10,7 +10,7 @@ use crate::api::models::{
     GroupAdminContent, UserContent, UserIdentityContent, now_iso, record_id_to_string,
 };
 use crate::auth::password;
-use crate::db::{DbConn, is_unique_constraint_error};
+use crate::db::{DbConn, FIXTURE_GROUP_ID, is_unique_constraint_error};
 
 const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
 const CREDENTIALS_PROVIDER: &str = "credentials";
@@ -20,10 +20,6 @@ const CREDENTIALS_PROVIDER: &str = "credentials";
 /// production boots cannot accidentally plant it.
 const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
 const DUMMY_ADMIN_EMAILS: [&str; 2] = ["admin1@poolpay.test", "admin2@poolpay.test"];
-/// Fixture group id mirrors `db::FIXTURE_GROUP_ID` — kept in sync manually
-/// because `FIXTURE_GROUP_ID` is a private constant in `db.rs`. If the
-/// business-fixture group id ever changes, update this too.
-const DUMMY_ADMIN_GROUP_GRANT_ID: &str = "1";
 
 /// Seed the initial admin account if none exists and the required env vars
 /// are set. Safe to call on every boot.
@@ -196,13 +192,7 @@ pub async fn seed_dummy_admins_with_flag(
         // runs; `ensure_group_admin_grant` is idempotent on unique conflict.
         if idx == 0 {
             if let Some(user_id) = user_id {
-                ensure_group_admin_grant(
-                    db,
-                    &user_id,
-                    DUMMY_ADMIN_GROUP_GRANT_ID,
-                    &super_admin_id,
-                )
-                .await?;
+                ensure_group_admin_grant(db, &user_id, FIXTURE_GROUP_ID, &super_admin_id).await?;
             }
         }
     }

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -362,7 +362,20 @@ async fn ensure_admin_fixture(
         reason: Some("fixture_seed".into()),
         created_at: now,
     };
-    let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
+    // Fixture seeding must not fail startup on a transient audit-write
+    // error. The user + identity rows are already persisted, so degrade to
+    // a warn-and-continue on audit issues — matches the best-effort
+    // contract documented on `seed_dummy_admins`.
+    let audit_result: Result<Option<DbAuthEvent>, _> =
+        db.create("auth_event").content(event).await;
+    if let Err(e) = audit_result {
+        warn!(
+            email_redacted = redact(email),
+            user_id = user_id.as_str(),
+            error = %e,
+            "fixture admin auth_event insert failed — continuing"
+        );
+    }
 
     info!(
         email_redacted = redact(email),
@@ -423,7 +436,20 @@ async fn ensure_group_admin_grant(
                 reason: Some("fixture_seed".into()),
                 created_at: now,
             };
-            let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
+            // Grant row is already persisted; treat the audit write as
+            // best-effort so a transient audit failure doesn't abort the
+            // dev-only seed path (which is already best-effort per the
+            // comment below on the `Ok(None)` arm).
+            let audit_result: Result<Option<DbAuthEvent>, _> =
+                db.create("auth_event").content(event).await;
+            if let Err(e) = audit_result {
+                warn!(
+                    user_id,
+                    group_id,
+                    error = %e,
+                    "fixture group_admin grant audit event insert failed — continuing"
+                );
+            }
             info!(user_id, group_id, "fixture group_admin grant created");
             Ok(())
         }

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -159,6 +159,13 @@ pub async fn seed_dummy_admins(db: &DbConn) -> Result<(), surrealdb::Error> {
 /// `SEED_ON_EMPTY` + `APP_ENV` gates; tests call it directly so they never
 /// have to mutate env vars at runtime (which would race with concurrent
 /// `std::env::var` reads elsewhere in the suite).
+///
+/// Marked `#[doc(hidden)]` — `pub` is required because integration tests
+/// live in the external `tests/` crate, but it must not be treated as part
+/// of the public surface. Production code should call `seed_dummy_admins`
+/// so the env-based safety gates are always evaluated. Mirrors the pattern
+/// used by `auth::hmac::sign_for_testing`.
+#[doc(hidden)]
 pub async fn seed_dummy_admins_with_flag(
     db: &DbConn,
     enabled: bool,
@@ -240,11 +247,42 @@ async fn ensure_admin_fixture(
         .check()?;
     let existing: Vec<DbUserIdentity> = resp.take(0).unwrap_or_default();
     if let Some(identity) = existing.into_iter().next() {
-        info!(
-            email_redacted = redact(email),
-            "fixture admin already seeded — reusing user_id"
-        );
-        return Ok(Some(identity.user_id));
+        // Don't blindly trust the identity pointer — the underlying `user`
+        // row may have been soft-deleted or disabled via the admin UI since
+        // the fixture was first seeded. Reusing a stale pointer would let
+        // `ensure_group_admin_grant` award a grant to a non-admin, and
+        // silently mask a broken fixture. Verify the user is still an
+        // active admin before returning its id.
+        let linked: Option<DbUser> = db.select(("user", identity.user_id.as_str())).await?;
+        return match linked {
+            Some(u)
+                if u.deleted_at.is_none()
+                    && u.status == "active"
+                    && matches!(u.role.as_str(), "admin" | "super_admin") =>
+            {
+                info!(
+                    email_redacted = redact(email),
+                    "fixture admin already seeded — reusing user_id"
+                );
+                Ok(Some(identity.user_id))
+            }
+            Some(_) => {
+                warn!(
+                    email_redacted = redact(email),
+                    user_id = identity.user_id.as_str(),
+                    "fixture admin identity points at a disabled/non-admin user — skipping grant"
+                );
+                Ok(None)
+            }
+            None => {
+                warn!(
+                    email_redacted = redact(email),
+                    user_id = identity.user_id.as_str(),
+                    "fixture admin identity points at a missing user — skipping grant"
+                );
+                Ok(None)
+            }
+        };
     }
 
     let password_hash = match password::hash(password_plain) {

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -6,13 +6,23 @@
 use tracing::{info, warn};
 
 use crate::api::models::{
-    AuthEventContent, DbAuthEvent, DbUser, DbUserIdentity, UserContent, UserIdentityContent,
-    now_iso, record_id_to_string,
+    AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbUser, DbUserIdentity,
+    GroupAdminContent, UserContent, UserIdentityContent, now_iso, record_id_to_string,
 };
 use crate::auth::password;
-use crate::db::DbConn;
+use crate::db::{DbConn, is_unique_constraint_error};
 
 const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
+const CREDENTIALS_PROVIDER: &str = "credentials";
+
+/// Dev-only fixture password for `seed_dummy_admins`. Only applied when
+/// `SEED_ON_EMPTY=true`, so production boots cannot accidentally plant it.
+const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
+const DUMMY_ADMIN_EMAILS: [&str; 2] = ["admin1@poolpay.test", "admin2@poolpay.test"];
+/// Fixture group id mirrors `db::FIXTURE_GROUP_ID` — kept in sync manually
+/// because `FIXTURE_GROUP_ID` is a private constant in `db.rs`. If the
+/// business-fixture group id ever changes, update this too.
+const DUMMY_ADMIN_GROUP_GRANT_ID: &str = "1";
 
 /// Seed the initial admin account if none exists and the required env vars
 /// are set. Safe to call on every boot.
@@ -115,5 +125,217 @@ fn redact(email: &str) -> String {
             format!("{first}***@{domain}")
         }
         None => "***".into(),
+    }
+}
+
+/// Dev-only: seed two fixture admin users so the admin-management UI has
+/// clickable targets without forcing manual `POST /api/admin/users` calls.
+///
+/// - `admin1@poolpay.test` — active admin with a `group_admin` grant on
+///   fixture group `1` (exercises the group-scoped extractor path).
+/// - `admin2@poolpay.test` — active admin with no grants (exercises the
+///   "grant a new group" flow).
+///
+/// Both use `must_reset_password: false` so login is one-shot, unlike the
+/// bootstrap super-admin. Idempotent on every email: a restart re-checks
+/// `user_identity` and skips anything already present. Gated on
+/// `SEED_ON_EMPTY=true` so production boots never execute this path.
+pub async fn seed_dummy_admins(db: &DbConn) -> Result<(), surrealdb::Error> {
+    if std::env::var("SEED_ON_EMPTY").as_deref() != Ok("true") {
+        return Ok(());
+    }
+
+    // Attribute fixture grants + audit events to the real super-admin so the
+    // audit trail is symmetric with the endpoint-driven path. If no
+    // super-admin exists yet (bootstrap env vars were unset), skip — there's
+    // no plausible actor to record.
+    let super_admin_id = match find_super_admin_id(db).await? {
+        Some(id) => id,
+        None => {
+            info!("seed_dummy_admins: no super-admin present — skipping");
+            return Ok(());
+        }
+    };
+
+    for (idx, email) in DUMMY_ADMIN_EMAILS.iter().enumerate() {
+        let created =
+            ensure_admin_fixture(db, email, DUMMY_ADMIN_PASSWORD, &super_admin_id).await?;
+        // Only admin1 (index 0) gets the group grant — admin2 stays
+        // ungranted so the dashboard has a target for testing grant creation.
+        if idx == 0 {
+            if let Some(user_id) = created {
+                ensure_group_admin_grant(
+                    db,
+                    &user_id,
+                    DUMMY_ADMIN_GROUP_GRANT_ID,
+                    &super_admin_id,
+                )
+                .await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn find_super_admin_id(db: &DbConn) -> Result<Option<String>, surrealdb::Error> {
+    let mut resp = db
+        .query(
+            "SELECT * FROM user \
+             WHERE role = 'super_admin' AND status = 'active' AND deleted_at IS NONE \
+             LIMIT 1",
+        )
+        .await?
+        .check()?;
+    let users: Vec<DbUser> = resp.take(0).unwrap_or_default();
+    Ok(users.into_iter().next().map(|u| record_id_to_string(u.id)))
+}
+
+/// Returns the newly-created user id if the fixture row was inserted; `None`
+/// if the email already existed (so the caller can skip follow-up writes
+/// like group grants and know this run was a no-op for that email).
+async fn ensure_admin_fixture(
+    db: &DbConn,
+    email: &str,
+    password_plain: &str,
+    super_admin_id: &str,
+) -> Result<Option<String>, surrealdb::Error> {
+    let email_normalised = email.to_lowercase();
+
+    let mut resp = db
+        .query(
+            "SELECT * FROM user_identity \
+             WHERE provider = $p AND provider_subject = $s LIMIT 1",
+        )
+        .bind(("p", CREDENTIALS_PROVIDER.to_string()))
+        .bind(("s", email_normalised.clone()))
+        .await?
+        .check()?;
+    let existing: Vec<DbUserIdentity> = resp.take(0).unwrap_or_default();
+    if !existing.is_empty() {
+        info!(
+            email_redacted = redact(email),
+            "fixture admin already seeded — skipping"
+        );
+        return Ok(None);
+    }
+
+    let password_hash = match password::hash(password_plain) {
+        Ok(h) => h,
+        Err(e) => {
+            warn!(
+                error = ?e,
+                email_redacted = redact(email),
+                "fixture admin hash failed — skipping"
+            );
+            return Ok(None);
+        }
+    };
+
+    let now = now_iso();
+    let user_content = UserContent {
+        email: email.to_string(),
+        email_normalised: email_normalised.clone(),
+        password_hash: Some(password_hash),
+        role: "admin".into(),
+        status: "active".into(),
+        token_version: 0,
+        // Dev fixtures skip the first-login rotation so the login flow is
+        // one-shot. The real `POST /api/admin/users` path still sets this
+        // to true — only this seed path differs.
+        must_reset_password: false,
+        version: 1,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        deleted_at: None,
+    };
+    let created: Option<DbUser> = db.create("user").content(user_content).await?;
+    let user_id = match created {
+        Some(u) => record_id_to_string(u.id),
+        None => {
+            warn!(
+                email_redacted = redact(email),
+                "fixture admin create returned no record — skipping"
+            );
+            return Ok(None);
+        }
+    };
+
+    let identity = UserIdentityContent {
+        user_id: user_id.clone(),
+        provider: CREDENTIALS_PROVIDER.into(),
+        provider_subject: email_normalised,
+        email_at_link: email.to_string(),
+        created_at: now.clone(),
+    };
+    let _: Option<DbUserIdentity> = db.create("user_identity").content(identity).await?;
+
+    let event = AuthEventContent {
+        user_id: Some(user_id.clone()),
+        actor_id: Some(super_admin_id.to_string()),
+        event_type: "user_created".into(),
+        ip: None,
+        user_agent: None,
+        success: true,
+        reason: Some("fixture_seed".into()),
+        created_at: now,
+    };
+    let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
+
+    info!(
+        email_redacted = redact(email),
+        "fixture admin created"
+    );
+    Ok(Some(user_id))
+}
+
+async fn ensure_group_admin_grant(
+    db: &DbConn,
+    user_id: &str,
+    group_id: &str,
+    super_admin_id: &str,
+) -> Result<(), surrealdb::Error> {
+    // Skip cleanly if the business-fixture group isn't present — e.g. a
+    // partial DB where `seed()` didn't run but a super-admin already exists.
+    let group: Option<DbGroup> = db.select(("group", group_id)).await?;
+    if group.filter(|g| g.deleted_at.is_none()).is_none() {
+        info!(
+            group_id,
+            "fixture group missing — skipping group_admin grant"
+        );
+        return Ok(());
+    }
+
+    let now = now_iso();
+    let content = GroupAdminContent {
+        user_id: user_id.to_string(),
+        group_id: group_id.to_string(),
+        created_at: now.clone(),
+        created_by: super_admin_id.to_string(),
+    };
+    let insert: Result<Option<DbGroupAdmin>, _> = db.create("group_admin").content(content).await;
+    match insert {
+        Ok(_) => {
+            let event = AuthEventContent {
+                user_id: Some(user_id.to_string()),
+                actor_id: Some(super_admin_id.to_string()),
+                event_type: "group_admin_granted".into(),
+                ip: None,
+                user_agent: None,
+                success: true,
+                reason: Some("fixture_seed".into()),
+                created_at: now,
+            };
+            let _: Option<DbAuthEvent> = db.create("auth_event").content(event).await?;
+            info!(user_id, group_id, "fixture group_admin grant created");
+            Ok(())
+        }
+        Err(e) if is_unique_constraint_error(&e.to_string()) => {
+            info!(
+                user_id,
+                group_id, "fixture group_admin grant already exists — skipping"
+            );
+            Ok(())
+        }
+        Err(e) => Err(e),
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -239,8 +239,11 @@ pub(crate) fn is_unique_constraint_error(message: &str) -> bool {
 
 // ── Fixture data ──────────────────────────────────────────────────────────────
 
-/// The seeded group ID used across all fixtures.
-const FIXTURE_GROUP_ID: &str = "1";
+/// The seeded group ID used across all fixtures. Exposed `pub(crate)` so
+/// the dev-only `auth::bootstrap::seed_dummy_admins` path can target the
+/// same group without a duplicated string literal — keeps both seed paths
+/// compile-break together if the fixture group id ever changes.
+pub(crate) const FIXTURE_GROUP_ID: &str = "1";
 
 fn fixture_groups() -> Vec<(&'static str, GroupContent)> {
     vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,9 +100,10 @@ async fn main() {
         error!(error = %e, "Bootstrap admin seeding failed");
     }
 
-    // Dev-only fixture admins (admin1/admin2). Gated on SEED_ON_EMPTY so
-    // production boots never touch this path. Failures are logged but do
-    // not abort startup — the real super-admin is already in place.
+    // Dev-only fixture admins (admin1/admin2). Only runs when
+    // SEED_ON_EMPTY=true and APP_ENV is development or test, so production
+    // boots never touch this path. Failures are logged but do not abort
+    // startup — the real super-admin is already in place.
     if let Err(e) = auth::bootstrap::seed_dummy_admins(&surreal_db).await {
         error!(error = %e, "Dummy admin seeding failed");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,13 @@ async fn main() {
         error!(error = %e, "Bootstrap admin seeding failed");
     }
 
+    // Dev-only fixture admins (admin1/admin2). Gated on SEED_ON_EMPTY so
+    // production boots never touch this path. Failures are logged but do
+    // not abort startup — the real super-admin is already in place.
+    if let Err(e) = auth::bootstrap::seed_dummy_admins(&surreal_db).await {
+        error!(error = %e, "Dummy admin seeding failed");
+    }
+
     // Spawn the Axum HTTP server.
     // Monitored below — if the server dies the process exits rather than
     // silently running without an API.

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2829,3 +2829,47 @@ async fn seed_dummy_admins_restores_missing_admin1_grant_on_restart() {
     assert_eq!(grants, 1, "restart must restore admin1's fixture grant");
 }
 
+#[tokio::test]
+async fn seed_dummy_admins_skips_grant_when_fixture_user_is_disabled() {
+    // If the fixture admin1 was disabled via the admin UI (soft-deleted or
+    // status=disabled) after the first seed, a subsequent seed must NOT
+    // award a fresh `group_admin` grant to that disabled user — the fixture
+    // is no longer in a usable state, and silently granting would mask the
+    // fact that admin1 has been taken offline.
+    let (_app, db) = test_app().await;
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("first seed");
+
+    // Soft-delete admin1 and wipe the fixture grant to mirror a "disabled
+    // admin + stripped grant" state on the second boot.
+    db.query(
+        "UPDATE user \
+         SET status = 'disabled', deleted_at = '2026-04-22T00:00:00Z' \
+         WHERE email_normalised = 'admin1@poolpay.test'",
+    )
+    .await
+    .unwrap()
+    .check()
+    .unwrap();
+    db.query("DELETE group_admin WHERE group_id = '1'")
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("second seed tolerates disabled fixture admin");
+
+    let grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin WHERE group_id = '1' GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        grants, 0,
+        "disabled fixture admin must not receive a restored grant"
+    );
+}
+

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2694,3 +2694,116 @@ async fn revoke_group_admin_replay_after_success_returns_404() {
     assert_eq!(second.status(), StatusCode::NOT_FOUND);
 }
 
+// ── Dev-only dummy admin fixtures ─────────────────────────────────────────────
+
+/// Toggle `SEED_ON_EMPTY` inside the shared env lock. Every dummy-admin test
+/// goes through this so we never race with `init_env`'s writer window or
+/// leave the flag set for the next test.
+fn set_seed_on_empty(enabled: bool) {
+    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    // Safety: serialised by `env_lock` — matches the pattern in `init_env`.
+    unsafe {
+        if enabled {
+            std::env::set_var("SEED_ON_EMPTY", "true");
+        } else {
+            std::env::remove_var("SEED_ON_EMPTY");
+        }
+    }
+}
+
+async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
+    let mut resp = db.query(query).await.unwrap().check().unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0)
+}
+
+#[tokio::test]
+async fn seed_dummy_admins_creates_both_admins_and_grant_for_admin1() {
+    let (_app, db) = test_app().await;
+    set_seed_on_empty(true);
+    bootstrap::seed_dummy_admins(&db)
+        .await
+        .expect("seed_dummy_admins");
+    set_seed_on_empty(false);
+
+    let admins = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         AND role = 'admin' AND status = 'active' AND must_reset_password = false \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(admins, 2, "both fixture admins must be created as active admin-role users");
+
+    let grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin \
+         WHERE group_id = '1' AND user_id IN (\
+             SELECT VALUE meta::id(id) FROM user WHERE email_normalised = 'admin1@poolpay.test'\
+         ) GROUP ALL",
+    )
+    .await;
+    assert_eq!(grants, 1, "admin1 must receive exactly one fixture grant on group 1");
+
+    let admin2_grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin \
+         WHERE user_id IN (\
+             SELECT VALUE meta::id(id) FROM user WHERE email_normalised = 'admin2@poolpay.test'\
+         ) GROUP ALL",
+    )
+    .await;
+    assert_eq!(admin2_grants, 0, "admin2 must not receive any fixture grants");
+}
+
+#[tokio::test]
+async fn seed_dummy_admins_is_idempotent_across_restarts() {
+    let (_app, db) = test_app().await;
+    set_seed_on_empty(true);
+    bootstrap::seed_dummy_admins(&db)
+        .await
+        .expect("first seed");
+    bootstrap::seed_dummy_admins(&db)
+        .await
+        .expect("second seed (simulated restart)");
+    set_seed_on_empty(false);
+
+    let admins = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(admins, 2, "restart must not duplicate fixture admin rows");
+
+    let grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin WHERE group_id = '1' GROUP ALL",
+    )
+    .await;
+    assert_eq!(grants, 1, "restart must not duplicate fixture grants");
+}
+
+#[tokio::test]
+async fn seed_dummy_admins_is_noop_without_flag() {
+    let (_app, db) = test_app().await;
+    // `SEED_ON_EMPTY` is unset in the normal test env — verify the guard
+    // short-circuits rather than relying on idempotency alone, so a
+    // production boot without the flag is provably silent.
+    set_seed_on_empty(false);
+    bootstrap::seed_dummy_admins(&db)
+        .await
+        .expect("seed_dummy_admins noop");
+
+    let admins = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(admins, 0, "fixture admins must not be seeded without SEED_ON_EMPTY=true");
+}
+

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2695,21 +2695,13 @@ async fn revoke_group_admin_replay_after_success_returns_404() {
 }
 
 // ── Dev-only dummy admin fixtures ─────────────────────────────────────────────
-
-/// Toggle `SEED_ON_EMPTY` inside the shared env lock. Every dummy-admin test
-/// goes through this so we never race with `init_env`'s writer window or
-/// leave the flag set for the next test.
-fn set_seed_on_empty(enabled: bool) {
-    let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
-    // Safety: serialised by `env_lock` — matches the pattern in `init_env`.
-    unsafe {
-        if enabled {
-            std::env::set_var("SEED_ON_EMPTY", "true");
-        } else {
-            std::env::remove_var("SEED_ON_EMPTY");
-        }
-    }
-}
+//
+// Tests drive the seed path via the boolean-flag helper instead of toggling
+// `SEED_ON_EMPTY` at runtime. Flipping a process-wide env var inside a
+// parallel test binary races with any concurrent `std::env::var` read in
+// other tests or async tasks — `set_var`'s safety precondition only holds
+// when there are no concurrent readers, which we can't guarantee in an
+// async test harness. The flag-taking helper sidesteps the hazard entirely.
 
 async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
     let mut resp = db.query(query).await.unwrap().check().unwrap();
@@ -2720,11 +2712,9 @@ async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
 #[tokio::test]
 async fn seed_dummy_admins_creates_both_admins_and_grant_for_admin1() {
     let (_app, db) = test_app().await;
-    set_seed_on_empty(true);
-    bootstrap::seed_dummy_admins(&db)
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
         .await
         .expect("seed_dummy_admins");
-    set_seed_on_empty(false);
 
     let admins = count_rows(
         &db,
@@ -2760,14 +2750,12 @@ async fn seed_dummy_admins_creates_both_admins_and_grant_for_admin1() {
 #[tokio::test]
 async fn seed_dummy_admins_is_idempotent_across_restarts() {
     let (_app, db) = test_app().await;
-    set_seed_on_empty(true);
-    bootstrap::seed_dummy_admins(&db)
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
         .await
         .expect("first seed");
-    bootstrap::seed_dummy_admins(&db)
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
         .await
         .expect("second seed (simulated restart)");
-    set_seed_on_empty(false);
 
     let admins = count_rows(
         &db,
@@ -2789,11 +2777,9 @@ async fn seed_dummy_admins_is_idempotent_across_restarts() {
 #[tokio::test]
 async fn seed_dummy_admins_is_noop_without_flag() {
     let (_app, db) = test_app().await;
-    // `SEED_ON_EMPTY` is unset in the normal test env — verify the guard
-    // short-circuits rather than relying on idempotency alone, so a
-    // production boot without the flag is provably silent.
-    set_seed_on_empty(false);
-    bootstrap::seed_dummy_admins(&db)
+    // Verify the guard short-circuits rather than relying on idempotency
+    // alone, so a production boot without the flag is provably silent.
+    bootstrap::seed_dummy_admins_with_flag(&db, false)
         .await
         .expect("seed_dummy_admins noop");
 
@@ -2805,5 +2791,41 @@ async fn seed_dummy_admins_is_noop_without_flag() {
     )
     .await;
     assert_eq!(admins, 0, "fixture admins must not be seeded without SEED_ON_EMPTY=true");
+}
+
+#[tokio::test]
+async fn seed_dummy_admins_restores_missing_admin1_grant_on_restart() {
+    // Idempotency contract: if admin1 already exists but the `group_admin`
+    // grant was manually deleted (partial cleanup, ops intervention), a
+    // subsequent seed must restore the grant rather than silently skip it.
+    let (_app, db) = test_app().await;
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("first seed");
+
+    // Wipe admin1's grant without touching the user row, simulating a manual
+    // cleanup that left the fixture admin intact but stripped the grant.
+    db.query("DELETE group_admin WHERE group_id = '1'")
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let grants_after_wipe = count_rows(
+        &db,
+        "SELECT count() FROM group_admin WHERE group_id = '1' GROUP ALL",
+    )
+    .await;
+    assert_eq!(grants_after_wipe, 0, "precondition: grant wiped");
+
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("second seed restores grant");
+
+    let grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin WHERE group_id = '1' GROUP ALL",
+    )
+    .await;
+    assert_eq!(grants, 1, "restart must restore admin1's fixture grant");
 }
 


### PR DESCRIPTION
## Summary
- Add `seed_dummy_admins` to `auth::bootstrap`, wired in `main` after `ensure_admin_user`. Provisions `admin1@poolpay.test` (active admin, group-admin grant on fixture group `1`) and `admin2@poolpay.test` (active admin, no grants) when `SEED_ON_EMPTY=true`, so the admin-management UI has clickable targets without manual `POST /api/admin/users` calls.
- Fixtures use `must_reset_password=false` (one-shot login) and share password `PoolPayQA2026!`. Idempotent across restarts via `user_identity` pre-check + unique-constraint detection on the grant insert. Fail-closed: production boots without the flag execute zero writes on this path.
- Docs updated (`.env.example`, `docs/RUNBOOK.md`) so operators know the seed surface before flipping the flag.

## Test plan
- [x] `cargo test` — full suite (320+) green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] New tests: fixture creation + grant shape, restart idempotency, guard-flag no-op
- [ ] Manual: `rm -rf data.surreal && cargo run` with `SEED_ON_EMPTY=true`, then log in as `admin1@poolpay.test` / `PoolPayQA2026!` and verify group-1 scope works
- [ ] Manual: verify `admin2@poolpay.test` can receive a new `POST /api/admin/users/:id/groups/:gid` grant