### PR TITLE
[REFACTOR] - Push filter predicates into SurrealDB + add pagination to GET handlers

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use serde::Deserialize;
@@ -15,20 +15,33 @@ use crate::api::models::{
     MemberContent, Payment, PaymentContent, Receipt, ReceiptContent, ReceiptStatus,
     UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest, now_iso, record_id_to_string,
 };
+use crate::api::pagination::{
+    header_u32, Pagination, PaginationParams, HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT,
+};
 use crate::db::{DbConn, reseed};
 
 // ── Query params ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
+pub struct GroupsQuery {
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct GroupIdQuery {
     #[serde(rename = "groupId")]
     pub group_id: Option<EntityId>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct PaymentsQuery {
     #[serde(rename = "cycleId")]
     pub cycle_id: Option<EntityId>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,99 +49,194 @@ pub struct ReceiptsQuery {
     #[serde(rename = "groupId")]
     pub group_id: Option<EntityId>,
     pub status: Option<String>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
+}
+
+/// Build the standard `X-Total-Count` / `X-Limit` / `X-Offset` header
+/// trio for a paginated list response. Centralised so every handler
+/// emits the exact same casing.
+fn pagination_headers(total: u32, page: Pagination) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(HEADER_TOTAL_COUNT, header_u32(total));
+    headers.insert(HEADER_LIMIT, header_u32(page.limit));
+    headers.insert(HEADER_OFFSET, header_u32(page.offset));
+    headers
+}
+
+/// Wrapper used by handlers that need to bind a `count()` aggregate's
+/// `count` column out of a SurrealDB response. Lives here (rather than
+/// in `models`) because it's a query-shape concern, not a domain type.
+#[derive(Debug, Deserialize, SurrealValue)]
+struct CountRow {
+    count: i64,
+}
+
+/// Pull the first `count()` aggregate out of a freshly-resolved query
+/// response. Returns 0 when the aggregate yielded no rows (which is
+/// what SurrealDB does for an empty `GROUP ALL`).
+fn take_count(resp: &mut surrealdb::IndexedResults, idx: usize) -> Result<u32, AppError> {
+    let rows: Vec<CountRow> = resp.take(idx)?;
+    let total = rows.first().map(|r| r.count).unwrap_or(0);
+    // Counts are non-negative by construction; clamp the impossible
+    // negative branch to zero rather than over-reporting via wrap.
+    Ok(u32::try_from(total.max(0)).unwrap_or(u32::MAX))
 }
 
 // ── Public GET handlers ──────────────────────────────────────────────────────
 
-pub async fn get_groups(State(db): State<DbConn>) -> Result<Json<Vec<Group>>, AppError> {
-    let rows: Vec<DbGroup> = db
-        .query("SELECT * FROM group WHERE deleted_at IS NONE")
-        .await?
-        .take(0)?;
+pub async fn get_groups(
+    State(db): State<DbConn>,
+    Query(params): Query<GroupsQuery>,
+) -> Result<(HeaderMap, Json<Vec<Group>>), AppError> {
+    let page = Pagination::from_params(&params.pagination)?;
+
+    // One round-trip: count() + page query, indexed in declaration order.
+    let mut resp = db
+        .query(
+            "SELECT count() FROM group WHERE deleted_at IS NONE GROUP ALL; \
+             SELECT * FROM group WHERE deleted_at IS NONE LIMIT $limit START $offset",
+        )
+        .bind(("limit", page.limit as i64))
+        .bind(("offset", page.offset as i64))
+        .await?;
+
+    let total = take_count(&mut resp, 0)?;
+    let rows: Vec<DbGroup> = resp.take(1)?;
     let groups: Result<Vec<Group>, AppError> = rows.into_iter().map(Group::try_from).collect();
-    Ok(Json(groups?))
+    Ok((pagination_headers(total, page), Json(groups?)))
 }
 
 pub async fn get_members(
     State(db): State<DbConn>,
     Query(params): Query<GroupIdQuery>,
-) -> Result<Json<Vec<Member>>, AppError> {
-    let rows: Vec<DbMember> = match params.group_id {
-        Some(gid) => db
-            .query("SELECT * FROM member WHERE deleted_at IS NONE AND group_id = $gid")
-            .bind(("gid", gid))
-            .await?
-            .take(0)?,
-        None => db
-            .query("SELECT * FROM member WHERE deleted_at IS NONE")
-            .await?
-            .take(0)?,
+) -> Result<(HeaderMap, Json<Vec<Member>>), AppError> {
+    let page = Pagination::from_params(&params.pagination)?;
+
+    // The `WHERE` is shared between count and page so the X-Total-Count
+    // reflects the total *matching* rows, not the table-wide total.
+    let where_clause = match params.group_id {
+        Some(_) => "deleted_at IS NONE AND group_id = $gid",
+        None => "deleted_at IS NONE",
     };
+    let sql = format!(
+        "SELECT count() FROM member WHERE {where_clause} GROUP ALL; \
+         SELECT * FROM member WHERE {where_clause} LIMIT $limit START $offset"
+    );
+
+    let mut q = db
+        .query(sql)
+        .bind(("limit", page.limit as i64))
+        .bind(("offset", page.offset as i64));
+    if let Some(gid) = params.group_id {
+        q = q.bind(("gid", gid));
+    }
+    let mut resp = q.await?;
+    let total = take_count(&mut resp, 0)?;
+    let rows: Vec<DbMember> = resp.take(1)?;
     let members: Result<Vec<Member>, AppError> = rows.into_iter().map(Member::try_from).collect();
-    Ok(Json(members?))
+    Ok((pagination_headers(total, page), Json(members?)))
 }
 
 pub async fn get_cycles(
     State(db): State<DbConn>,
     Query(params): Query<GroupIdQuery>,
-) -> Result<Json<Vec<Cycle>>, AppError> {
+) -> Result<(HeaderMap, Json<Vec<Cycle>>), AppError> {
+    let page = Pagination::from_params(&params.pagination)?;
+
     // Cycles are hard-deleted (no `deleted_at`), so the only optional
-    // predicate is `group_id`.
-    let rows: Vec<DbCycle> = match params.group_id {
-        Some(gid) => db
-            .query("SELECT * FROM cycle WHERE group_id = $gid")
-            .bind(("gid", gid))
-            .await?
-            .take(0)?,
-        None => db.query("SELECT * FROM cycle").await?.take(0)?,
+    // predicate is `group_id`. The two-statement `count() + select`
+    // shape mirrors the other handlers for uniformity.
+    let (count_sql, page_sql) = match params.group_id.as_ref() {
+        Some(_) => (
+            "SELECT count() FROM cycle WHERE group_id = $gid GROUP ALL".to_string(),
+            "SELECT * FROM cycle WHERE group_id = $gid LIMIT $limit START $offset".to_string(),
+        ),
+        None => (
+            "SELECT count() FROM cycle GROUP ALL".to_string(),
+            "SELECT * FROM cycle LIMIT $limit START $offset".to_string(),
+        ),
     };
+    let sql = format!("{count_sql}; {page_sql}");
+
+    let mut q = db
+        .query(sql)
+        .bind(("limit", page.limit as i64))
+        .bind(("offset", page.offset as i64));
+    if let Some(gid) = params.group_id {
+        q = q.bind(("gid", gid));
+    }
+    let mut resp = q.await?;
+    let total = take_count(&mut resp, 0)?;
+    let rows: Vec<DbCycle> = resp.take(1)?;
     let cycles: Result<Vec<Cycle>, AppError> = rows.into_iter().map(Cycle::try_from).collect();
-    Ok(Json(cycles?))
+    Ok((pagination_headers(total, page), Json(cycles?)))
 }
 
 pub async fn get_payments(
     State(db): State<DbConn>,
     Query(params): Query<PaymentsQuery>,
-) -> Result<Json<Vec<Payment>>, AppError> {
-    let rows: Vec<DbPayment> = match params.cycle_id {
-        Some(cid) => db
-            .query("SELECT * FROM payment WHERE deleted_at IS NONE AND cycle_id = $cid")
-            .bind(("cid", cid))
-            .await?
-            .take(0)?,
-        None => db
-            .query("SELECT * FROM payment WHERE deleted_at IS NONE")
-            .await?
-            .take(0)?,
+) -> Result<(HeaderMap, Json<Vec<Payment>>), AppError> {
+    let page = Pagination::from_params(&params.pagination)?;
+
+    let where_clause = match params.cycle_id {
+        Some(_) => "deleted_at IS NONE AND cycle_id = $cid",
+        None => "deleted_at IS NONE",
     };
+    let sql = format!(
+        "SELECT count() FROM payment WHERE {where_clause} GROUP ALL; \
+         SELECT * FROM payment WHERE {where_clause} LIMIT $limit START $offset"
+    );
+
+    let mut q = db
+        .query(sql)
+        .bind(("limit", page.limit as i64))
+        .bind(("offset", page.offset as i64));
+    if let Some(cid) = params.cycle_id {
+        q = q.bind(("cid", cid));
+    }
+    let mut resp = q.await?;
+    let total = take_count(&mut resp, 0)?;
+    let rows: Vec<DbPayment> = resp.take(1)?;
     let payments: Result<Vec<Payment>, AppError> =
         rows.into_iter().map(Payment::try_from).collect();
-    Ok(Json(payments?))
+    Ok((pagination_headers(total, page), Json(payments?)))
 }
 
 pub async fn get_receipts(
     State(db): State<DbConn>,
     Query(params): Query<ReceiptsQuery>,
-) -> Result<Json<Vec<Receipt>>, AppError> {
-    // Validate status filter up-front so an unknown value returns 400 rather
-    // than silently producing an empty list.
+) -> Result<(HeaderMap, Json<Vec<Receipt>>), AppError> {
+    // Validate status filter up-front so an unknown value returns 400
+    // rather than silently producing an empty list.
     let status_filter: Option<ReceiptStatus> = match params.status.as_deref() {
         None => None,
         Some(s) => Some(s.parse::<ReceiptStatus>().map_err(AppError::BadRequest)?),
     };
 
-    // Build the WHERE clause dynamically based on which optional filters
-    // are present. The base predicate (`deleted_at IS NONE`) is always
-    // applied; `group_id` and `status` join with AND when supplied.
-    let mut sql = String::from("SELECT * FROM receipt WHERE deleted_at IS NONE");
+    let page = Pagination::from_params(&params.pagination)?;
+
+    // Build the WHERE clause dynamically based on which optional
+    // filters are present. The base predicate (`deleted_at IS NONE`) is
+    // always applied; `group_id` and `status` join with AND when
+    // supplied. The same WHERE drives both the count and the page so
+    // X-Total-Count reflects the filtered total.
+    let mut where_clause = String::from("deleted_at IS NONE");
     if params.group_id.is_some() {
-        sql.push_str(" AND group_id = $gid");
+        where_clause.push_str(" AND group_id = $gid");
     }
     if status_filter.is_some() {
-        sql.push_str(" AND status = $status");
+        where_clause.push_str(" AND status = $status");
     }
+    let sql = format!(
+        "SELECT count() FROM receipt WHERE {where_clause} GROUP ALL; \
+         SELECT * FROM receipt WHERE {where_clause} LIMIT $limit START $offset"
+    );
 
-    let mut q = db.query(sql);
+    let mut q = db
+        .query(sql)
+        .bind(("limit", page.limit as i64))
+        .bind(("offset", page.offset as i64));
     if let Some(gid) = params.group_id {
         q = q.bind(("gid", gid));
     }
@@ -142,10 +250,12 @@ pub async fn get_receipts(
         };
         q = q.bind(("status", stored.to_string()));
     }
-    let rows: Vec<DbReceipt> = q.await?.take(0)?;
+    let mut resp = q.await?;
+    let total = take_count(&mut resp, 0)?;
+    let rows: Vec<DbReceipt> = resp.take(1)?;
     let receipts: Result<Vec<Receipt>, AppError> =
         rows.into_iter().map(Receipt::try_from).collect();
-    Ok(Json(receipts?))
+    Ok((pagination_headers(total, page), Json(receipts?)))
 }
 
 // ── Admin Group handlers ─────────────────────────────────────────────────────

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -92,10 +92,14 @@ pub async fn get_groups(
     let page = Pagination::from_params(&params.pagination)?;
 
     // One round-trip: count() + page query, indexed in declaration order.
+    // The page query uses an explicit ORDER BY so offset pagination is
+    // stable — without it the DB is free to reorder rows between calls,
+    // which would make `?offset=` produce duplicate/missing items.
     let mut resp = db
         .query(
             "SELECT count() FROM group WHERE deleted_at IS NONE GROUP ALL; \
-             SELECT * FROM group WHERE deleted_at IS NONE LIMIT $limit START $offset",
+             SELECT * FROM group WHERE deleted_at IS NONE \
+             ORDER BY created_at ASC, id ASC LIMIT $limit START $offset",
         )
         .bind(("limit", page.limit as i64))
         .bind(("offset", page.offset as i64))
@@ -121,7 +125,8 @@ pub async fn get_members(
     };
     let sql = format!(
         "SELECT count() FROM member WHERE {where_clause} GROUP ALL; \
-         SELECT * FROM member WHERE {where_clause} LIMIT $limit START $offset"
+         SELECT * FROM member WHERE {where_clause} \
+         ORDER BY created_at ASC, id ASC LIMIT $limit START $offset"
     );
 
     let mut q = db
@@ -150,11 +155,14 @@ pub async fn get_cycles(
     let (count_sql, page_sql) = match params.group_id.as_ref() {
         Some(_) => (
             "SELECT count() FROM cycle WHERE group_id = $gid GROUP ALL".to_string(),
-            "SELECT * FROM cycle WHERE group_id = $gid LIMIT $limit START $offset".to_string(),
+            "SELECT * FROM cycle WHERE group_id = $gid \
+             ORDER BY created_at ASC, id ASC LIMIT $limit START $offset"
+                .to_string(),
         ),
         None => (
             "SELECT count() FROM cycle GROUP ALL".to_string(),
-            "SELECT * FROM cycle LIMIT $limit START $offset".to_string(),
+            "SELECT * FROM cycle ORDER BY created_at ASC, id ASC LIMIT $limit START $offset"
+                .to_string(),
         ),
     };
     let sql = format!("{count_sql}; {page_sql}");
@@ -185,7 +193,8 @@ pub async fn get_payments(
     };
     let sql = format!(
         "SELECT count() FROM payment WHERE {where_clause} GROUP ALL; \
-         SELECT * FROM payment WHERE {where_clause} LIMIT $limit START $offset"
+         SELECT * FROM payment WHERE {where_clause} \
+         ORDER BY created_at ASC, id ASC LIMIT $limit START $offset"
     );
 
     let mut q = db
@@ -230,7 +239,8 @@ pub async fn get_receipts(
     }
     let sql = format!(
         "SELECT count() FROM receipt WHERE {where_clause} GROUP ALL; \
-         SELECT * FROM receipt WHERE {where_clause} LIMIT $limit START $offset"
+         SELECT * FROM receipt WHERE {where_clause} \
+         ORDER BY received_at ASC, id ASC LIMIT $limit START $offset"
     );
 
     let mut q = db

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -41,65 +41,69 @@ pub struct ReceiptsQuery {
 // ── Public GET handlers ──────────────────────────────────────────────────────
 
 pub async fn get_groups(State(db): State<DbConn>) -> Result<Json<Vec<Group>>, AppError> {
-    let rows: Vec<DbGroup> = db.select("group").await?;
-    let groups: Result<Vec<Group>, AppError> = rows
-        .into_iter()
-        .map(Group::try_from)
-        .collect();
-    let groups = groups?;
-    let filtered: Vec<Group> = groups.into_iter().filter(|g| g.deleted_at.is_none()).collect();
-    Ok(Json(filtered))
+    let rows: Vec<DbGroup> = db
+        .query("SELECT * FROM group WHERE deleted_at IS NONE")
+        .await?
+        .take(0)?;
+    let groups: Result<Vec<Group>, AppError> = rows.into_iter().map(Group::try_from).collect();
+    Ok(Json(groups?))
 }
 
 pub async fn get_members(
     State(db): State<DbConn>,
     Query(params): Query<GroupIdQuery>,
 ) -> Result<Json<Vec<Member>>, AppError> {
-    let rows: Vec<DbMember> = db.select("member").await?;
+    let rows: Vec<DbMember> = match params.group_id {
+        Some(gid) => db
+            .query("SELECT * FROM member WHERE deleted_at IS NONE AND group_id = $gid")
+            .bind(("gid", gid))
+            .await?
+            .take(0)?,
+        None => db
+            .query("SELECT * FROM member WHERE deleted_at IS NONE")
+            .await?
+            .take(0)?,
+    };
     let members: Result<Vec<Member>, AppError> = rows.into_iter().map(Member::try_from).collect();
-    let members = members?;
-
-    let filtered: Vec<Member> = members
-        .into_iter()
-        .filter(|m| m.deleted_at.is_none())
-        .filter(|m| params.group_id.as_ref().is_none_or(|gid| m.group_id == *gid))
-        .collect();
-
-    Ok(Json(filtered))
+    Ok(Json(members?))
 }
 
 pub async fn get_cycles(
     State(db): State<DbConn>,
     Query(params): Query<GroupIdQuery>,
 ) -> Result<Json<Vec<Cycle>>, AppError> {
-    let rows: Vec<DbCycle> = db.select("cycle").await?;
+    // Cycles are hard-deleted (no `deleted_at`), so the only optional
+    // predicate is `group_id`.
+    let rows: Vec<DbCycle> = match params.group_id {
+        Some(gid) => db
+            .query("SELECT * FROM cycle WHERE group_id = $gid")
+            .bind(("gid", gid))
+            .await?
+            .take(0)?,
+        None => db.query("SELECT * FROM cycle").await?.take(0)?,
+    };
     let cycles: Result<Vec<Cycle>, AppError> = rows.into_iter().map(Cycle::try_from).collect();
-    let cycles = cycles?;
-
-    let filtered: Vec<Cycle> = cycles
-        .into_iter()
-        .filter(|c| params.group_id.as_ref().is_none_or(|gid| c.group_id == *gid))
-        .collect();
-
-    Ok(Json(filtered))
+    Ok(Json(cycles?))
 }
 
 pub async fn get_payments(
     State(db): State<DbConn>,
     Query(params): Query<PaymentsQuery>,
 ) -> Result<Json<Vec<Payment>>, AppError> {
-    let rows: Vec<DbPayment> = db.select("payment").await?;
+    let rows: Vec<DbPayment> = match params.cycle_id {
+        Some(cid) => db
+            .query("SELECT * FROM payment WHERE deleted_at IS NONE AND cycle_id = $cid")
+            .bind(("cid", cid))
+            .await?
+            .take(0)?,
+        None => db
+            .query("SELECT * FROM payment WHERE deleted_at IS NONE")
+            .await?
+            .take(0)?,
+    };
     let payments: Result<Vec<Payment>, AppError> =
         rows.into_iter().map(Payment::try_from).collect();
-    let payments = payments?;
-
-    let filtered: Vec<Payment> = payments
-        .into_iter()
-        .filter(|p| p.deleted_at.is_none())
-        .filter(|p| params.cycle_id.as_ref().is_none_or(|cid| p.cycle_id == *cid))
-        .collect();
-
-    Ok(Json(filtered))
+    Ok(Json(payments?))
 }
 
 pub async fn get_receipts(
@@ -113,19 +117,35 @@ pub async fn get_receipts(
         Some(s) => Some(s.parse::<ReceiptStatus>().map_err(AppError::BadRequest)?),
     };
 
-    let rows: Vec<DbReceipt> = db.select("receipt").await?;
+    // Build the WHERE clause dynamically based on which optional filters
+    // are present. The base predicate (`deleted_at IS NONE`) is always
+    // applied; `group_id` and `status` join with AND when supplied.
+    let mut sql = String::from("SELECT * FROM receipt WHERE deleted_at IS NONE");
+    if params.group_id.is_some() {
+        sql.push_str(" AND group_id = $gid");
+    }
+    if status_filter.is_some() {
+        sql.push_str(" AND status = $status");
+    }
+
+    let mut q = db.query(sql);
+    if let Some(gid) = params.group_id {
+        q = q.bind(("gid", gid));
+    }
+    if let Some(s) = status_filter {
+        // Persist the canonical lowercase form so the WHERE matches the
+        // stored value (`status: "pending" | "confirmed" | "rejected"`).
+        let stored = match s {
+            ReceiptStatus::Pending => "pending",
+            ReceiptStatus::Confirmed => "confirmed",
+            ReceiptStatus::Rejected => "rejected",
+        };
+        q = q.bind(("status", stored.to_string()));
+    }
+    let rows: Vec<DbReceipt> = q.await?.take(0)?;
     let receipts: Result<Vec<Receipt>, AppError> =
         rows.into_iter().map(Receipt::try_from).collect();
-    let receipts = receipts?;
-
-    let filtered: Vec<Receipt> = receipts
-        .into_iter()
-        .filter(|r| r.deleted_at.is_none())
-        .filter(|r| params.group_id.as_ref().is_none_or(|gid| r.group_id == *gid))
-        .filter(|r| status_filter.as_ref().is_none_or(|s| r.status == *s))
-        .collect();
-
-    Ok(Json(filtered))
+    Ok(Json(receipts?))
 }
 
 // ── Admin Group handlers ─────────────────────────────────────────────────────

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,7 +5,7 @@ pub mod models;
 pub mod pagination;
 
 use axum::{
-    http::{header, Method},
+    http::{header, HeaderName, Method},
     routing::{delete, get, patch, post},
     Extension, Router,
 };
@@ -167,10 +167,18 @@ fn build_cors() -> CorsLayer {
             .parse()
             .expect("DASHBOARD_ORIGIN is not a valid header value");
 
+        // Pagination headers must be in `expose_headers` or browsers
+        // will block `fetch()` from reading `X-Total-Count` / `X-Limit`
+        // / `X-Offset` even though the server sets them.
         CorsLayer::new()
             .allow_origin(parsed)
             .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
             .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+            .expose_headers([
+                HeaderName::from_static("x-total-count"),
+                HeaderName::from_static("x-limit"),
+                HeaderName::from_static("x-offset"),
+            ])
     } else {
         CorsLayer::permissive()
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod admin_users;
 pub mod auth_endpoints;
 pub mod handlers;
 pub mod models;
+pub mod pagination;
 
 use axum::{
     http::{header, Method},

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,12 +5,13 @@ pub mod models;
 pub mod pagination;
 
 use axum::{
-    http::{header, HeaderName, Method},
+    http::{header, Method},
     routing::{delete, get, patch, post},
     Extension, Router,
 };
 use tower_http::cors::CorsLayer;
 
+use crate::api::pagination::{HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT};
 use crate::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
@@ -175,9 +176,9 @@ fn build_cors() -> CorsLayer {
             .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
             .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
             .expose_headers([
-                HeaderName::from_static("x-total-count"),
-                HeaderName::from_static("x-limit"),
-                HeaderName::from_static("x-offset"),
+                HEADER_TOTAL_COUNT,
+                HEADER_LIMIT,
+                HEADER_OFFSET,
             ])
     } else {
         CorsLayer::permissive()

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -22,6 +22,14 @@ pub const DEFAULT_LIMIT: u32 = 50;
 /// 200) and make API contract debugging painful.
 pub const MAX_LIMIT: u32 = 200;
 
+/// Hard cap on `?offset`. Offset pagination scans+discards every row up
+/// to `offset`, so an unbounded `u32` lets callers request scans of
+/// billions of rows on these public GET endpoints — an easy DoS vector.
+/// 100k is well past any plausible UI deep-paging need; clients hitting
+/// this should switch to a filter (`group_id`, `cycle_id`, …) or a
+/// future cursor-based endpoint.
+pub const MAX_OFFSET: u32 = 100_000;
+
 /// Header names exposed alongside paginated list responses. Constants so
 /// every handler emits the exact same casing and tests can match by name.
 pub const HEADER_TOTAL_COUNT: HeaderName = HeaderName::from_static("x-total-count");
@@ -70,6 +78,11 @@ impl Pagination {
             None => 0,
             Some(raw) => parse_u32(raw, "offset")?,
         };
+        if offset > MAX_OFFSET {
+            return Err(AppError::BadRequest(format!(
+                "offset must be <= {MAX_OFFSET}"
+            )));
+        }
 
         Ok(Self { limit, offset })
     }
@@ -141,5 +154,19 @@ mod tests {
         let p = Pagination::from_params(&params(Some("10"), Some("20"))).unwrap();
         assert_eq!(p.limit, 10);
         assert_eq!(p.offset, 20);
+    }
+
+    #[test]
+    fn rejects_over_max_offset() {
+        let raw = (MAX_OFFSET + 1).to_string();
+        let err = Pagination::from_params(&params(None, Some(&raw))).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn accepts_max_offset() {
+        let raw = MAX_OFFSET.to_string();
+        let p = Pagination::from_params(&params(None, Some(&raw))).unwrap();
+        assert_eq!(p.offset, MAX_OFFSET);
     }
 }

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -1,0 +1,145 @@
+//! Pagination helpers shared by every public list endpoint.
+//!
+//! The shape is intentionally minimal: a `?limit=` and `?offset=` query
+//! pair with sane defaults and a hard cap, plus a small struct that the
+//! handler uses to drive `LIMIT … START …` clauses and the matching
+//! `X-Limit` / `X-Offset` / `X-Total-Count` response headers.
+//!
+//! Body shape stays a flat JSON array — pagination metadata travels via
+//! headers so existing FE consumers don't need a coordinated migration.
+
+use axum::http::{HeaderName, HeaderValue};
+use serde::Deserialize;
+
+use crate::api::models::AppError;
+
+/// Default page size when `?limit` is omitted.
+pub const DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on `?limit` to keep response sizes bounded. Requests above
+/// this are rejected with 400 rather than silently clamped — clamping
+/// would mask client bugs (a UI asking for 1000 rows and only getting
+/// 200) and make API contract debugging painful.
+pub const MAX_LIMIT: u32 = 200;
+
+/// Header names exposed alongside paginated list responses. Constants so
+/// every handler emits the exact same casing and tests can match by name.
+pub const HEADER_TOTAL_COUNT: HeaderName = HeaderName::from_static("x-total-count");
+pub const HEADER_LIMIT: HeaderName = HeaderName::from_static("x-limit");
+pub const HEADER_OFFSET: HeaderName = HeaderName::from_static("x-offset");
+
+/// Raw query params before validation. Both fields are `Option<String>`
+/// so we can produce a clear 400 on non-numeric values rather than the
+/// terse default Axum extractor error (`Failed to deserialize query
+/// string: invalid digit found in string`), which leaks the parser
+/// internals and isn't actionable for FE devs.
+#[derive(Debug, Default, Deserialize)]
+pub struct PaginationParams {
+    pub limit: Option<String>,
+    pub offset: Option<String>,
+}
+
+/// Parsed and validated pagination state. Constructed via
+/// [`Pagination::from_params`].
+#[derive(Debug, Clone, Copy)]
+pub struct Pagination {
+    pub limit: u32,
+    pub offset: u32,
+}
+
+impl Pagination {
+    /// Apply defaults and the `MAX_LIMIT` cap. A `?limit=0` request is
+    /// rejected with 400 — a zero-row page is never a useful answer and
+    /// returning an empty array on `limit=0` would hide client bugs the
+    /// same way silent clamping does.
+    pub fn from_params(params: &PaginationParams) -> Result<Self, AppError> {
+        let limit = match params.limit.as_deref() {
+            None => DEFAULT_LIMIT,
+            Some(raw) => parse_u32(raw, "limit")?,
+        };
+        if limit == 0 {
+            return Err(AppError::BadRequest("limit must be >= 1".into()));
+        }
+        if limit > MAX_LIMIT {
+            return Err(AppError::BadRequest(format!(
+                "limit must be <= {MAX_LIMIT}"
+            )));
+        }
+
+        let offset = match params.offset.as_deref() {
+            None => 0,
+            Some(raw) => parse_u32(raw, "offset")?,
+        };
+
+        Ok(Self { limit, offset })
+    }
+}
+
+fn parse_u32(raw: &str, field: &str) -> Result<u32, AppError> {
+    raw.parse::<u32>()
+        .map_err(|_| AppError::BadRequest(format!("{field} must be a non-negative integer")))
+}
+
+/// Format a `u32` as a header value. Numeric values are always valid
+/// header bytes, so the `from_str` call cannot fail in practice — the
+/// `expect` documents the invariant rather than papering over it.
+pub fn header_u32(value: u32) -> HeaderValue {
+    HeaderValue::from_str(&value.to_string())
+        .expect("decimal u32 is always a valid header value")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(limit: Option<&str>, offset: Option<&str>) -> PaginationParams {
+        PaginationParams {
+            limit: limit.map(str::to_string),
+            offset: offset.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn defaults_when_unset() {
+        let p = Pagination::from_params(&params(None, None)).unwrap();
+        assert_eq!(p.limit, DEFAULT_LIMIT);
+        assert_eq!(p.offset, 0);
+    }
+
+    #[test]
+    fn rejects_zero_limit() {
+        let err = Pagination::from_params(&params(Some("0"), None)).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn rejects_over_max_limit() {
+        let err = Pagination::from_params(&params(Some("201"), None)).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn accepts_max_limit() {
+        let p = Pagination::from_params(&params(Some("200"), None)).unwrap();
+        assert_eq!(p.limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn rejects_non_numeric_limit() {
+        let err = Pagination::from_params(&params(Some("abc"), None)).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn rejects_negative_offset() {
+        let err = Pagination::from_params(&params(None, Some("-1"))).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn accepts_offset() {
+        let p = Pagination::from_params(&params(Some("10"), Some("20"))).unwrap();
+        assert_eq!(p.limit, 10);
+        assert_eq!(p.offset, 20);
+    }
+}

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -2240,3 +2240,152 @@ async fn delete_payment_unknown_cycle_denies_non_scoped_admin_opaquely() {
     .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+//
+// Cover the limit/offset contract added in #16: defaults, hard cap,
+// validation errors, header trio, and the count-vs-page invariant when
+// filters and pagination combine. All five list endpoints share the same
+// parser (`api::pagination`), so per-handler coverage is intentionally
+// thin — the contract tests below pick the most informative endpoint
+// for each rule and rely on the shared parser unit tests in
+// `src/api/pagination.rs` for the rest.
+
+/// Read the `X-Total-Count` header as `u32`, panicking with a clear
+/// message if it's missing or unparseable. Centralised so each test
+/// reads the contract the same way.
+fn total_count_header(resp: &Response) -> u32 {
+    resp.headers()
+        .get("x-total-count")
+        .expect("X-Total-Count header missing")
+        .to_str()
+        .expect("X-Total-Count is not valid ASCII")
+        .parse::<u32>()
+        .expect("X-Total-Count is not a u32")
+}
+
+#[tokio::test]
+async fn pagination_default_limit_returns_all_payments_with_total_header() {
+    // Fixture has 49 payments; with the default limit of 50 the body
+    // returns all of them and X-Total-Count reports 49.
+    let resp = call(test_app().await, get("/api/payments")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(total_count_header(&resp), 49);
+    assert_eq!(resp.headers().get("x-limit").unwrap(), "50");
+    assert_eq!(resp.headers().get("x-offset").unwrap(), "0");
+    let payments: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(payments.len(), 49);
+}
+
+#[tokio::test]
+async fn pagination_explicit_limit_truncates_body_but_not_total_count() {
+    // ?limit=10 returns 10 rows in the body; the header still reports
+    // the table-wide total so the FE can render "showing 10 of 49".
+    let resp = call(test_app().await, get("/api/payments?limit=10")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(total_count_header(&resp), 49);
+    assert_eq!(resp.headers().get("x-limit").unwrap(), "10");
+    let payments: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(payments.len(), 10);
+}
+
+#[tokio::test]
+async fn pagination_offset_skips_rows_and_keeps_total_count_stable() {
+    // Take the first 10 rows, then take the next 10 by offsetting; the
+    // page two contents must not overlap with page one (id-disjoint).
+    let app = test_app().await;
+    let page1: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get("/api/payments?limit=10")).await).await;
+    let resp = call(app, get("/api/payments?limit=10&offset=10")).await;
+    assert_eq!(total_count_header(&resp), 49);
+    assert_eq!(resp.headers().get("x-offset").unwrap(), "10");
+    let page2: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(page2.len(), 10);
+    let page1_ids: std::collections::HashSet<&str> =
+        page1.iter().map(|p| p["id"].as_str().unwrap()).collect();
+    for p in &page2 {
+        let id = p["id"].as_str().unwrap();
+        assert!(
+            !page1_ids.contains(id),
+            "offset page must not overlap with first page; saw {id} on both"
+        );
+    }
+}
+
+#[tokio::test]
+async fn pagination_limit_over_max_returns_400() {
+    let resp = call(test_app().await, get("/api/payments?limit=300")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn pagination_limit_zero_returns_400() {
+    // A zero-row page is never useful — clamping silently would mask
+    // FE bugs. We reject and document the contract.
+    let resp = call(test_app().await, get("/api/payments?limit=0")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn pagination_non_numeric_limit_returns_400() {
+    let resp = call(test_app().await, get("/api/payments?limit=abc")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn pagination_negative_offset_returns_400() {
+    // The parser accepts only non-negative integers; a leading `-` is a
+    // signed digit that fails `u32::parse`.
+    let resp = call(test_app().await, get("/api/payments?offset=-1")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn pagination_filter_and_limit_combine_correctly_for_members() {
+    // Group 1 has 6 members; with limit=2 the body returns 2 rows but
+    // X-Total-Count still reports the filtered total (6).
+    let resp = call(test_app().await, get("/api/members?groupId=1&limit=2")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(total_count_header(&resp), 6);
+    let members: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(members.len(), 2);
+    for m in &members {
+        assert_eq!(m["groupId"], "1");
+    }
+}
+
+#[tokio::test]
+async fn pagination_filter_and_limit_combine_correctly_for_payments_by_cycle() {
+    // Cycle 1 has 6 fixture payments. limit=3 must return 3 rows; the
+    // header reports 6, not the table-wide 49.
+    let resp = call(test_app().await, get("/api/payments?cycleId=1&limit=3")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(total_count_header(&resp), 6);
+    let payments: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(payments.len(), 3);
+    for p in &payments {
+        assert_eq!(p["cycleId"], "1");
+    }
+}
+
+#[tokio::test]
+async fn pagination_excludes_soft_deleted_payments_from_total_count() {
+    // The receipts fixture seeds two rows — one active, one
+    // soft-deleted. After filtering, the count + body should both
+    // surface only the active row.
+    let resp = call(test_app().await, get("/api/receipts?limit=200")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let total = total_count_header(&resp);
+    let receipts: Vec<serde_json::Value> = json_body(resp).await;
+    assert_eq!(
+        receipts.len() as u32,
+        total,
+        "header must equal body length when limit > total"
+    );
+    assert!(
+        receipts
+            .iter()
+            .all(|r| r.get("deletedAt").is_none() || r["deletedAt"].is_null()),
+        "soft-deleted rows must be excluded from the page"
+    );
+}

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -2280,7 +2280,8 @@ async fn pagination_default_limit_returns_all_payments_with_total_header() {
 #[tokio::test]
 async fn pagination_explicit_limit_truncates_body_but_not_total_count() {
     // ?limit=10 returns 10 rows in the body; the header still reports
-    // the table-wide total so the FE can render "showing 10 of 49".
+    // the total matching the endpoint's filters (for payments, the
+    // active/undeleted total) so the FE can render "showing 10 of 49".
     let resp = call(test_app().await, get("/api/payments?limit=10")).await;
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(total_count_header(&resp), 49);
@@ -2369,7 +2370,7 @@ async fn pagination_filter_and_limit_combine_correctly_for_payments_by_cycle() {
 }
 
 #[tokio::test]
-async fn pagination_excludes_soft_deleted_payments_from_total_count() {
+async fn pagination_excludes_soft_deleted_receipts_from_total_count() {
     // The receipts fixture seeds two rows — one active, one
     // soft-deleted. After filtering, the count + body should both
     // surface only the active row.


### PR DESCRIPTION
## Summary

- **Push filter predicates into SurrealDB queries** for all 5 GET handlers (`get_groups`, `get_members`, `get_cycles`, `get_payments`, `get_receipts`). Filters previously applied in Rust closures (`group_id`, `cycle_id`, `status`, `deleted_at IS NONE`) now ride in the WHERE clause.
- **Add limit/offset pagination** uniformly: `?limit=` (default 50, max 200) and `?offset=` (default 0). Bad input (over-cap, non-numeric, zero limit) -> 400.
- **Non-breaking response shape** -- body stays a flat JSON array; pagination metadata travels via `X-Total-Count`, `X-Limit`, `X-Offset` response headers.
- Shared `Pagination` parser in `src/api/pagination.rs` so each handler doesn't re-implement the param plumbing. Each handler issues a single multi-statement query that returns both the count and the page in one round-trip; the count uses the same WHERE as the page so `X-Total-Count` reflects the filtered total.

Closes #16.

> Note: stacks logically on top of issue #15's `is_none_or` migration. If #15 lands first, this branch may need a trivial rebase since the filter chains it touches in the same handlers will already be removed by Commit 1 here.

## Test plan

- [x] `cargo test` passes (328 -> 345)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual smoke: `curl -i http://localhost:8080/api/groups?limit=2` returns 2 groups + `X-Total-Count` header
- [ ] Manual smoke: `curl -i 'http://localhost:8080/api/groups?limit=300'` returns 400