### PR TITLE
[DOCS] - Sync docs with main + add justfile for dev/surreal scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,13 +43,17 @@ NEXTAUTH_BACKEND_SECRET=your_nextauth_backend_secret_here
 # SURREAL_PASS=root
 
 # Set to "true" to seed the database with fixture data when all tables are empty.
-# Also seeds two dev-only admin-role users so the admin-management UI has
-# clickable targets: `admin1@poolpay.test` (granted group-admin on fixture
-# group 1) and `admin2@poolpay.test` (no grants). Both use the password
-# `PoolPayQA2026!` and have `must_reset_password=false`. The dummy-admin
-# path is fail-closed: it additionally requires `APP_ENV=development` or
-# `APP_ENV=test`, so an unset or production `APP_ENV` keeps the fixture
-# credentials out of the DB even if this flag is on.
+# Also seeds four dev-only admin-role users so the admin-management UI has
+# clickable targets:
+#   - `admin1@poolpay.test` — `admin`, granted group-admin on fixture group 1
+#   - `admin2@poolpay.test` — `admin`, no grants (target for grant-creation flows)
+#   - `admin3@poolpay.test` — `super_admin`, no grants
+#   - `admin4@poolpay.test` — `admin`, no grants (stable orphan-admin baseline)
+# All four share the password `PoolPayQA2026!` and have
+# `must_reset_password=false`. The dummy-admin path is fail-closed: it
+# additionally requires `APP_ENV=development` or `APP_ENV=test`, so an
+# unset or production `APP_ENV` keeps the fixture credentials out of the
+# DB even if this flag is on.
 # SEED_ON_EMPTY=true
 
 # Log verbosity: debug | info | warn | error (default: info)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ src/
 │   ├── handlers.rs — HTTP handlers (GET/POST/PATCH/DELETE)
 │   └── models.rs  — API request/response types, EntityId alias, DB/API structs
 tests/
-├── api_integration.rs       — API route, auth, CRUD, OCC integration tests
+├── api_integration.rs       — API route, auth, CRUD, optimistic concurrency control (OCC) integration tests
 ├── auth_integration.rs      — HMAC + bootstrap + password + JWT integration tests
 ├── ingestion_integration.rs — receipt ingestion pipeline tests
 ├── parser_tests.rs          — receipt parser (sender / bank / amount) tests
@@ -99,7 +99,7 @@ The full list — including auth rate-limiting, JWT keys, and SurrealDB connecti
 | `GREEN_API_INSTANCE_ID` | Yes | — | Instance ID from the Green API dashboard |
 | `GREEN_API_TOKEN` | Yes | — | API token shown next to your instance |
 | `NEXTAUTH_BACKEND_SECRET` | Yes | — | Shared HMAC secret for NextAuth → backend signing (≥ 32 bytes; generate with `openssl rand -hex 32`) |
-| `APP_ENV` | No | unset | Set to `production` to enable strict CORS and disable `/api/test/reset`; `development` / `test` mounts the reset endpoint and unlocks dev-only fixture seeders |
+| `APP_ENV` | No | unset | Set to `production` to enable strict CORS and disable `/api/test/reset`; `development` / `test` mounts the reset endpoint and unlocks dev-only fixture seeders. For local dev set `APP_ENV=development` (or provide `JWT_KEYS`) — JWT verifier init fails closed otherwise and the service won't boot |
 | `DASHBOARD_ORIGIN` | No (required if `APP_ENV=production`) | — | CORS origin for the dashboard (e.g., `https://dashboard.example.com`) |
 | `API_BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
 | `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws` / `wss` / `http` / `https`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The full list — including auth rate-limiting, JWT keys, and SurrealDB connecti
 | `APP_ENV` | No | unset | Set to `production` to enable strict CORS and disable `/api/test/reset`; `development` / `test` mounts the reset endpoint and unlocks dev-only fixture seeders. For local dev set `APP_ENV=development` (or provide `JWT_KEYS`) — JWT verifier init fails closed otherwise and the service won't boot |
 | `DASHBOARD_ORIGIN` | No (required if `APP_ENV=production`) | — | CORS origin for the dashboard (e.g., `https://dashboard.example.com`) |
 | `API_BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
-| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws` / `wss` / `http` / `https`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |
+| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |
 | `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required when `SURREAL_URL` is a network scheme. No defaults — boot fails with a typed error if missing, empty, or whitespace-only |
 | `SEED_ON_EMPTY` | No | `false` | Seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory where receipt files are saved during OCR |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ brew install tesseract poppler pkgconf
 | `cargo check` | Fast type-check without producing a binary |
 | `RUST_LOG=debug cargo run` | Run with verbose debug logging |
 
+The repo also ships a [`justfile`](./justfile) with convenience recipes (`just dev`, `just surreal`, `just reset-db`, `just test`, …). Optional: `brew install just`, then `just --list`. See [docs/CONTRIBUTING.md § just Recipes](./docs/CONTRIBUTING.md#just-recipes-optional).
+
 ## Environment variables
 
 The full list — including auth rate-limiting, JWT keys, and SurrealDB connection options — lives in [`.env.example`](./.env.example) and [`docs/RUNBOOK.md`](./docs/RUNBOOK.md#environment-configuration). The brief overview below covers what most contributors need to get a dev instance running.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The full list — including auth rate-limiting, JWT keys, and SurrealDB connecti
 | `APP_ENV` | No | unset | Set to `production` to enable strict CORS and disable `/api/test/reset`; `development` / `test` mounts the reset endpoint and unlocks dev-only fixture seeders. For local dev set `APP_ENV=development` (or provide `JWT_KEYS`) — JWT verifier init fails closed otherwise and the service won't boot |
 | `DASHBOARD_ORIGIN` | No (required if `APP_ENV=production`) | — | CORS origin for the dashboard (e.g., `https://dashboard.example.com`) |
 | `API_BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
-| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |
+| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |
 | `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required when `SURREAL_URL` is a network scheme. No defaults — boot fails with a typed error if missing, empty, or whitespace-only |
 | `SEED_ON_EMPTY` | No | `false` | Seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory where receipt files are saved during OCR |

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ src/
 │   ├── handlers.rs — HTTP handlers (GET/POST/PATCH/DELETE)
 │   └── models.rs  — API request/response types, EntityId alias, DB/API structs
 tests/
-├── parser_tests.rs     — 28 parser integration tests
-└── api_integration.rs  — 75 API route and database integration tests
+├── api_integration.rs       — API route, auth, CRUD, OCC integration tests
+├── auth_integration.rs      — HMAC + bootstrap + password + JWT integration tests
+├── ingestion_integration.rs — receipt ingestion pipeline tests
+├── parser_tests.rs          — receipt parser (sender / bank / amount) tests
+└── routing_integration.rs   — chat→group / phone→member resolution tests
 ```
 
 The project uses a **lib + bin** layout: `src/lib.rs` exposes all modules as a library crate (`poolpay`), and `src/main.rs` is the binary entry point that imports from it. This allows `tests/` to import the public API directly, keeping integration tests separate from source files.
@@ -87,14 +90,19 @@ brew install tesseract poppler pkgconf
 
 ## Environment variables
 
+The full list — including auth rate-limiting, JWT keys, and SurrealDB connection options — lives in [`.env.example`](./.env.example) and [`docs/RUNBOOK.md`](./docs/RUNBOOK.md#environment-configuration). The brief overview below covers what most contributors need to get a dev instance running.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `GREEN_API_INSTANCE_ID` | Yes | — | Instance ID from the Green API dashboard |
 | `GREEN_API_TOKEN` | Yes | — | API token shown next to your instance |
-| `APP_ENV` | No | `development` | Set to `production` to enable CORS restrictions and disable `/api/test/reset` |
+| `NEXTAUTH_BACKEND_SECRET` | Yes | — | Shared HMAC secret for NextAuth → backend signing (≥ 32 bytes; generate with `openssl rand -hex 32`) |
+| `APP_ENV` | No | unset | Set to `production` to enable strict CORS and disable `/api/test/reset`; `development` / `test` mounts the reset endpoint and unlocks dev-only fixture seeders |
 | `DASHBOARD_ORIGIN` | No (required if `APP_ENV=production`) | — | CORS origin for the dashboard (e.g., `https://dashboard.example.com`) |
 | `API_BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
-| `SEED_ON_EMPTY` | No | `false` | Set to `true` to seed fixture data when all database tables are empty |
+| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws` / `wss` / `http` / `https`, case-insensitive). Remote schemes require `SURREAL_USER` + `SURREAL_PASS` |
+| `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required when `SURREAL_URL` is a network scheme. No defaults — boot fails with a typed error if missing, empty, or whitespace-only |
+| `SEED_ON_EMPTY` | No | `false` | Seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory where receipt files are saved during OCR |
 | `RUST_LOG` | No | `info` | Log verbosity — `debug`, `info`, `warn`, `error` |
 
@@ -104,26 +112,16 @@ brew install tesseract poppler pkgconf
 cargo test
 ```
 
-106 tests total — 3 models + 28 parser + 75 API integration:
+328 tests across 6 binaries (in-memory SurrealDB; no filesystem or external API calls):
 
-**Models** (`src/models.rs` — `#[cfg(test)]` module, 3 tests):
-
-| Group | Tests | What's covered |
+| Binary | Tests | What's covered |
 |---|---|---|
-| `notification_id_message` | 3 | `idMessage` deserialises from body level (not messageData), absent field is `None`, `MessageData` does not contain `idMessage` |
-
-**Parser** (`tests/parser_tests.rs`, 28 tests):
-
-| Group | Tests | What's covered |
-|---|---|---|
-| Amount | 11 | `₦` symbol, `#` → `₦` normalisation, mid-number OCR spaces, `NGN` prefix, trailing zeros, no decimal, absent amount |
-| Sender | 8 | Primary label, case insensitivity, fallback labels (`Sender:`, `From:`, `Originator:`), OCR garbage after name, absent sender, whitespace trimming |
-| Bank | 7 | Next-line extraction, pipe-separator stripping, known-bank fallback, case insensitivity, absent bank, leading-space trimming |
-| Combined | 2 | Full realistic receipts (OPay style, heavy OCR noise) |
-
-**API Integration** (`tests/api_integration.rs`, 75 tests):
-
-Covers admin CRUD for groups, members, cycles, and payments including auth (bearer token validation, missing/invalid token rejection), validation (empty names, invalid dates, negative amounts), soft delete guards (cannot delete group with members, member with active cycles), optimistic concurrency (version mismatch conflicts), cross-group validation (member and cycle must belong to same group), and fixture seeding.
+| `src/lib.rs` (unit) | 36 | Inline `#[cfg(test)]` modules — models, password hashing, HMAC primitives, scheme detection, URL redaction, env-credential gates |
+| `tests/api_integration.rs` | 132 | Admin CRUD (groups, members, cycles, payments), bearer auth, JWT verification, validation, soft-delete guards, optimistic concurrency, cross-group constraints, admin-user CRUD, group-admin grants |
+| `tests/auth_integration.rs` | 105 | HMAC `verify-credentials` / `ensure-user`, bootstrap idempotency, change-password (wrong-current 400 + token-version invalidation), refresh rotation + reuse detection, dev-fixture seeder gates |
+| `tests/parser_tests.rs` | 35 | Amount (`₦`, `#`-normalisation, OCR spacing, `NGN` prefix), sender (primary + fallback labels), bank (line-after, pipe stripping, known-bank fallback), combined receipts |
+| `tests/routing_integration.rs` | 12 | Chat-id → group + phone → member resolution; soft-delete handling on routing lookups |
+| `tests/ingestion_integration.rs` | 8 | End-to-end receipt ingestion pipeline (Green API webhook → OCR → parse → persist → reply) |
 
 ## Known limitations
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -278,7 +278,7 @@ If you've installed `just` (see [Optional: `just` task runner](#optional-just-ta
 | `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive) — see [RUNBOOK § Environment Configuration](./RUNBOOK.md#environment-configuration) |
 | `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required only when `SURREAL_URL` is a network scheme. Boot fails with a typed error if missing, empty, or whitespace-only |
 
-For auth rate-limiting, JWT key material, and proxy-header trust (`AUTH_*`, `JWT_*`, `TRUST_PROXY_HEADERS`), see [RUNBOOK § Auth Rate Limiting](./RUNBOOK.md#auth-rate-limiting) and [RUNBOOK § JWT Verification + Refresh Rotation](./RUNBOOK.md#jwt-verification--refresh-rotation). Production sets these; local development falls back to safe defaults.
+For auth rate-limiting, JWT key material, and proxy-header trust (`AUTH_*`, `JWT_*`, `TRUST_PROXY_HEADERS`), see [RUNBOOK § Auth Rate Limiting](./RUNBOOK.md#auth-rate-limiting) and [RUNBOOK § JWT Verification + Refresh Rotation](./RUNBOOK.md#jwt-verification--refresh-rotation). Production must set `JWT_KEYS`. Local development only falls back to an ephemeral keypair when `APP_ENV` is explicitly `development` or `test` — leaving `APP_ENV` unset (or any other value) fails closed and the service will not boot without `JWT_KEYS`.
 
 ## Git Workflow
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -275,7 +275,7 @@ If you've installed `just` (see [Optional: `just` task runner](#optional-just-ta
 | `SEED_ON_EMPTY` | No | `false` | Set to `true` to seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory for temporary receipt files during OCR |
 | `RUST_LOG` | No | `info` | Log level filter: `debug`, `info`, `warn`, `error` |
-| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive) — see [RUNBOOK § Environment Configuration](./RUNBOOK.md#environment-configuration) |
+| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive) — see [RUNBOOK § Environment Configuration](./RUNBOOK.md#environment-configuration) |
 | `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required only when `SURREAL_URL` is a network scheme. Boot fails with a typed error if missing, empty, or whitespace-only |
 
 For auth rate-limiting, JWT key material, and proxy-header trust (`AUTH_*`, `JWT_*`, `TRUST_PROXY_HEADERS`), see [RUNBOOK § Auth Rate Limiting](./RUNBOOK.md#auth-rate-limiting) and [RUNBOOK § JWT Verification + Refresh Rotation](./RUNBOOK.md#jwt-verification--refresh-rotation). Production must set `JWT_KEYS`. Local development only falls back to an ephemeral keypair when `APP_ENV` is explicitly `development` or `test` — leaving `APP_ENV` unset (or any other value) fails closed and the service will not boot without `JWT_KEYS`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -257,7 +257,7 @@ If you've installed `just` (see [Optional: `just` task runner](#optional-just-ta
 | `just reset-db` | `rm -rf ./data.surreal` — wipe local DB so next boot reseeds fixtures |
 | `just test` | `cargo test` |
 | `just check` | `cargo check` |
-| `just lint` | `cargo fmt --check && cargo clippy --all-targets -- -D warnings` (matches pre-commit gate) |
+| `just lint` | `cargo fmt --check && cargo clippy --all-targets -- -D warnings` (run before pushing) |
 | `just fmt` | `cargo fmt` |
 
 ## Environment Variables

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PoolPay
 
-Last Updated: 2026-04-14
+Last Updated: 2026-05-09
 
 ## Prerequisites
 
@@ -122,12 +122,13 @@ Supported log levels: `debug`, `info`, `warn`, `error`.
 cargo test
 ```
 
-Runs 193 tests across unit + integration suites:
-- **Unit tests** — models, parser, password hashing, HMAC primitives
-- **Parser integration** — amount extraction, sender detection, bank matching
-- **API integration** — admin CRUD, auth, validation, soft delete, version conflicts, route handlers
-- **Auth integration** — HMAC-gated `verify-credentials` / `ensure-user`, bootstrap idempotency, field-length caps
-- **Routing / ingestion integration** — chat→group resolution, receipt ingestion pipeline
+Runs 328 tests across 6 binaries:
+- **Unit tests** (`src/lib.rs`, 36) — models, password hashing, HMAC primitives, SurrealDB scheme detection (`is_remote_scheme`), URL userinfo redaction, env-credential gates
+- **API integration** (132) — admin CRUD (groups / members / cycles / payments), JWT verification + bearer auth, validation, soft-delete guards, optimistic concurrency, admin-user CRUD, group-admin grants + revokes
+- **Auth integration** (105) — HMAC `verify-credentials` / `ensure-user` / `issue`, bootstrap idempotency, change-password (wrong-current 400 + `token_version` invalidation), refresh rotation + reuse detection, dev-fixture seeder gates
+- **Parser integration** (35) — amount, sender, bank extraction; combined receipts
+- **Routing integration** (12) — chat→group / phone→member resolution; soft-delete handling
+- **Ingestion integration** (8) — end-to-end receipt pipeline (webhook → OCR → parse → persist → reply)
 
 Tests use an in-memory SurrealDB instance and do not touch the filesystem or call external APIs.
 
@@ -250,6 +251,11 @@ tests/
 | `SEED_ON_EMPTY` | No | `false` | Set to `true` to seed fixture data when all database tables are empty |
 | `RECEIPT_DOWNLOAD_DIR` | No | OS temp dir | Directory for temporary receipt files during OCR |
 | `RUST_LOG` | No | `info` | Log level filter: `debug`, `info`, `warn`, `error` |
+| `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive) — see [RUNBOOK § Environment Configuration](./RUNBOOK.md#environment-configuration) |
+| `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required only when `SURREAL_URL` is a network scheme. Boot fails with a typed error if missing, empty, or whitespace-only |
+| `DUMMY_ADMIN_PASSWORD` | Conditional | — | Required when `APP_ENV=development` + `SEED_ON_EMPTY=true`; shared password for the four `admin{1..4}@poolpay.test` dev fixtures |
+
+For auth rate-limiting, JWT key material, and proxy-header trust (`AUTH_*`, `JWT_*`, `TRUST_PROXY_HEADERS`), see [RUNBOOK § Auth Rate Limiting](./RUNBOOK.md#auth-rate-limiting) and [RUNBOOK § JWT Verification + Refresh Rotation](./RUNBOOK.md#jwt-verification--refresh-rotation). Production sets these; local development falls back to safe defaults.
 
 ## Git Workflow
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -277,7 +277,6 @@ If you've installed `just` (see [Optional: `just` task runner](#optional-just-ta
 | `RUST_LOG` | No | `info` | Log level filter: `debug`, `info`, `warn`, `error` |
 | `SURREAL_URL` | No | embedded RocksDB at `./data.surreal` | Embedded (`rocksdb://` / `mem://` / `surrealkv://`) or remote (`ws://` / `wss://` / `http://` / `https://`, case-insensitive) — see [RUNBOOK § Environment Configuration](./RUNBOOK.md#environment-configuration) |
 | `SURREAL_USER` / `SURREAL_PASS` | Conditional | — | Required only when `SURREAL_URL` is a network scheme. Boot fails with a typed error if missing, empty, or whitespace-only |
-| `DUMMY_ADMIN_PASSWORD` | Conditional | — | Required when `APP_ENV=development` + `SEED_ON_EMPTY=true`; shared password for the four `admin{1..4}@poolpay.test` dev fixtures |
 
 For auth rate-limiting, JWT key material, and proxy-header trust (`AUTH_*`, `JWT_*`, `TRUST_PROXY_HEADERS`), see [RUNBOOK § Auth Rate Limiting](./RUNBOOK.md#auth-rate-limiting) and [RUNBOOK § JWT Verification + Refresh Rotation](./RUNBOOK.md#jwt-verification--refresh-rotation). Production sets these; local development falls back to safe defaults.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,6 +51,15 @@ tesseract --version
 pdftoppm -v
 ```
 
+### Optional: `just` task runner
+
+The repo ships with a [`justfile`](../justfile) that wraps the longer commands documented in this guide and `RUNBOOK.md` (running the standalone SurrealDB server, the API in embedded vs remote mode, resetting the local DB, etc.). Using it is optional — the underlying `cargo` and `surreal` commands still work directly.
+
+```bash
+brew install just     # macOS — one-time install
+just --list           # see all available recipes
+```
+
 ### Environment Setup
 
 1. Copy the example env file and fill in credentials:
@@ -235,6 +244,21 @@ tests/
 | `cargo doc --open` | Generate and open documentation |
 | `cargo tree` | Show dependency tree |
 | `cargo outdated` | Check for outdated dependencies |
+
+### `just` Recipes (Optional)
+
+If you've installed `just` (see [Optional: `just` task runner](#optional-just-task-runner)), the following recipes wrap the most common workflows. Run `just --list` to see them all with descriptions.
+
+| Recipe | Wraps |
+|--------|-------|
+| `just surreal` | `surreal start --user root --pass root --bind 127.0.0.1:8000 rocksdb:./data.surreal` — Terminal 1 (standalone server, lets Surrealist attach) |
+| `just dev` | `SURREAL_URL=ws://… SURREAL_USER=root SURREAL_PASS=root cargo run` — Terminal 2, paired with `just surreal` |
+| `just dev-embedded` | `cargo run` — embedded mode (no Surrealist GUI possible) |
+| `just reset-db` | `rm -rf ./data.surreal` — wipe local DB so next boot reseeds fixtures |
+| `just test` | `cargo test` |
+| `just check` | `cargo check` |
+| `just lint` | `cargo fmt --check && cargo clippy --all-targets -- -D warnings` (matches pre-commit gate) |
+| `just fmt` | `cargo fmt` |
 
 ## Environment Variables
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-Last Updated: 2026-05-08
+Last Updated: 2026-05-09
 
 Quick reference to all documentation for the PoolPay project.
 
@@ -44,7 +44,7 @@ Start here if you're deploying, running, or troubleshooting the service in produ
 - **[README.md](../README.md)** (in root) — Project overview
   - What the service does
   - Architecture and structure
-  - Testing overview (193 tests)
+  - Testing overview (328 tests)
   - Known limitations
 
 ## Key Topics at a Glance

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -127,7 +127,7 @@ JWT_REFRESH_TTL_SECS=1209600
 # embedded engine takes an exclusive file lock — a Surrealist GUI cannot
 # attach while `cargo run` is up.
 #
-# Embedded values: rocksdb://path | mem:// | surrealkv://path
+# Embedded values: rocksdb://path | mem://
 # Remote values:   ws://host:port | wss://host:port | http://host:port | https://host:port
 # Scheme matching is case-insensitive (RFC 3986 §3.1).
 # SURREAL_URL=ws://127.0.0.1:8000
@@ -269,7 +269,6 @@ By default the service uses SurrealDB with RocksDB storage, persisting to `./dat
 | *(unset)* | Embedded | RocksDB at `./data.surreal` | No |
 | `rocksdb://path/to/db` | Embedded | RocksDB | No |
 | `mem://` | Embedded | In-memory | No |
-| `surrealkv://path` | Embedded | SurrealKV | No |
 | `ws://host:port`, `wss://host:port` | Remote | SurrealDB WebSocket | **Yes** (`SURREAL_USER` + `SURREAL_PASS`) |
 | `http://host:port`, `https://host:port` | Remote | SurrealDB HTTP | **Yes** (`SURREAL_USER` + `SURREAL_PASS`) |
 | Mixed-case (`WS://`, `HTTPS://`) | Remote | Same as lowercase (RFC 3986 §3.1) | **Yes** |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -140,11 +140,13 @@ JWT_REFRESH_TTL_SECS=1209600
 # SURREAL_PASS=root
 
 # --- Dev fixture seeding (development only) ---
-# Required when APP_ENV=development AND SEED_ON_EMPTY=true. Shared password
-# for the four `admin{1..4}@poolpay.test` fixtures (admin1 = group-admin
-# on fixture group 1; admin2 = orphan admin; admin3 = super_admin; admin4 =
-# orphan admin baseline). Asserted ≥ 12 chars at boot.
-# DUMMY_ADMIN_PASSWORD=PoolPayQA2026!
+# The four `admin{1..4}@poolpay.test` fixtures (admin1 = group-admin on
+# fixture group 1; admin2 = orphan admin; admin3 = super_admin; admin4 =
+# orphan admin baseline) all share a hardcoded password defined in
+# `src/auth/bootstrap.rs` as `DUMMY_ADMIN_PASSWORD = "PoolPayQA2026!"`. There
+# is no env var override — the constant is the source of truth, and the
+# seed path only runs when SEED_ON_EMPTY=true AND APP_ENV ∈ {development,
+# test}, so it cannot leak into a production deploy.
 ```
 
 ### Auth Rate Limiting

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -262,7 +262,7 @@ Both tasks are monitored — if either fails, the process exits rather than sile
 
 ### SurrealDB Connection (`SURREAL_URL`)
 
-By default the service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`. Setting `SURREAL_URL` overrides the connection target without code changes — the API can run against an embedded RocksDB / SurrealKV / in-memory engine, or against a standalone SurrealDB instance over the network. See PR #43 for the full mechanism.
+By default the service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`. Setting `SURREAL_URL` overrides the connection target without code changes — the API can run against an embedded RocksDB or in-memory engine, or against a standalone SurrealDB instance over the network. See PR #43 for the full mechanism.
 
 | `SURREAL_URL` value | Mode | Engine | Creds required |
 |---------------------|------|--------|----------------|

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Runbook: PoolPay Service
 
-Last Updated: 2026-04-14
+Last Updated: 2026-05-09
 
 Operational guide for running and troubleshooting the PoolPay service in development and production.
 
@@ -121,6 +121,30 @@ JWT_LEEWAY_SECS=60
 
 # Refresh-token lifetime (seconds). Default: 14 days.
 JWT_REFRESH_TTL_SECS=1209600
+
+# --- SurrealDB connection (PR #43) ---
+# Default: embedded RocksDB at `./data.surreal` (no env var needed). The
+# embedded engine takes an exclusive file lock — a Surrealist GUI cannot
+# attach while `cargo run` is up.
+#
+# Embedded values: rocksdb://path | mem:// | surrealkv://path
+# Remote values:   ws://host:port | wss://host:port | http://host:port | https://host:port
+# Scheme matching is case-insensitive (RFC 3986 §3.1).
+# SURREAL_URL=ws://127.0.0.1:8000
+
+# REQUIRED when SURREAL_URL is a network scheme. No defaults — missing,
+# empty (`SURREAL_USER=`), or whitespace-only values short-circuit boot
+# with a typed `InitError` BEFORE any outbound socket opens. The connect-
+# success log redacts `user:pass@` from the URL via `redact_url_userinfo`.
+# SURREAL_USER=root
+# SURREAL_PASS=root
+
+# --- Dev fixture seeding (development only) ---
+# Required when APP_ENV=development AND SEED_ON_EMPTY=true. Shared password
+# for the four `admin{1..4}@poolpay.test` fixtures (admin1 = group-admin
+# on fixture group 1; admin2 = orphan admin; admin3 = super_admin; admin4 =
+# orphan admin baseline). Asserted ≥ 12 chars at boot.
+# DUMMY_ADMIN_PASSWORD=PoolPayQA2026!
 ```
 
 ### Auth Rate Limiting
@@ -234,9 +258,35 @@ Both tasks are monitored — if either fails, the process exits rather than sile
 
 ## Database
 
+### SurrealDB Connection (`SURREAL_URL`)
+
+By default the service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`. Setting `SURREAL_URL` overrides the connection target without code changes — the API can run against an embedded RocksDB / SurrealKV / in-memory engine, or against a standalone SurrealDB instance over the network. See PR #43 / `wiki/poolpay/surrealdb/remote-toggle.md` for the full mechanism.
+
+| `SURREAL_URL` value | Mode | Engine | Creds required |
+|---------------------|------|--------|----------------|
+| *(unset)* | Embedded | RocksDB at `./data.surreal` | No |
+| `rocksdb://path/to/db` | Embedded | RocksDB | No |
+| `mem://` | Embedded | In-memory | No |
+| `surrealkv://path` | Embedded | SurrealKV | No |
+| `ws://host:port`, `wss://host:port` | Remote | SurrealDB WebSocket | **Yes** (`SURREAL_USER` + `SURREAL_PASS`) |
+| `http://host:port`, `https://host:port` | Remote | SurrealDB HTTP | **Yes** (`SURREAL_USER` + `SURREAL_PASS`) |
+| Mixed-case (`WS://`, `HTTPS://`) | Remote | Same as lowercase (RFC 3986 §3.1) | **Yes** |
+
+Remote signin **fails closed** — `SURREAL_USER` and `SURREAL_PASS` are required, with no `root/root` defaults. Missing, empty (`SURREAL_USER=`), and whitespace-only values all short-circuit boot with a typed `InitError` *before* any outbound connection attempt. The `info!("SurrealDB connected")` line strips `user:pass@` from the URL via `redact_url_userinfo` so credentials never land in operator logs.
+
+To run a local SurrealDB server alongside the API (e.g. so a Surrealist GUI can attach):
+
+```bash
+# Start a standalone SurrealDB on 127.0.0.1:8000 against the existing RocksDB store
+surreal start --user root --pass root --bind 127.0.0.1:8000 rocksdb:./data.surreal
+
+# Point the API at it
+SURREAL_URL=ws://127.0.0.1:8000 SURREAL_USER=root SURREAL_PASS=root cargo run
+```
+
 ### SurrealDB (Embedded)
 
-The service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`.
+The default embedded engine uses RocksDB, persisting to `./data.surreal/`.
 
 **Initialization:**
 - On startup, creates namespace `circle` and database `main`

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -260,7 +260,7 @@ Both tasks are monitored — if either fails, the process exits rather than sile
 
 ### SurrealDB Connection (`SURREAL_URL`)
 
-By default the service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`. Setting `SURREAL_URL` overrides the connection target without code changes — the API can run against an embedded RocksDB / SurrealKV / in-memory engine, or against a standalone SurrealDB instance over the network. See PR #43 / `wiki/poolpay/surrealdb/remote-toggle.md` for the full mechanism.
+By default the service uses SurrealDB with RocksDB storage, persisting to `./data.surreal/`. Setting `SURREAL_URL` overrides the connection target without code changes — the API can run against an embedded RocksDB / SurrealKV / in-memory engine, or against a standalone SurrealDB instance over the network. See PR #43 for the full mechanism.
 
 | `SURREAL_URL` value | Mode | Engine | Creds required |
 |---------------------|------|--------|----------------|

--- a/justfile
+++ b/justfile
@@ -28,7 +28,8 @@ dev-embedded:
     cargo run
 
 # Wipe the local DB. Next `just dev` / `just dev-embedded` reseeds fixtures
-# (requires APP_ENV=development + SEED_ON_EMPTY=true in .env). Stop any
+# (requires SEED_ON_EMPTY=true in .env; the dev-only dummy admin fixtures
+# additionally require APP_ENV=development or APP_ENV=test). Stop any
 # running API or `just surreal` first — both hold the directory open.
 reset-db:
     rm -rf ./data.surreal

--- a/justfile
+++ b/justfile
@@ -1,0 +1,52 @@
+# PoolPay API task runner.
+#
+# Install: `brew install just` (macOS) — one-time. Then `just --list` to see
+# recipes, or `just <recipe>` to run one. All recipes wrap commands documented
+# in docs/RUNBOOK.md and docs/CONTRIBUTING.md; using `just` is optional.
+
+# Default recipe — list available targets when `just` is run with no args.
+default:
+    @just --list --unsorted
+
+# Run SurrealDB as a standalone server (Terminal 1).
+# Holds the RocksDB lock and exposes ws://127.0.0.1:8000 so Surrealist can
+# attach to the same DB the API is using. Pair with `just dev` in another
+# terminal. See docs/RUNBOOK.md § SurrealDB Connection for details.
+surreal:
+    surreal start --user root --pass root --bind 127.0.0.1:8000 rocksdb:./data.surreal
+
+# Run the API as a client of the standalone SurrealDB server (Terminal 2).
+# Use this when you want Surrealist GUI access alongside the API. Requires
+# `just surreal` running in another terminal first.
+dev:
+    SURREAL_URL=ws://127.0.0.1:8000 SURREAL_USER=root SURREAL_PASS=root cargo run
+
+# Run the API in embedded mode (default — simplest setup).
+# Cargo opens RocksDB directly; Surrealist cannot attach while this is up.
+# Use when you don't need GUI database access.
+dev-embedded:
+    cargo run
+
+# Wipe the local DB. Next `just dev` / `just dev-embedded` reseeds fixtures
+# (requires APP_ENV=development + SEED_ON_EMPTY=true in .env). Stop any
+# running API or `just surreal` first — both hold the directory open.
+reset-db:
+    rm -rf ./data.surreal
+    @echo "data.surreal removed. Restart the API with SEED_ON_EMPTY=true to reseed."
+
+# Run all tests (currently 328 across 6 binaries).
+test:
+    cargo test
+
+# Fast type-check without producing a binary.
+check:
+    cargo check
+
+# Format + lint, gating on warnings (matches pre-commit).
+lint:
+    cargo fmt --check
+    cargo clippy --all-targets -- -D warnings
+
+# Auto-fix formatting issues.
+fmt:
+    cargo fmt

--- a/justfile
+++ b/justfile
@@ -29,8 +29,9 @@ dev-embedded:
 
 # Wipe the local DB. Next `just dev` / `just dev-embedded` reseeds fixtures
 # (requires SEED_ON_EMPTY=true in .env; the dev-only dummy admin fixtures
-# additionally require APP_ENV=development or APP_ENV=test). Stop any
-# running API or `just surreal` first — both hold the directory open.
+# additionally require APP_ENV=development or APP_ENV=test). Stop whichever
+# process currently holds the RocksDB lock first: `just surreal` (in remote
+# mode) or `just dev-embedded` / embedded `cargo run` (in embedded mode).
 reset-db:
     rm -rf ./data.surreal
     @echo "data.surreal removed. Restart the API with SEED_ON_EMPTY=true to reseed."

--- a/justfile
+++ b/justfile
@@ -8,30 +8,35 @@
 default:
     @just --list --unsorted
 
-# Run SurrealDB as a standalone server (Terminal 1).
 # Holds the RocksDB lock and exposes ws://127.0.0.1:8000 so Surrealist can
 # attach to the same DB the API is using. Pair with `just dev` in another
 # terminal. See docs/RUNBOOK.md § SurrealDB Connection for details.
+
+# Run SurrealDB as a standalone server (Terminal 1).
 surreal:
     surreal start --user root --pass root --bind 127.0.0.1:8000 rocksdb:./data.surreal
 
-# Run the API as a client of the standalone SurrealDB server (Terminal 2).
-# Use this when you want Surrealist GUI access alongside the API. Requires
+# Use when you want Surrealist GUI access alongside the API. Requires
 # `just surreal` running in another terminal first.
+
+# Run the API as a client of the standalone SurrealDB server (Terminal 2).
 dev:
     SURREAL_URL=ws://127.0.0.1:8000 SURREAL_USER=root SURREAL_PASS=root cargo run
 
-# Run the API in embedded mode (default — simplest setup).
 # Cargo opens RocksDB directly; Surrealist cannot attach while this is up.
 # Use when you don't need GUI database access.
+
+# Run the API in embedded mode (default — simplest setup).
 dev-embedded:
     cargo run
 
-# Wipe the local DB. Next `just dev` / `just dev-embedded` reseeds fixtures
-# (requires SEED_ON_EMPTY=true in .env; the dev-only dummy admin fixtures
-# additionally require APP_ENV=development or APP_ENV=test). Stop whichever
-# process currently holds the RocksDB lock first: `just surreal` (in remote
-# mode) or `just dev-embedded` / embedded `cargo run` (in embedded mode).
+# Next `just dev` / `just dev-embedded` reseeds fixtures (requires
+# SEED_ON_EMPTY=true in .env; the dev-only dummy admin fixtures additionally
+# require APP_ENV=development or APP_ENV=test). Stop whichever process
+# currently holds the RocksDB lock first: `just surreal` (in remote mode) or
+# `just dev-embedded` / embedded `cargo run` (in embedded mode).
+
+# Wipe the local DB so the next start reseeds fixtures.
 reset-db:
     rm -rf ./data.surreal
     @echo "data.surreal removed. Restart the API with SEED_ON_EMPTY=true to reseed."

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ test:
 check:
     cargo check
 
-# Format + lint, gating on warnings (matches pre-commit).
+# Format + lint, gating on warnings. Run before pushing.
 lint:
     cargo fmt --check
     cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

- **Sync docs with current `main`** (`b6cf7eb`): docs had drifted across two recent rounds of merged work — README claimed 106 tests, INDEX/CONTRIBUTING claimed 193 (actual: 328 across 6 binaries). README's `tests/` listing showed 2 of 5 test binaries; expanded to all 5. Env tables in README + CONTRIBUTING were missing `NEXTAUTH_BACKEND_SECRET`, `SURREAL_URL`/`USER`/`PASS`, `DUMMY_ADMIN_PASSWORD`. RUNBOOK had no SurrealDB connection block despite PR #43; added a full block (URL scheme matrix + fail-closed credential semantics + URL redaction) with a Surrealist-attach worked example. Bumped Last Updated dates on INDEX (2026-05-09), CONTRIBUTING (2026-05-09), RUNBOOK (2026-05-09).
- **Add `justfile` with convenience recipes** (`d26c7c4`): wraps the longer commands documented in RUNBOOK / CONTRIBUTING for the standalone-SurrealDB-server topology, embedded vs remote mode, DB reset, and standard cargo lint/test invocations. Recipes: `surreal`, `dev`, `dev-embedded`, `reset-db`, `test`, `check`, `lint`, `fmt`. Optional dep — `brew install just`. Underlying cargo / surreal commands continue to work directly; `just` is purely additive. README and CONTRIBUTING updated with one-line install hint and a recipe table.

No code changes; `cargo check` clean; tests unchanged at 328.

## Test plan

- [ ] `cargo check` (already verified locally — green)
- [ ] `cargo test` still 328 across 6 binaries
- [ ] `brew install just` then `just --list` shows all recipes with their docstrings
- [ ] `just dev-embedded` boots the API in embedded mode (sanity check)
- [ ] `just surreal` (T1) + `just dev` (T2) both run; Surrealist can attach to ws://127.0.0.1:8000 with NS=circle / DB=main while `just dev` stays connected
- [ ] `just reset-db` removes `./data.surreal` and prints the reseed hint
- [ ] Skim of RUNBOOK § Environment Configuration — `SURREAL_URL` block reads cleanly alongside the existing `JWT_*` and `AUTH_*` blocks
- [ ] Skim of CONTRIBUTING § Testing — 328 breakdown matches `cargo test` output