### PR TITLE
Seed more fixtures: 3 pending cycles + 2 role-specific dummy admins

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -241,10 +241,12 @@ The service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`
 **Initialization:**
 - On startup, creates namespace `circle` and database `main`
 - If `SEED_ON_EMPTY=true` and all tables are empty, seeds with fixture data (groups, members, cycles, payments)
-- If `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, also seeds two dev-only admin users after the bootstrap super-admin runs:
-  - `admin1@poolpay.test` — active admin, granted group-admin on fixture group `1`
-  - `admin2@poolpay.test` — active admin, no group grants (use this one to exercise grant creation from the dashboard)
-  - Both use password `PoolPayQA2026!` and `must_reset_password=false` so login is one-shot
+- If `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, also seeds four dev-only admin users after the bootstrap super-admin runs, each mapping a distinct role × grant combination the admin UI can render:
+  - `admin1@poolpay.test` — role `admin`, granted group-admin on fixture group `1` (typical group admin)
+  - `admin2@poolpay.test` — role `admin`, no group grants (target for manually exercising grant creation from the dashboard)
+  - `admin3@poolpay.test` — role `super_admin`, no group grants (second super-admin so super-admin-on-super-admin flows like demotion can be tested without touching the bootstrap account)
+  - `admin4@poolpay.test` — role `admin`, no group grants (stable "orphan admin" baseline that stays ungranted even after admin2 is manually granted during testing)
+  - All use password `PoolPayQA2026!` and `must_reset_password=false` so login is one-shot
   - Idempotent across restarts; existing users are re-used and admin1's fixture grant is re-asserted if it was manually removed
   - Guard is fail-closed on two axes: either an unset/misconfigured `APP_ENV` **or** `SEED_ON_EMPTY!=true` prevents any writes on this path. Both must be satisfied.
 

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -3,6 +3,7 @@
 //! Runs once at startup and on demand in tests. Idempotent: if any active
 //! admin user already exists, this is a no-op.
 
+use surrealdb::types::RecordId;
 use tracing::{info, warn};
 
 use crate::api::models::{
@@ -254,6 +255,15 @@ async fn ensure_admin_fixture(
     role: &str,
     super_admin_id: &str,
 ) -> Result<Option<String>, surrealdb::Error> {
+    // Defence-in-depth: `role` is only ever sourced from the in-module
+    // `DUMMY_ADMINS` `const`, but guard against a typo slipping in during
+    // future edits so a bogus role can't be silently written to `user.role`
+    // (where extractors + admin_users UPDATE queries compare against the
+    // exact strings `"admin"` / `"super_admin"`).
+    assert!(
+        matches!(role, "admin" | "super_admin"),
+        "fixture admin role must be 'admin' or 'super_admin', got {role:?}"
+    );
     let email_normalised = email.to_lowercase();
 
     let mut resp = db
@@ -280,10 +290,28 @@ async fn ensure_admin_fixture(
                     && u.status == "active"
                     && matches!(u.role.as_str(), "admin" | "super_admin") =>
             {
-                info!(
-                    email_redacted = redact(email),
-                    "fixture admin already seeded — reusing user_id"
-                );
+                // Reconcile drift: if the fixture spec now declares a role
+                // different from what's persisted (e.g. admin3 was demoted
+                // to `admin` via the UI since the last boot), restore the
+                // spec'd role so the declared fixture matrix is the source
+                // of truth. Mirrors `admin_users::update` — bump `version`
+                // for OCC and `token_version` to invalidate any live access
+                // tokens the reconciled user still holds.
+                if u.role.as_str() != role {
+                    reconcile_fixture_role(db, &identity.user_id, role).await?;
+                    info!(
+                        email_redacted = redact(email),
+                        user_id = identity.user_id.as_str(),
+                        from = u.role.as_str(),
+                        to = role,
+                        "fixture admin role drifted from spec — reconciled"
+                    );
+                } else {
+                    info!(
+                        email_redacted = redact(email),
+                        "fixture admin already seeded — reusing user_id"
+                    );
+                }
                 Ok(Some(identity.user_id))
             }
             Some(_) => {
@@ -427,6 +455,34 @@ async fn rollback_fixture_user(db: &DbConn, user_id: &str) {
             "fixture admin rollback failed after identity error — orphan user row"
         );
     }
+}
+
+/// Reconcile a persisted fixture admin's role to the spec. Used when
+/// `ensure_admin_fixture` detects that `user.role` has drifted from the
+/// `DUMMY_ADMINS` entry (typically because the UI was used to promote or
+/// demote the fixture between restarts). Bumps `version` (OCC) and
+/// `token_version` (invalidates cached access tokens) to match the
+/// semantics of the real `PATCH /api/admin/users/:id` role-change path.
+async fn reconcile_fixture_role(
+    db: &DbConn,
+    user_id: &str,
+    new_role: &str,
+) -> Result<(), surrealdb::Error> {
+    let now = now_iso();
+    db.query(
+        "UPDATE $id SET \
+             role = $role, \
+             updated_at = $now, \
+             version = version + 1, \
+             token_version = token_version + 1 \
+         WHERE deleted_at IS NONE",
+    )
+    .bind(("id", RecordId::new("user", user_id.to_string())))
+    .bind(("role", new_role.to_string()))
+    .bind(("now", now))
+    .await?
+    .check()?;
+    Ok(())
 }
 
 async fn ensure_group_admin_grant(

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -19,7 +19,32 @@ const CREDENTIALS_PROVIDER: &str = "credentials";
 /// `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, so
 /// production boots cannot accidentally plant it.
 const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
-const DUMMY_ADMIN_EMAILS: [&str; 2] = ["admin1@poolpay.test", "admin2@poolpay.test"];
+
+/// Declarative spec for the dev-only fixture admin accounts. Each row pairs
+/// an email with its role and whether to receive a `group_admin` grant on
+/// `FIXTURE_GROUP_ID` — lets us cover every role × grant combination the
+/// admin UI can render without branching inside the seed loop.
+///
+/// Current matrix:
+/// - admin1: `admin` + FIXTURE_GROUP_ID grant — typical group admin.
+/// - admin2: `admin`, no grant — target for manually testing grant creation.
+/// - admin3: `super_admin`, no grant — second super-admin so super-admin-on-
+///   super-admin flows (e.g. demotion) can be exercised without touching
+///   the bootstrap account.
+/// - admin4: `admin`, no grant — stable "orphan admin" baseline that stays
+///   ungranted even after admin2 gets manually granted during testing.
+struct DummyAdmin {
+    email: &'static str,
+    role: &'static str,
+    grant_fixture_group: bool,
+}
+
+const DUMMY_ADMINS: [DummyAdmin; 4] = [
+    DummyAdmin { email: "admin1@poolpay.test", role: "admin",       grant_fixture_group: true  },
+    DummyAdmin { email: "admin2@poolpay.test", role: "admin",       grant_fixture_group: false },
+    DummyAdmin { email: "admin3@poolpay.test", role: "super_admin", grant_fixture_group: false },
+    DummyAdmin { email: "admin4@poolpay.test", role: "admin",       grant_fixture_group: false },
+];
 
 /// Seed the initial admin account if none exists and the required env vars
 /// are set. Safe to call on every boot.
@@ -182,15 +207,19 @@ pub async fn seed_dummy_admins_with_flag(
         }
     };
 
-    for (idx, email) in DUMMY_ADMIN_EMAILS.iter().enumerate() {
-        let user_id = ensure_admin_fixture(db, email, DUMMY_ADMIN_PASSWORD, &super_admin_id)
-            .await?;
-        // Only admin1 (index 0) gets the group grant — admin2 stays
-        // ungranted so the dashboard has a target for testing grant creation.
+    for spec in DUMMY_ADMINS.iter() {
+        let user_id = ensure_admin_fixture(
+            db,
+            spec.email,
+            DUMMY_ADMIN_PASSWORD,
+            spec.role,
+            &super_admin_id,
+        )
+        .await?;
         // Re-asserting the grant on every run (not just when the user was
         // created this run) restores it after manual cleanup / partial prior
         // runs; `ensure_group_admin_grant` is idempotent on unique conflict.
-        if idx == 0 {
+        if spec.grant_fixture_group {
             if let Some(user_id) = user_id {
                 ensure_group_admin_grant(db, &user_id, FIXTURE_GROUP_ID, &super_admin_id).await?;
             }
@@ -222,6 +251,7 @@ async fn ensure_admin_fixture(
     db: &DbConn,
     email: &str,
     password_plain: &str,
+    role: &str,
     super_admin_id: &str,
 ) -> Result<Option<String>, surrealdb::Error> {
     let email_normalised = email.to_lowercase();
@@ -292,7 +322,7 @@ async fn ensure_admin_fixture(
         email: email.to_string(),
         email_normalised: email_normalised.clone(),
         password_hash: Some(password_hash),
-        role: "admin".into(),
+        role: role.into(),
         status: "active".into(),
         token_version: 0,
         // Dev fixtures skip the first-login rotation so the login flow is

--- a/src/db.rs
+++ b/src/db.rs
@@ -329,7 +329,29 @@ fn fixture_cycles() -> Vec<(&'static str, CycleContent)> {
         ("3", CycleContent {
             cycle_number: 9, start_date: "2026-03-01".into(), end_date: "2026-03-31".into(),
             contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "3".into(), status: "active".into(), group_id, notes: None,
+            recipient_member_id: "3".into(), status: "active".into(), group_id: group_id.clone(), notes: None,
+            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
+        }),
+        // Round 2 upcoming: Apr–Jun 2026 (cycles 10–12, pending). Scheduled
+        // but not yet started — gives the dashboard a `pending` cycle state
+        // to render alongside closed/active, and extends the rotation preview
+        // through end-of-round without disturbing the active-cycle id (3).
+        ("10", CycleContent {
+            cycle_number: 10, start_date: "2026-04-01".into(), end_date: "2026-04-30".into(),
+            contribution_per_member: 1_000_000, total_amount: 6_000_000,
+            recipient_member_id: "4".into(), status: "pending".into(), group_id: group_id.clone(), notes: None,
+            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
+        }),
+        ("11", CycleContent {
+            cycle_number: 11, start_date: "2026-05-01".into(), end_date: "2026-05-31".into(),
+            contribution_per_member: 1_000_000, total_amount: 6_000_000,
+            recipient_member_id: "5".into(), status: "pending".into(), group_id: group_id.clone(), notes: None,
+            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
+        }),
+        ("12", CycleContent {
+            cycle_number: 12, start_date: "2026-06-01".into(), end_date: "2026-06-30".into(),
+            contribution_per_member: 1_000_000, total_amount: 6_000_000,
+            recipient_member_id: "6".into(), status: "pending".into(), group_id, notes: None,
             created_at: created_at.into(), updated_at: created_at.into(), version: 1,
         }),
     ]

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -6,7 +6,8 @@
 /// Fixture counts (defined in db.rs):
 ///   - 1 group
 ///   - 6 members (all in group 1)
-///   - 9 cycles (all in group 1)
+///   - 12 cycles (all in group 1): cycles 1–8 closed, cycle 9 active,
+///     cycles 10–12 pending (upcoming Apr–Jun 2026)
 ///   - 49 payments
 use axum::{
     body::Body,
@@ -723,10 +724,10 @@ async fn get_cycles_returns_200() {
 }
 
 #[tokio::test]
-async fn get_cycles_returns_nine_cycles() {
+async fn get_cycles_returns_all_fixture_cycles() {
     let resp = call(test_app().await, get("/api/cycles")).await;
     let cycles: Vec<serde_json::Value> = json_body(resp).await;
-    assert_eq!(cycles.len(), 9);
+    assert_eq!(cycles.len(), 12);
 }
 
 #[tokio::test]
@@ -773,7 +774,7 @@ async fn get_cycles_status_values_are_valid() {
 async fn get_cycles_filter_by_group_id() {
     let resp = call(test_app().await, get("/api/cycles?groupId=1")).await;
     let cycles: Vec<serde_json::Value> = json_body(resp).await;
-    assert_eq!(cycles.len(), 9);
+    assert_eq!(cycles.len(), 12);
 }
 
 #[tokio::test]
@@ -1374,7 +1375,7 @@ async fn reset_restores_cycles() {
     call(app.clone(), post_empty("/api/test/reset")).await;
     let cycles: Vec<serde_json::Value> =
         json_body(call(app, get("/api/cycles")).await).await;
-    assert_eq!(cycles.len(), 9);
+    assert_eq!(cycles.len(), 12);
 }
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2946,3 +2946,72 @@ async fn seed_dummy_admins_skips_grant_when_fixture_user_is_disabled() {
     );
 }
 
+#[tokio::test]
+async fn seed_dummy_admins_reconciles_role_drift_on_restart() {
+    // If a fixture admin was re-roled via the admin UI after first seed
+    // (e.g. admin3 demoted from super_admin to admin), the next restart
+    // must restore the role declared in DUMMY_ADMINS so the fixture matrix
+    // stays the source of truth. Also bumps token_version so any cached
+    // access token the drifted user held is invalidated.
+    let (_app, db) = test_app().await;
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("first seed");
+
+    // Drift admin3 from super_admin -> admin, simulating a manual demotion
+    // via PATCH /api/admin/users/:id.
+    let admin3_tv_before: Vec<i64> = db
+        .query(
+            "SELECT VALUE token_version FROM user \
+             WHERE email_normalised = 'admin3@poolpay.test'",
+        )
+        .await
+        .unwrap()
+        .check()
+        .unwrap()
+        .take(0)
+        .unwrap();
+    let tv_before = *admin3_tv_before.first().expect("admin3 token_version");
+    db.query(
+        "UPDATE user SET role = 'admin' \
+         WHERE email_normalised = 'admin3@poolpay.test'",
+    )
+    .await
+    .unwrap()
+    .check()
+    .unwrap();
+
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("second seed reconciles role");
+
+    let super_admin_rows = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised = 'admin3@poolpay.test' \
+         AND role = 'super_admin' AND status = 'active' \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        super_admin_rows, 1,
+        "admin3 must be reconciled back to super_admin after drift"
+    );
+
+    let admin3_tv_after: Vec<i64> = db
+        .query(
+            "SELECT VALUE token_version FROM user \
+             WHERE email_normalised = 'admin3@poolpay.test'",
+        )
+        .await
+        .unwrap()
+        .check()
+        .unwrap()
+        .take(0)
+        .unwrap();
+    let tv_after = *admin3_tv_after.first().expect("admin3 token_version");
+    assert!(
+        tv_after > tv_before,
+        "role reconciliation must bump token_version (before={tv_before}, after={tv_after})"
+    );
+}

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2751,23 +2751,45 @@ async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_creates_both_admins_and_grant_for_admin1() {
+async fn seed_dummy_admins_creates_all_fixtures_with_expected_roles_and_grants() {
     let (_app, db) = test_app().await;
     bootstrap::seed_dummy_admins_with_flag(&db, true)
         .await
         .expect("seed_dummy_admins");
 
-    let admins = count_rows(
+    // admin1, admin2, admin4 — regular `admin` role.
+    let admin_role_rows = count_rows(
         &db,
         "SELECT count() FROM user \
-         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         WHERE email_normalised IN [\
+             'admin1@poolpay.test', 'admin2@poolpay.test', 'admin4@poolpay.test'\
+         ] \
          AND role = 'admin' AND status = 'active' AND must_reset_password = false \
          GROUP ALL",
     )
     .await;
-    assert_eq!(admins, 2, "both fixture admins must be created as active admin-role users");
+    assert_eq!(
+        admin_role_rows, 3,
+        "admin1/admin2/admin4 must be created as active admin-role users"
+    );
 
-    let grants = count_rows(
+    // admin3 — super_admin role, to exercise super-admin-on-super-admin flows
+    // without touching the bootstrap account.
+    let super_admin_rows = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised = 'admin3@poolpay.test' \
+         AND role = 'super_admin' AND status = 'active' AND must_reset_password = false \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        super_admin_rows, 1,
+        "admin3 must be created as an active super_admin"
+    );
+
+    // Only admin1 receives a FIXTURE_GROUP_ID grant.
+    let admin1_grants = count_rows(
         &db,
         "SELECT count() FROM group_admin \
          WHERE group_id = '1' AND user_id IN (\
@@ -2775,17 +2797,21 @@ async fn seed_dummy_admins_creates_both_admins_and_grant_for_admin1() {
          ) GROUP ALL",
     )
     .await;
-    assert_eq!(grants, 1, "admin1 must receive exactly one fixture grant on group 1");
+    assert_eq!(admin1_grants, 1, "admin1 must receive exactly one fixture grant on group 1");
 
-    let admin2_grants = count_rows(
-        &db,
-        "SELECT count() FROM group_admin \
-         WHERE user_id IN (\
-             SELECT VALUE meta::id(id) FROM user WHERE email_normalised = 'admin2@poolpay.test'\
-         ) GROUP ALL",
-    )
-    .await;
-    assert_eq!(admin2_grants, 0, "admin2 must not receive any fixture grants");
+    for email in ["admin2@poolpay.test", "admin3@poolpay.test", "admin4@poolpay.test"] {
+        let grants = count_rows(
+            &db,
+            &format!(
+                "SELECT count() FROM group_admin \
+                 WHERE user_id IN (\
+                     SELECT VALUE meta::id(id) FROM user WHERE email_normalised = '{email}'\
+                 ) GROUP ALL"
+            ),
+        )
+        .await;
+        assert_eq!(grants, 0, "{email} must not receive any fixture grants");
+    }
 }
 
 #[tokio::test]
@@ -2801,11 +2827,14 @@ async fn seed_dummy_admins_is_idempotent_across_restarts() {
     let admins = count_rows(
         &db,
         "SELECT count() FROM user \
-         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         WHERE email_normalised IN [\
+             'admin1@poolpay.test', 'admin2@poolpay.test', \
+             'admin3@poolpay.test', 'admin4@poolpay.test'\
+         ] \
          GROUP ALL",
     )
     .await;
-    assert_eq!(admins, 2, "restart must not duplicate fixture admin rows");
+    assert_eq!(admins, 4, "restart must not duplicate fixture admin rows");
 
     let grants = count_rows(
         &db,
@@ -2827,7 +2856,10 @@ async fn seed_dummy_admins_is_noop_without_flag() {
     let admins = count_rows(
         &db,
         "SELECT count() FROM user \
-         WHERE email_normalised IN ['admin1@poolpay.test', 'admin2@poolpay.test'] \
+         WHERE email_normalised IN [\
+             'admin1@poolpay.test', 'admin2@poolpay.test', \
+             'admin3@poolpay.test', 'admin4@poolpay.test'\
+         ] \
          GROUP ALL",
     )
     .await;


### PR DESCRIPTION
## Summary
Expands the dev-only fixture set so every role × grant state the admin UI renders (and the `pending` cycle status) has seeded data — previously only half the matrix was covered, which forced manual setup for each UI path.

- **Cycles (+3):** Adds cycles 10/11/12 as `pending` for Apr/May/Jun 2026 (recipient members 4/5/6, continuing the round-2 rotation). Cycle 3 stays active; no payments change.
- **Admins (+2):** Adds `admin3@poolpay.test` (role `super_admin`) and `admin4@poolpay.test` (role `admin`, no grant). Refactors the fixture constant into a `DummyAdmin` spec array carrying role + grant flag per row.
- **Docs:** `docs/RUNBOOK.md` now lists all four fixtures + the role/grant rationale for each.

## Why

- `pending` cycle status wasn't covered by any fixture — dashboard had no way to render that state without hand-crafting a cycle.
- Only one `super_admin` existed (the bootstrap account). Testing super-admin-on-super-admin flows (role demotion, self-mutation guards) risked bricking bootstrap, which requires a DB wipe to recover. admin3 is a disposable second super-admin.
- admin4 is a stable "orphan admin" baseline — once admin2 is manually granted during testing, there's no other ungranted admin to exercise the empty-grants UI state.

## Scope trade-off

Originally considered flipping cycle 3 → closed and activating cycle 10. Walked that back: ~20 tests in `tests/api_integration.rs` hardcode cycle id `3` as the active cycle (payment creation, member-delete-guard checks, etc). Pending cycles add the missing state without disturbing those invariants.

## Test plan
- [x] `cargo test` — full suite green (317 tests, including 5 seed tests and 8 cycle tests)
- [x] `cargo build` + `cargo clippy --tests` clean
- [ ] Manual: `SEED_ON_EMPTY=true APP_ENV=development cargo run`, confirm all 4 admin accounts log in with `PoolPayQA2026!` and dashboard shows 12 cycles (3 pending)
- [ ] Manual: verify admin3 can demote/promote roles (excluding self) without affecting bootstrap super-admin