### PR TITLE
[FEAT] - Return 400 + typed `bad_current` code on wrong current-password

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -601,6 +601,37 @@ or signing failure, also with a `token_issue_failure` audit row
 (`reason` in `{db_error, mint_access_failed}`). `400` on empty or
 oversized `userId` (>128 chars).
 
+#### POST /api/auth/change-password
+
+Bearer-authenticated. Rotates the caller's password (change path) or attaches
+a credentials identity to a social-only account (set path). Bumps
+`token_version` so in-flight access tokens invalidate within one access-TTL;
+the change path additionally revokes every live refresh token for the user.
+
+**Request:**
+```json
+{ "currentPassword": "...", "newPassword": "..." }
+```
+
+`currentPassword` is required when the user already has a `password_hash`
+and is omitted on the social set-path. Body is capped at 5 KiB pre-parse.
+
+**Response:** `204 No Content` on success.
+
+| Status | Body | When |
+|---|---|---|
+| `204` | — | Success. |
+| `400` | `{ "code": "bad_current", "message": "Current password is incorrect." }` | `currentPassword` did not match the stored hash. Typed so the FE can tell a wrong-password failure from a dead session without inference (see [issue #39](https://github.com/Sensei3k/poolpay-api/issues/39)). Writes a `password_change_failure` audit row with `reason=bad_current`. |
+| `400` | `{ "error": "..." }` | Shape or policy violation — missing `newPassword`, whitespace-only, oversized (>1 KiB), or `currentPassword` omitted when a hash already exists. Not audited. |
+| `401` | `{ "error": "unauthorized" }` | Bearer missing, malformed, expired, or `token_version` stale (post-rotation replay, role change, etc.). **Does not include wrong-current-password.** |
+| `409` | `{ "error": "..." }` | Set path only: the `(provider='credentials', provider_subject=email_normalised)` identity is already owned by a different user. No hash is written. |
+| `500` | `{ "error": "an internal error occurred" }` | DB or Argon2 hashing failure. |
+
+On success the change path writes `password_changed` (no `reason`) and the
+set path writes `password_changed` with `reason=set`. The wrong-password
+branch writes `password_change_failure` with `reason=bad_current` before
+responding.
+
 ### Dev-Only Endpoint
 
 #### POST /api/test/reset

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -422,9 +422,11 @@ pub async fn change_password(
     match db_user.password_hash.as_deref() {
         Some(existing_hash) => {
             // Change path: verify current then rotate. Bad-current-password
-            // failures write an audit row before returning 401 so brute-force
-            // probes remain observable (shape-level 400s from missing fields
-            // or policy violations are intentionally not audited).
+            // failures write an audit row before returning 400 + a typed
+            // `bad_current` code so brute-force probes remain observable;
+            // shape-level 400s from missing fields or policy violations are
+            // intentionally not audited. 401 stays reserved for genuine
+            // token failures — see issue #39.
             let Some(current) = req.current_password.as_deref() else {
                 return Err(AppError::BadRequest(
                     "currentPassword required to change an existing password".into(),
@@ -441,7 +443,7 @@ pub async fn change_password(
                     Some(&ip),
                 )
                 .await;
-                return Err(AppError::Unauthorized);
+                return Err(AppError::BadCurrentPassword);
             }
 
             // Only hash the new password once the current one is verified —

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -18,6 +18,21 @@ struct ErrorBody {
     error: String,
 }
 
+/// Body shape for errors the FE needs to disambiguate from generic 400s —
+/// `{ "code": "<stable slug>", "message": "<human copy>" }`. Kept distinct
+/// from `ErrorBody` so existing callers that read `.error` are untouched.
+#[derive(Debug, Serialize)]
+struct CodedErrorBody {
+    code: &'static str,
+    message: &'static str,
+}
+
+/// Stable slug surfaced on `400 /api/auth/change-password` when the submitted
+/// `currentPassword` fails verification. Split out of the generic 401 so the
+/// FE stops having to infer the case from a post-refresh retry. See issue #39.
+const BAD_CURRENT_PASSWORD_CODE: &str = "bad_current";
+const BAD_CURRENT_PASSWORD_MESSAGE: &str = "Current password is incorrect.";
+
 /// Unified API error type — implements `IntoResponse` so handlers can use `?`
 /// directly and always return a JSON body with an `"error"` field.
 #[derive(Debug)]
@@ -25,6 +40,11 @@ pub enum AppError {
     NotFound(String),
     BadRequest(String),
     Unauthorized,
+    /// `400 Bad Request` with body `{ code: "bad_current", message: ... }` —
+    /// reserved for wrong-`currentPassword` on `/api/auth/change-password`.
+    /// Separating this from `Unauthorized` lets the FE skip its
+    /// post-refresh-401 inference; see issue #39.
+    BadCurrentPassword,
     Forbidden(String),
     Conflict(String),
     /// `retry_after_secs` populates the `Retry-After` header when present.
@@ -40,6 +60,14 @@ impl IntoResponse for AppError {
             AppError::NotFound(msg) => simple(StatusCode::NOT_FOUND, msg),
             AppError::BadRequest(msg) => simple(StatusCode::BAD_REQUEST, msg),
             AppError::Unauthorized => simple(StatusCode::UNAUTHORIZED, "unauthorized".to_string()),
+            AppError::BadCurrentPassword => (
+                StatusCode::BAD_REQUEST,
+                Json(CodedErrorBody {
+                    code: BAD_CURRENT_PASSWORD_CODE,
+                    message: BAD_CURRENT_PASSWORD_MESSAGE,
+                }),
+            )
+                .into_response(),
             AppError::Forbidden(msg) => simple(StatusCode::FORBIDDEN, msg),
             AppError::Conflict(msg) => simple(StatusCode::CONFLICT, msg),
             AppError::TooManyRequests { retry_after_secs } => {

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -34,7 +34,9 @@ const BAD_CURRENT_PASSWORD_CODE: &str = "bad_current";
 const BAD_CURRENT_PASSWORD_MESSAGE: &str = "Current password is incorrect.";
 
 /// Unified API error type — implements `IntoResponse` so handlers can use `?`
-/// directly and always return a JSON body with an `"error"` field.
+/// directly and return a JSON error body. Most variants use the legacy
+/// `{ "error": "..." }` shape, while `BadCurrentPassword` returns the coded
+/// `{ "code": "<stable slug>", "message": "<human copy>" }` shape.
 #[derive(Debug)]
 pub enum AppError {
     NotFound(String),

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1315,8 +1315,13 @@ async fn change_password_rotates_hash_bumps_token_version_and_clears_must_reset(
     assert_eq!(verify_resp.status(), StatusCode::OK);
 }
 
+/// Wrong `currentPassword` used to collapse onto `401`, which forced the FE
+/// to infer it from a post-refresh retry against a still-valid session.
+/// Since issue #39 it returns `400 + { code: "bad_current", message }` so the
+/// FE can read the failure mode directly; `401` stays reserved for genuine
+/// token failures. Audit + no-mutation invariants unchanged.
 #[tokio::test]
-async fn change_password_wrong_current_returns_401_and_does_not_mutate() {
+async fn change_password_wrong_current_returns_400_bad_current_and_does_not_mutate() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let admin_id = bootstrap_admin_id(&db).await;
     let access = verifier
@@ -1325,16 +1330,52 @@ async fn change_password_wrong_current_returns_401_and_does_not_mutate() {
 
     let hash_before = user_password_hash(&db, &admin_id).await;
     let version_before = user_token_version(&db, &admin_id).await;
+    let failures_before =
+        count_auth_events(&db, &admin_id, "password_change_failure").await;
 
     let body = serde_json::json!({
         "currentPassword": "this-is-not-the-real-password",
         "newPassword": "some-new-password",
     });
     let resp = call(app, change_password_req(&access, &body)).await;
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    let body: serde_json::Value = json_body(resp).await;
+    assert_eq!(body["code"], "bad_current");
+    assert_eq!(body["message"], "Current password is incorrect.");
+    assert!(
+        body.get("error").is_none(),
+        "coded errors must not also carry the legacy `error` field"
+    );
 
     assert_eq!(user_password_hash(&db, &admin_id).await, hash_before);
     assert_eq!(user_token_version(&db, &admin_id).await, version_before);
+    assert_eq!(
+        count_auth_events(&db, &admin_id, "password_change_failure").await,
+        failures_before + 1,
+        "bad-current-password must still write a `password_change_failure` audit row"
+    );
+}
+
+/// Genuine token failures (malformed bearer, bad signature) must still
+/// return `401` — the FE relies on this split post-#39 to tell a real auth
+/// failure from a wrong-password one.
+#[tokio::test]
+async fn change_password_with_malformed_bearer_returns_401() {
+    let (app, _db, _verifier) = build_app_full(lax_rate_cfg()).await;
+    let body = serde_json::json!({
+        "currentPassword": BOOTSTRAP_PASSWORD,
+        "newPassword": "some-new-password",
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/change-password")
+        .header("authorization", "Bearer not-a-real-jwt")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Closes #39. Splits `POST /api/auth/change-password` so wrong `currentPassword` returns **400** with body `{ "code": "bad_current", "message": "Current password is incorrect." }` and **401** stays reserved for genuine token failures.
- Implemented via a narrow new `AppError::BadCurrentPassword` variant + a `CodedErrorBody` serializer. Existing `{ error: ... }` body shape is untouched for every other error path, so no other endpoint's contract moves.
- Audit behaviour is unchanged — the bad-current branch still writes `password_change_failure{reason:bad_current}` before returning, so brute-force probes remain observable.

## Why

`secureAction` on `poolpay-app` transparently retries 401s once after refreshing the access token. Because wrong-password and dead-session both returned 401, the FE had to infer which happened from whether the refresh succeeded (mapping the post-refresh 401 to `bad_current`). Works today, brittle under any BE refactor. Making the split explicit deletes the inference.

## Files

- `src/api/models.rs` — new `AppError::BadCurrentPassword` + `CodedErrorBody { code, message }` serializer. Module-private constants `BAD_CURRENT_PASSWORD_CODE` / `..._MESSAGE` so the wire contract is defined once.
- `src/api/auth_endpoints.rs` — `change_password` returns `BadCurrentPassword` on wrong current instead of `Unauthorized`. Updated the inline doc.
- `tests/auth_integration.rs`
  - `change_password_wrong_current_returns_400_bad_current_and_does_not_mutate` (renamed + retargeted) — asserts status 400, body `{ code: "bad_current", message }`, no `error` field, no hash/version mutation, and that the `password_change_failure` audit row still fires.
  - `change_password_with_malformed_bearer_returns_401` (new) — exercises the explicit 401 side of the contract with a garbage bearer.
- `docs/RUNBOOK.md` — adds the `POST /api/auth/change-password` section with a status/body table including the new `bad_current` code.

## Test plan

- [x] `cargo test --all-targets` → 317 pass (316 baseline + 1 new malformed-bearer test; renamed test is count-neutral)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Wrong-current test asserts 400 + body + audit row
- [x] Malformed-bearer test asserts 401
- [x] Stale-token (`token_version` bump) replay still returns 401 — covered by existing `change_password_rotates_hash_bumps_token_version_and_clears_must_reset` and `promote_target_stale_token`
- [x] Missing-bearer returns 401 — existing `change_password_without_bearer_returns_401`
- [x] Shape-level 400s (missing `newPassword`, whitespace, oversized, `currentPassword` missing when hash exists) unchanged — existing tests green

## Coordination

Merge this before (or with) the FE companion on `poolpay-app` (`poolpay-app` #48), which deletes the `retry_exhausted → bad_current` inference and reads the new 400 + `code` pair directly.