### PR TITLE
[DOCS] - Add ai-workflow guide and graphify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Rust service that manages PoolPay savings groups with a REST API and WhatsApp receipt OCR. Built with Axum, SurrealDB, and Green API.
 
+> Docs index: [`docs/INDEX.md`](./docs/INDEX.md). For AI-assisted development setup see [`docs/ai-workflow.md`](./docs/ai-workflow.md) (optional).
+
 ## What it does
 
 **REST API** for managing multi-group PoolPay savings groups:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-Last Updated: 2026-04-14
+Last Updated: 2026-05-08
 
 Quick reference to all documentation for the PoolPay project.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,16 @@ Start here if you're setting up the development environment or contributing code
   - Git workflow and commit conventions
   - Troubleshooting common build issues
 
+## For AI-Assisted Development
+
+Optional. Skip if you don't use AI agents.
+
+- **[ai-workflow.md](./ai-workflow.md)** — Setup for AI-assisted development
+  - Graphify (codebase knowledge graph) install + first run
+  - Supported agents (Claude Code, Cursor, Codex, Aider, etc.)
+  - Maintenance and useful slash commands
+  - Why graph artefacts are gitignored
+
 ## For Operations
 
 Start here if you're deploying, running, or troubleshooting the service in production.

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -45,7 +45,7 @@ After meaningful structural changes (new modules, big renames, removed files), r
 graphify update .
 ```
 
-AST-only mode is local + free (no API cost). For semantic enrichment with an LLM, set `GEMINI_API_KEY` and run `graphify extract .` — optional.
+AST-only mode is local + free (no API cost). For semantic enrichment with an LLM, set `GEMINI_API_KEY` and run `graphify extract .` — optional. Treat `GEMINI_API_KEY` as a secret: keep it in your shell profile or a secret manager, and never paste it into tracked files (`.env` files, scripts, docs, commit messages).
 
 ## Useful commands inside the agent
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -7,7 +7,7 @@ This repo is built with AI-assisted development. Tooling is **optional** and **a
 ```bash
 uv tool install graphifyy        # one-time global install
 graphify install --platform claude   # one-time Claude Code skill registration (or pick another agent)
-cd ~/projects/poolpay-api
+cd /path/to/poolpay-api
 graphify update .                # builds graphify-out/ — your local code knowledge graph
 ```
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -4,6 +4,8 @@ This repo is built with AI-assisted development. Tooling is **optional** and **a
 
 ## TL;DR
 
+> Prerequisite: `uv` (Astral's Python package manager). Install via `curl -LsSf https://astral.sh/uv/install.sh | sh` or see [the uv install guide](https://docs.astral.sh/uv/getting-started/installation/). If you'd rather not use `uv`, swap step 1 for `pipx install graphifyy` (or `pip install --user graphifyy`).
+
 ```bash
 uv tool install graphifyy        # one-time global install
 graphify install --platform claude   # one-time Claude Code skill registration (or pick another agent)

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,10 +1,10 @@
 # AI Workflow — poolpay-api
 
-This repo is built with AI-assisted development. Tooling is **optional** and **agent-agnostic** — you can contribute without it. If you want the AI to navigate the codebase efficiently (instead of grepping 40 files per question), follow this guide.
+Contributing to this repo does **not** require any AI tooling — a plain editor and the standard toolchain are enough. This guide is for contributors who *choose* to use an AI assistant and want it to navigate the codebase efficiently (instead of grepping 40 files per question).
 
 ## TL;DR
 
-> Prerequisite: `uv` (Astral's Python package manager). Install via `curl -LsSf https://astral.sh/uv/install.sh | sh` or see [the uv install guide](https://docs.astral.sh/uv/getting-started/installation/). If you'd rather not use `uv`, swap step 1 for `pipx install graphifyy` (or `pip install --user graphifyy`).
+> Prerequisite: `uv` (Astral's Python package manager). The simplest install is `curl -LsSf https://astral.sh/uv/install.sh | sh` — if you're cautious about piping a remote script straight into a shell (reasonable!), download it first (`curl -LsSf https://astral.sh/uv/install.sh -o uv-install.sh`), inspect it, then run `sh uv-install.sh`. The [uv install guide](https://docs.astral.sh/uv/getting-started/installation/) also lists Homebrew, winget, and standalone installer options. If you'd rather skip `uv` entirely, swap step 1 for `pipx install graphifyy` (or `pip install --user graphifyy`).
 
 ```bash
 uv tool install graphifyy        # one-time global install
@@ -13,7 +13,7 @@ cd /path/to/poolpay-api
 graphify update .                # builds graphify-out/ — your local code knowledge graph
 ```
 
-That's it. `graphify-out/` is a derived artefact and shouldn't be committed — add it to your global gitignore (`~/.gitignore_global`) or this clone's `.git/info/exclude` so it stays out of every commit.
+That's it. `graphify-out/` is a derived artefact and shouldn't be committed. The simplest fix is to add it to this clone's `.git/info/exclude` (works immediately, no Git config needed). Alternatively, if you have a global excludes file configured (`git config --global core.excludesfile` — usually `~/.config/git/ignore` or `~/.gitignore_global`), add it there so it's ignored across every repo.
 
 ## What is graphify?
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -11,7 +11,7 @@ cd ~/projects/poolpay-api
 graphify update .                # builds graphify-out/ — your local code knowledge graph
 ```
 
-That's it. `graphify-out/` is already gitignored globally.
+That's it. `graphify-out/` is a derived artefact and shouldn't be committed — add it to your global gitignore (`~/.gitignore_global`) or this clone's `.git/info/exclude` so it stays out of every commit.
 
 ## What is graphify?
 
@@ -57,7 +57,7 @@ Once the agent has the graph loaded, prefer these over grep:
 
 ## What's NOT in this repo
 
-- The graph artefacts (`graphify-out/`) — gitignored globally; each dev builds their own
+- The graph artefacts (`graphify-out/`) — each dev builds their own; keep it out of commits via your global gitignore or `.git/info/exclude`
 - Claude Code per-repo settings — graphify integrates via a **global skill** in your `~/.claude/`, not via repo hooks. Nothing to commit, nothing future devs inherit by accident.
 - Project context / decisions / roadmap — those live in the team's knowledge wiki (currently in the maintainer's Obsidian vault; public mirror TBD)
 
@@ -75,4 +75,4 @@ Once the agent has the graph loaded, prefer these over grep:
 
 ## Why this is opt-in
 
-The graph is a **derived artefact**, not source. Each dev's local copy reflects their local code state. Committing it would create constant noise (regenerated on every code change), so we keep it local-only via the global gitignore.
+The graph is a **derived artefact**, not source. Each dev's local copy reflects their local code state. Committing it would create constant noise (regenerated on every code change), so we keep it local-only via each contributor's global gitignore (or `.git/info/exclude`).

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,0 +1,78 @@
+# AI Workflow — poolpay-api
+
+This repo is built with AI-assisted development. Tooling is **optional** and **agent-agnostic** — you can contribute without it. If you want the AI to navigate the codebase efficiently (instead of grepping 40 files per question), follow this guide.
+
+## TL;DR
+
+```bash
+uv tool install graphifyy        # one-time global install
+graphify install --platform claude   # one-time Claude Code skill registration (or pick another agent)
+cd ~/projects/poolpay-api
+graphify update .                # builds graphify-out/ — your local code knowledge graph
+```
+
+That's it. `graphify-out/` is already gitignored globally.
+
+## What is graphify?
+
+A CLI that turns the codebase into a queryable knowledge graph (AST-based, no LLM needed for the basic graph). It writes three artefacts to `graphify-out/`:
+
+| File | Purpose |
+|---|---|
+| `graph.html` | Interactive browser visualisation — click nodes, search, filter |
+| `GRAPH_REPORT.md` | Markdown summary: god nodes, surprising connections, suggested questions |
+| `graph.json` | Programmatic access for AI assistants |
+
+When you ask Claude Code (or any supporting agent) a codebase question, it reads `GRAPH_REPORT.md` instead of grepping. Faster, fewer tokens, structurally aware.
+
+## Supported agents
+
+Graphify ships with skills for:
+
+- Claude Code → `graphify install --platform claude`
+- Cursor → `graphify install --platform cursor`
+- OpenCode / Codex / Gemini CLI / Aider / GitHub Copilot CLI / Trae / Hermes / Kiro / Pi / Antigravity → see `graphify install --help`
+
+Pick the one you use. They all read the same `graphify-out/` artefacts.
+
+## Maintenance
+
+After meaningful structural changes (new modules, big renames, removed files), refresh the graph:
+
+```bash
+graphify update .
+```
+
+AST-only mode is local + free (no API cost). For semantic enrichment with an LLM, set `GEMINI_API_KEY` and run `graphify extract .` — optional.
+
+## Useful commands inside the agent
+
+Once the agent has the graph loaded, prefer these over grep:
+
+| Question | Command |
+|---|---|
+| "How does X relate to Y?" | `/graphify path "X" "Y"` |
+| "Explain this concept" | `/graphify explain "concept"` |
+| "Open question about codebase" | `/graphify query "your question"` |
+
+## What's NOT in this repo
+
+- The graph artefacts (`graphify-out/`) — gitignored globally; each dev builds their own
+- Claude Code per-repo settings — graphify integrates via a **global skill** in your `~/.claude/`, not via repo hooks. Nothing to commit, nothing future devs inherit by accident.
+- Project context / decisions / roadmap — those live in the team's knowledge wiki (currently in the maintainer's Obsidian vault; public mirror TBD)
+
+## Companion repos
+
+- **poolpay-app** — the Next.js dashboard. Same graphify setup applies in that repo; build its graph separately with `graphify update .` from its root.
+
+## Troubleshooting
+
+| Issue | Fix |
+|---|---|
+| `command not found: graphify` | Run `uv tool install graphifyy`, ensure `~/.local/bin` (or `uv` install dir) is on `PATH` |
+| Graph feels stale | Run `graphify update .` — AST-only, fast, free |
+| Agent doesn't seem to use the graph | Confirm `graphify-out/GRAPH_REPORT.md` exists and the platform skill is installed (`graphify install --platform <agent>`) |
+
+## Why this is opt-in
+
+The graph is a **derived artefact**, not source. Each dev's local copy reflects their local code state. Committing it would create constant noise (regenerated on every code change), so we keep it local-only via the global gitignore.


### PR DESCRIPTION
## Summary

- Adds `docs/ai-workflow.md` documenting the optional graphify setup for AI-assisted development
- Updates `docs/INDEX.md` with a new "For AI-Assisted Development" section
- Updates `README.md` with a top-of-file pointer to the docs index and ai-workflow guide

## Why

Graphify turns the codebase into a queryable knowledge graph (AST-based, Tree-sitter + Leiden clustering) so AI agents can navigate structural context instead of grepping every file. This PR documents the setup so future contributors can opt in regardless of which AI agent they use.

The graph artefacts (`graphify-out/`) are gitignored globally and rebuilt locally per clone — nothing in this repo changes for contributors who don't use AI agents.

## Scope

Pure docs. No code, no config, no hooks. Graphify integrates via a global Claude Code skill (`~/.claude/skills/graphify/`) rather than a per-repo `PreToolUse` hook, so there's no committed integration for future teammates to inherit by accident.

## Agent-agnostic

The guide covers install paths for Claude Code, Cursor, Codex, Aider, Gemini CLI, GitHub Copilot CLI, OpenCode, Trae, Hermes, Kiro, Pi, and Antigravity. Each contributor picks the agent they use.

## Companion PR

Mirror in `poolpay-app`: https://github.com/Sensei3k/poolpay-app/pull/51

## Test plan

- [ ] Render `docs/ai-workflow.md` on GitHub — verify markdown formatting, tables, and code blocks
- [ ] Confirm the new section in `docs/INDEX.md` appears between "For Developers" and "For Operations"
- [ ] Verify `README.md` link resolves to `docs/INDEX.md`