### PR TITLE
[FEAT] - WhatsApp ingestion + receipt action endpoints (slice 5 BE)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -7,13 +7,15 @@ use serde::Deserialize;
 use surrealdb_types::SurrealValue;
 use tracing::error;
 
+use crate::auth::audit::record_auth_event;
 use crate::auth::extractors::{AuthenticatedUser, GroupScopedAdmin, SuperAdminUser};
 use crate::api::models::{
     AppError, CreateCycleRequest, CreateGroupRequest, CreateMemberRequest, CreatePaymentRequest,
-    CreateWhatsappLinkRequest, Cycle, CycleContent, DbCycle, DbGroup, DbGroupLink, DbMember,
-    DbPayment, DbReceipt, EntityId, Group, GroupContent, GroupLink, GroupLinkContent, Member,
-    MemberContent, Payment, PaymentContent, Receipt, ReceiptContent, ReceiptStatus,
-    UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest, now_iso, record_id_to_string,
+    CreateWhatsappLinkRequest, Cycle, CycleContent, DbCycle, DbGroup, DbGroupLink, DbInboxItem,
+    DbMember, DbPayment, DbReceipt, EntityId, Group, GroupContent, GroupLink, GroupLinkContent,
+    InboxItemContent, InboxItemKind, Member, MemberContent, Payment, PaymentContent, Receipt,
+    ReceiptContent, ReceiptStatus, UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest,
+    now_iso, record_id_to_string,
 };
 use crate::api::pagination::{
     header_u32, Pagination, PaginationParams, HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT,
@@ -908,39 +910,202 @@ fn receipt_content_from(
     }
 }
 
+// Slice 5 PATCH dispatch ------------------------------------------------------
+
+/// Body for the unified `PATCH /api/receipts/{id}` action endpoint.
+///
+/// The discriminator lives in `action` rather than the URL so the FE can
+/// queue a single optimistic mutation per row regardless of which
+/// terminal state the admin chose. `reason` is meaningful only for
+/// reject/flag and must NEVER carry PII (no phone, no member name, no
+/// OCR text) — the audit row writes a short non-PII tag derived from it.
+#[derive(Debug, Deserialize)]
+pub struct PatchReceiptRequest {
+    pub action: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Cap on the size of an admin-supplied reject/flag reason. The DB column
+/// has no constraint (legacy rows are open-ended), so the cap lives here
+/// at the API boundary to keep a runaway string from bloating audit
+/// queries.
+const MAX_RECEIPT_REASON_LEN: usize = 280;
+
+/// Audit event slugs for receipt actions. Centralised so spelling drift
+/// across handler + tests cannot mask a coverage gap.
+const EVT_RECEIPT_CONFIRMED: &str = "receipt_confirmed";
+const EVT_RECEIPT_REJECTED: &str = "receipt_rejected";
+const EVT_RECEIPT_FLAGGED: &str = "receipt_flagged";
+
+/// Trim and length-cap the admin-supplied reason. Returns `None` when the
+/// input is empty, white-space only, or absent. An over-long reason is a
+/// hard 400 so the FE does not silently truncate a justification.
+fn sanitise_reason(reason: Option<String>) -> Result<Option<String>, AppError> {
+    match reason {
+        None => Ok(None),
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            if trimmed.len() > MAX_RECEIPT_REASON_LEN {
+                return Err(AppError::BadRequest(format!(
+                    "reason must be {MAX_RECEIPT_REASON_LEN} characters or fewer"
+                )));
+            }
+            Ok(Some(trimmed.to_string()))
+        }
+    }
+}
+
+/// Unified action dispatcher. The legacy POST `/api/admin/receipts/{id}/{confirm,reject}`
+/// routes stay alive and delegate to the same `_inner` helpers, so this
+/// endpoint and the legacy routes cannot diverge.
+pub async fn patch_receipt(
+    user: AuthenticatedUser,
+    State(db): State<DbConn>,
+    Path(id): Path<EntityId>,
+    Json(body): Json<PatchReceiptRequest>,
+) -> Result<Json<Receipt>, AppError> {
+    let action = body
+        .action
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AppError::BadRequest("action is required".into()))?;
+    let reason = sanitise_reason(body.reason)?;
+
+    match action {
+        "confirm" => {
+            // `confirm` does not record a reason. Rejecting non-empty reason
+            // up front catches FE bugs that mis-route a reject body.
+            if reason.is_some() {
+                return Err(AppError::BadRequest(
+                    "reason is not allowed for the 'confirm' action".into(),
+                ));
+            }
+            confirm_receipt_inner(user, &db, &id).await
+        }
+        "reject" => reject_receipt_inner(user, &db, &id, reason).await,
+        "flag" => flag_receipt_inner(user, &db, &id, reason).await,
+        other => Err(AppError::BadRequest(format!(
+            "unknown action '{other}'; must be one of confirm, reject, flag"
+        ))),
+    }
+}
+
+// Legacy POST routes ----------------------------------------------------------
+
 pub async fn confirm_receipt(
     user: AuthenticatedUser,
     State(db): State<DbConn>,
     Path(id): Path<EntityId>,
 ) -> Result<Json<Receipt>, AppError> {
-    let receipt = load_active_receipt_opt(&db, id.as_str()).await?;
+    confirm_receipt_inner(user, &db, &id).await
+}
+
+pub async fn reject_receipt(
+    user: AuthenticatedUser,
+    State(db): State<DbConn>,
+    Path(id): Path<EntityId>,
+) -> Result<Json<Receipt>, AppError> {
+    reject_receipt_inner(user, &db, &id, None).await
+}
+
+// Action handlers -------------------------------------------------------------
+//
+// Each `_inner` function performs:
+//   1. opaque auth via `GroupScopedAdmin::ensure_or_deny` (so a non-scoped
+//      admin cannot distinguish "no such id" from "wrong group");
+//   2. the state transition (`pending -> confirmed/rejected/flagged`);
+//   3. any side effects (confirm creates a Payment, then an inbox item);
+//   4. an `auth_event` audit row attributing the change to the actor.
+//
+// Failures hit `record_auth_event(..., success=false, reason=Some(tag))`
+// before the error is returned, so every rejection branch is traceable.
+
+async fn confirm_receipt_inner(
+    user: AuthenticatedUser,
+    db: &DbConn,
+    id: &EntityId,
+) -> Result<Json<Receipt>, AppError> {
+    let receipt = load_active_receipt_opt(db, id.as_str()).await?;
     let auth = GroupScopedAdmin::ensure_or_deny(
         user,
         receipt.as_ref().map(|r| r.group_id.as_str()),
-        &db,
+        db,
         AppError::NotFound(format!("receipt {id} does not exist")),
     )
     .await?;
     let receipt = receipt.expect("ensure_or_deny returns missing_err when None");
+    let actor_id = auth.0.user_id.clone();
 
     if receipt.status != "pending" {
+        record_auth_event(
+            db,
+            None,
+            Some(actor_id.clone()),
+            EVT_RECEIPT_CONFIRMED,
+            false,
+            Some("not_pending"),
+            None,
+        )
+        .await;
         return Err(AppError::Conflict(format!(
             "receipt {id} is already {}",
             receipt.status
         )));
     }
 
-    let member_id = receipt
-        .member_id
-        .clone()
-        .ok_or_else(|| AppError::Conflict("receipt has no linked member".into()))?;
-    let cycle_id = receipt
-        .cycle_id
-        .clone()
-        .ok_or_else(|| AppError::Conflict("receipt has no linked cycle".into()))?;
-    let amount = receipt
-        .extracted_amount
-        .ok_or_else(|| AppError::Conflict("receipt has no extracted amount".into()))?;
+    let member_id = match receipt.member_id.clone() {
+        Some(m) => m,
+        None => {
+            record_auth_event(
+                db,
+                None,
+                Some(actor_id),
+                EVT_RECEIPT_CONFIRMED,
+                false,
+                Some("no_member"),
+                None,
+            )
+            .await;
+            return Err(AppError::Conflict("receipt has no linked member".into()));
+        }
+    };
+    let cycle_id = match receipt.cycle_id.clone() {
+        Some(c) => c,
+        None => {
+            record_auth_event(
+                db,
+                None,
+                Some(actor_id),
+                EVT_RECEIPT_CONFIRMED,
+                false,
+                Some("no_cycle"),
+                None,
+            )
+            .await;
+            return Err(AppError::Conflict("receipt has no linked cycle".into()));
+        }
+    };
+    let amount = match receipt.extracted_amount {
+        Some(a) => a,
+        None => {
+            record_auth_event(
+                db,
+                None,
+                Some(actor_id),
+                EVT_RECEIPT_CONFIRMED,
+                false,
+                Some("no_amount"),
+                None,
+            )
+            .await;
+            return Err(AppError::Conflict("receipt has no extracted amount".into()));
+        }
+    };
 
     // Verify member and cycle still exist and belong to the same group.
     let member: Option<DbMember> = db.select(("member", member_id.as_str())).await?;
@@ -975,6 +1140,16 @@ pub async fn confirm_receipt(
         .await?
         .take(0)?;
     if !existing.is_empty() {
+        record_auth_event(
+            db,
+            None,
+            Some(actor_id),
+            EVT_RECEIPT_CONFIRMED,
+            false,
+            Some("duplicate_payment"),
+            None,
+        )
+        .await;
         return Err(AppError::Conflict(
             "a payment already exists for this member and cycle".into(),
         ));
@@ -989,7 +1164,6 @@ pub async fn confirm_receipt(
             ))
         })?;
 
-    let actor_id = auth.0.user_id.clone();
     let payment_content = PaymentContent {
         member_id: member_id.clone(),
         cycle_id: cycle_id.clone(),
@@ -1013,33 +1187,99 @@ pub async fn confirm_receipt(
     let content = receipt_content_from(
         &receipt,
         "confirmed",
-        now,
-        Some(actor_id),
+        now.clone(),
+        Some(actor_id.clone()),
         receipt.rejected_by.clone(),
         ReceiptPatchFields::default(),
     );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;
 
+    // HANDOFF §5.1: matched member gets a `receipt_confirmed` inbox item.
+    // The inbox row sources from the `member.user_id` link when available;
+    // until BE auth and membership are joined (separate ticket), the
+    // recipient `user_id` is the matched member id itself so the FE has
+    // something to render and tests can assert the row's presence.
+    let receipt_id_str = record_id_to_string(updated.id.clone());
+    write_inbox_item(
+        db,
+        &member_id,
+        InboxItemKind::ReceiptConfirmed,
+        "Receipt confirmed",
+        "Your payment was confirmed by an admin.",
+        Some(&updated.group_id),
+        updated.cycle_id.as_deref(),
+        Some(&receipt_id_str),
+        &now,
+    )
+    .await;
+
+    record_auth_event(
+        db,
+        None,
+        Some(actor_id),
+        EVT_RECEIPT_CONFIRMED,
+        true,
+        None,
+        None,
+    )
+    .await;
+
     Ok(Json(Receipt::try_from(updated)?))
 }
 
-pub async fn reject_receipt(
+async fn reject_receipt_inner(
     user: AuthenticatedUser,
-    State(db): State<DbConn>,
-    Path(id): Path<EntityId>,
+    db: &DbConn,
+    id: &EntityId,
+    reason: Option<String>,
 ) -> Result<Json<Receipt>, AppError> {
-    let receipt = load_active_receipt_opt(&db, id.as_str()).await?;
+    transition_receipt(user, db, id, "rejected", EVT_RECEIPT_REJECTED, reason).await
+}
+
+async fn flag_receipt_inner(
+    user: AuthenticatedUser,
+    db: &DbConn,
+    id: &EntityId,
+    reason: Option<String>,
+) -> Result<Json<Receipt>, AppError> {
+    transition_receipt(user, db, id, "flagged", EVT_RECEIPT_FLAGGED, reason).await
+}
+
+/// Shared body for the two non-confirming actions. Reject and flag share
+/// every step (auth, state check, reason persist, inbox item, audit), so
+/// only the stored status and audit slug differ — extracting the common
+/// shape keeps the two from drifting apart.
+async fn transition_receipt(
+    user: AuthenticatedUser,
+    db: &DbConn,
+    id: &EntityId,
+    new_status: &str,
+    audit_event: &'static str,
+    reason: Option<String>,
+) -> Result<Json<Receipt>, AppError> {
+    let receipt = load_active_receipt_opt(db, id.as_str()).await?;
     let auth = GroupScopedAdmin::ensure_or_deny(
         user,
         receipt.as_ref().map(|r| r.group_id.as_str()),
-        &db,
+        db,
         AppError::NotFound(format!("receipt {id} does not exist")),
     )
     .await?;
     let receipt = receipt.expect("ensure_or_deny returns missing_err when None");
+    let actor_id = auth.0.user_id.clone();
 
     if receipt.status != "pending" {
+        record_auth_event(
+            db,
+            None,
+            Some(actor_id.clone()),
+            audit_event,
+            false,
+            Some("not_pending"),
+            None,
+        )
+        .await;
         return Err(AppError::Conflict(format!(
             "receipt {id} is already {}",
             receipt.status
@@ -1048,16 +1288,95 @@ pub async fn reject_receipt(
 
     let content = receipt_content_from(
         &receipt,
-        "rejected",
+        new_status,
         now_iso(),
         receipt.confirmed_by.clone(),
-        Some(auth.0.user_id.clone()),
-        ReceiptPatchFields::default(),
+        Some(actor_id.clone()),
+        ReceiptPatchFields {
+            rejection_reason: reason.clone(),
+        },
     );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;
 
+    // Notify the matched member (if any) so they know the admin took
+    // action against their receipt. Reject and flag both yield an
+    // `admin_message` since the FE renders both as "needs your
+    // attention" rather than a payment confirmation.
+    if let Some(matched_member_id) = updated.member_id.as_ref() {
+        let title = if new_status == "flagged" {
+            "Receipt flagged for review"
+        } else {
+            "Receipt rejected"
+        };
+        let body = match reason.as_deref() {
+            Some(r) => format!("An admin marked this receipt as {new_status}: {r}"),
+            None => format!("An admin marked this receipt as {new_status}."),
+        };
+        let receipt_id_str = record_id_to_string(updated.id.clone());
+        write_inbox_item(
+            db,
+            matched_member_id,
+            InboxItemKind::AdminMessage,
+            title,
+            &body,
+            Some(&updated.group_id),
+            updated.cycle_id.as_deref(),
+            Some(&receipt_id_str),
+            &updated.updated_at,
+        )
+        .await;
+    }
+
+    record_auth_event(
+        db,
+        None,
+        Some(actor_id),
+        audit_event,
+        true,
+        None,
+        None,
+    )
+    .await;
+
     Ok(Json(Receipt::try_from(updated)?))
+}
+
+/// Best-effort inbox row writer. Failures are logged and swallowed:
+/// surfacing a 500 to the admin after the state transition has already
+/// committed would corrupt the user-visible audit story. The FE polls
+/// the inbox, so a missed write is recoverable; the audit row is the
+/// load-bearing record.
+#[allow(clippy::too_many_arguments)]
+async fn write_inbox_item(
+    db: &DbConn,
+    user_id: &str,
+    kind: InboxItemKind,
+    title: &str,
+    body: &str,
+    pool_id: Option<&str>,
+    cycle_id: Option<&str>,
+    receipt_id: Option<&str>,
+    created_at: &str,
+) {
+    let content = InboxItemContent {
+        user_id: user_id.to_string(),
+        kind: kind.as_str().to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        pool_id: pool_id.map(str::to_string),
+        cycle_id: cycle_id.map(str::to_string),
+        receipt_id: receipt_id.map(str::to_string),
+        read_at: None,
+        created_at: created_at.to_string(),
+    };
+    if let Err(e) = db
+        .create::<Option<DbInboxItem>>("inbox_item")
+        .content(content)
+        .await
+    {
+        tracing::warn!(error = %e, user_id, "inbox_item insert failed");
+    }
 }
 
 // ── Admin WhatsApp link handlers ─────────────────────────────────────────────

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1200,6 +1200,12 @@ async fn confirm_receipt_inner(
     // until BE auth and membership are joined (separate ticket), the
     // recipient `user_id` is the matched member id itself so the FE has
     // something to render and tests can assert the row's presence.
+    //
+    // SECURITY: `user_id` here is the matched member id from the receipt,
+    // not an authenticated session id. Future endpoints listing inbox items
+    // by `user_id` MUST NOT treat this column as an authenticated user
+    // identity. The auth and membership join lands in a follow-up; do not
+    // consume this column as a session principal until it does.
     let receipt_id_str = record_id_to_string(updated.id.clone());
     write_inbox_item(
         db,
@@ -1359,6 +1365,11 @@ async fn write_inbox_item(
     receipt_id: Option<&str>,
     created_at: &str,
 ) {
+    // SECURITY: `user_id` here is the matched member id from the receipt,
+    // not an authenticated session id. Future endpoints listing inbox items
+    // by `user_id` MUST NOT treat this column as an authenticated user
+    // identity. The auth and membership join lands in a follow-up; do not
+    // consume this column as a session principal until it does.
     let content = InboxItemContent {
         user_id: user_id.to_string(),
         kind: kind.as_str().to_string(),

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -257,6 +257,7 @@ pub async fn get_receipts(
             ReceiptStatus::Pending => "pending",
             ReceiptStatus::Confirmed => "confirmed",
             ReceiptStatus::Rejected => "rejected",
+            ReceiptStatus::Flagged => "flagged",
         };
         q = q.bind(("status", stored.to_string()));
     }
@@ -864,12 +865,21 @@ async fn load_active_receipt_opt(db: &DbConn, id: &str) -> Result<Option<DbRecei
     Ok(row.filter(|r| r.deleted_at.is_none()))
 }
 
+/// Optional new fields to set on the receipt row when transitioning state.
+/// Used by the slice 5 PATCH endpoint to attach a `rejection_reason`
+/// without disturbing any other column.
+#[derive(Default)]
+struct ReceiptPatchFields {
+    rejection_reason: Option<String>,
+}
+
 fn receipt_content_from(
     row: &DbReceipt,
     status: &str,
     updated_at: String,
     confirmed_by: Option<String>,
     rejected_by: Option<String>,
+    patch: ReceiptPatchFields,
 ) -> ReceiptContent {
     ReceiptContent {
         whatsapp_message_id: row.whatsapp_message_id.clone(),
@@ -885,6 +895,9 @@ fn receipt_content_from(
         ocr_text: row.ocr_text.clone(),
         sender_label: row.sender_label.clone(),
         bank_label: row.bank_label.clone(),
+        raw_image_url: row.raw_image_url.clone(),
+        // `None` on the patch means "keep prior value"; a `Some` overrides it.
+        rejection_reason: patch.rejection_reason.or_else(|| row.rejection_reason.clone()),
         received_at: row.received_at.clone(),
         created_at: row.created_at.clone(),
         updated_at,
@@ -1003,6 +1016,7 @@ pub async fn confirm_receipt(
         now,
         Some(actor_id),
         receipt.rejected_by.clone(),
+        ReceiptPatchFields::default(),
     );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;
@@ -1038,6 +1052,7 @@ pub async fn reject_receipt(
         now_iso(),
         receipt.confirmed_by.clone(),
         Some(auth.0.user_id.clone()),
+        ReceiptPatchFields::default(),
     );
     let updated: Option<DbReceipt> = db.upsert(("receipt", id.as_str())).content(content).await?;
     let updated = updated.ok_or_else(|| AppError::Internal("receipt update failed".into()))?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,7 @@ pub mod auth_endpoints;
 pub mod handlers;
 pub mod models;
 pub mod pagination;
+pub mod webhooks;
 
 use axum::{
     http::{header, Method},
@@ -100,9 +101,15 @@ pub fn router_with_config(
         .route("/api/admin/groups/{gid}/cycles", post(create_cycle))
         .route("/api/admin/cycles/{id}", patch(update_cycle))
         .route("/api/admin/cycles/{id}", delete(delete_cycle))
-        // Admin Receipt endpoints
+        // Admin Receipt endpoints. The legacy confirm/reject POST routes
+        // stay live alongside the new unified PATCH /api/receipts/{id}
+        // landing in the next commit so the FE can migrate without a
+        // synchronised cut; slice 6 drops them after callers move.
         .route("/api/admin/receipts/{id}/confirm", post(confirm_receipt))
         .route("/api/admin/receipts/{id}/reject", post(reject_receipt))
+        // Slice 5 inbound webhook for the WhatsApp bot. Bound to
+        // `WA_WEBHOOK_SECRET`, fail-closed when unset.
+        .route("/api/webhooks/whatsapp", post(webhooks::whatsapp_webhook))
         // Admin WhatsApp link endpoints
         .route("/api/admin/whatsapp-links", get(get_whatsapp_links))
         .route("/api/admin/whatsapp-links", post(create_whatsapp_link))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,7 +21,8 @@ use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
     create_whatsapp_link, delete_cycle, delete_group, delete_member, delete_payment,
     delete_whatsapp_link, get_cycles, get_groups, get_members, get_payments, get_receipts,
-    get_whatsapp_links, reject_receipt, reset_db, update_cycle, update_group, update_member,
+    get_whatsapp_links, patch_receipt, reject_receipt, reset_db, update_cycle, update_group,
+    update_member,
 };
 
 /// Build the Axum router with all API routes and CORS middleware.
@@ -102,11 +103,15 @@ pub fn router_with_config(
         .route("/api/admin/cycles/{id}", patch(update_cycle))
         .route("/api/admin/cycles/{id}", delete(delete_cycle))
         // Admin Receipt endpoints. The legacy confirm/reject POST routes
-        // stay live alongside the new unified PATCH /api/receipts/{id}
-        // landing in the next commit so the FE can migrate without a
-        // synchronised cut; slice 6 drops them after callers move.
+        // stay live alongside the new unified PATCH /api/receipts/{id} so
+        // the FE can migrate without a synchronised cut; slice 6 drops
+        // the POST routes once callers have moved across.
         .route("/api/admin/receipts/{id}/confirm", post(confirm_receipt))
         .route("/api/admin/receipts/{id}/reject", post(reject_receipt))
+        // Slice 5 unified action endpoint. Accepts
+        // `{ action: 'confirm' | 'reject' | 'flag', reason?: string }`
+        // and gates on `GroupScopedAdmin` via the inner helpers.
+        .route("/api/receipts/{id}", patch(patch_receipt))
         // Slice 5 inbound webhook for the WhatsApp bot. Bound to
         // `WA_WEBHOOK_SECRET`, fail-closed when unset.
         .route("/api/webhooks/whatsapp", post(webhooks::whatsapp_webhook))

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -165,6 +165,11 @@ pub enum ReceiptStatus {
     Pending,
     Confirmed,
     Rejected,
+    /// HANDOFF §4: admin marked the receipt as suspicious but did not commit
+    /// to confirm or reject. Stays out of the contribution ledger (same as
+    /// rejected) but lives in the queue under a distinct filter so the team
+    /// can revisit it.
+    Flagged,
 }
 
 impl std::str::FromStr for ReceiptStatus {
@@ -174,7 +179,56 @@ impl std::str::FromStr for ReceiptStatus {
             "pending" => Ok(Self::Pending),
             "confirmed" => Ok(Self::Confirmed),
             "rejected" => Ok(Self::Rejected),
+            "flagged" => Ok(Self::Flagged),
             _ => Err(format!("unknown receipt status: {s}")),
+        }
+    }
+}
+
+/// HANDOFF §4: closed vocabulary for `inbox_item.kind`. The DB-side
+/// `ASSERT $value IN [...]` mirrors this enum; both must stay in sync.
+/// The FE switches presentation on the kind, so widening this set is a
+/// cross-repo contract change.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InboxItemKind {
+    /// Admin confirmed a WhatsApp receipt linked to the recipient member.
+    ReceiptConfirmed,
+    /// New cycle is about to open in a pool the recipient belongs to.
+    CycleStarting,
+    /// Recipient is the upcoming cycle's payout target.
+    PayoutScheduled,
+    /// Free-form admin note (used by reject/flag flows).
+    AdminMessage,
+    /// Cycle closed without the recipient's contribution.
+    Overdue,
+}
+
+impl InboxItemKind {
+    /// Canonical lowercase string used on the wire and at the DB layer.
+    /// Kept centralised so handlers, the ASSERT clause in `db.rs`, and any
+    /// future filter parser never drift.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ReceiptConfirmed => "receipt_confirmed",
+            Self::CycleStarting => "cycle_starting",
+            Self::PayoutScheduled => "payout_scheduled",
+            Self::AdminMessage => "admin_message",
+            Self::Overdue => "overdue",
+        }
+    }
+}
+
+impl std::str::FromStr for InboxItemKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "receipt_confirmed" => Ok(Self::ReceiptConfirmed),
+            "cycle_starting" => Ok(Self::CycleStarting),
+            "payout_scheduled" => Ok(Self::PayoutScheduled),
+            "admin_message" => Ok(Self::AdminMessage),
+            "overdue" => Ok(Self::Overdue),
+            _ => Err(format!("unknown inbox item kind: {s}")),
         }
     }
 }
@@ -267,6 +321,14 @@ pub struct DbReceipt {
     pub ocr_text: Option<String>,
     pub sender_label: Option<String>,
     pub bank_label: Option<String>,
+    /// HANDOFF §4: direct URL to the WhatsApp screenshot the bot captured.
+    /// Optional so legacy rows ingested before slice 5 still deserialise.
+    #[surreal(default)]
+    pub raw_image_url: Option<String>,
+    /// HANDOFF §4: short admin-supplied note explaining a reject/flag
+    /// decision. Optional; never carries PII (no phone, no OCR text).
+    #[surreal(default)]
+    pub rejection_reason: Option<String>,
     pub received_at: String,
     pub created_at: String,
     pub updated_at: String,
@@ -433,6 +495,10 @@ pub struct Receipt {
     pub sender_label: Option<String>,
     #[serde(rename = "bankLabel", skip_serializing_if = "Option::is_none")]
     pub bank_label: Option<String>,
+    #[serde(rename = "rawImageUrl", skip_serializing_if = "Option::is_none")]
+    pub raw_image_url: Option<String>,
+    #[serde(rename = "rejectionReason", skip_serializing_if = "Option::is_none")]
+    pub rejection_reason: Option<String>,
     #[serde(rename = "receivedAt")]
     pub received_at: String,
     #[serde(rename = "createdAt")]
@@ -573,6 +639,8 @@ impl TryFrom<DbReceipt> for Receipt {
             ocr_text: db.ocr_text,
             sender_label: db.sender_label,
             bank_label: db.bank_label,
+            raw_image_url: db.raw_image_url,
+            rejection_reason: db.rejection_reason,
             received_at: db.received_at,
             created_at: db.created_at,
             updated_at: db.updated_at,
@@ -674,6 +742,8 @@ pub struct ReceiptContent {
     pub ocr_text: Option<String>,
     pub sender_label: Option<String>,
     pub bank_label: Option<String>,
+    pub raw_image_url: Option<String>,
+    pub rejection_reason: Option<String>,
     pub received_at: String,
     pub created_at: String,
     pub updated_at: String,
@@ -690,6 +760,76 @@ pub struct GroupLinkContent {
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
+}
+
+/// Insert shape for the `inbox_item` table. SCHEMAFULL on the DB side, so
+/// every field listed in `define_inbox_table` is mandatory unless declared
+/// `option<...>` there.
+#[derive(Debug, Clone, Serialize, SurrealValue)]
+pub struct InboxItemContent {
+    pub user_id: String,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    pub pool_id: Option<String>,
+    pub cycle_id: Option<String>,
+    pub receipt_id: Option<String>,
+    pub read_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize, SurrealValue)]
+pub struct DbInboxItem {
+    pub id: RecordId,
+    pub user_id: String,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    pub pool_id: Option<String>,
+    pub cycle_id: Option<String>,
+    pub receipt_id: Option<String>,
+    pub read_at: Option<String>,
+    pub created_at: String,
+}
+
+/// API-facing shape for inbox items. camelCase across the wire so the
+/// Next.js FE reads it without an adapter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboxItem {
+    pub id: EntityId,
+    #[serde(rename = "userId")]
+    pub user_id: String,
+    pub kind: InboxItemKind,
+    pub title: String,
+    pub body: String,
+    #[serde(rename = "poolId", skip_serializing_if = "Option::is_none")]
+    pub pool_id: Option<String>,
+    #[serde(rename = "cycleId", skip_serializing_if = "Option::is_none")]
+    pub cycle_id: Option<String>,
+    #[serde(rename = "receiptId", skip_serializing_if = "Option::is_none")]
+    pub receipt_id: Option<String>,
+    #[serde(rename = "readAt", skip_serializing_if = "Option::is_none")]
+    pub read_at: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+impl TryFrom<DbInboxItem> for InboxItem {
+    type Error = AppError;
+    fn try_from(db: DbInboxItem) -> Result<Self, AppError> {
+        Ok(Self {
+            id: record_id_to_string(db.id),
+            user_id: db.user_id,
+            kind: db.kind.parse().map_err(AppError::Internal)?,
+            title: db.title,
+            body: db.body,
+            pool_id: db.pool_id,
+            cycle_id: db.cycle_id,
+            receipt_id: db.receipt_id,
+            read_at: db.read_at,
+            created_at: db.created_at,
+        })
+    }
 }
 
 // ── Request bodies ──────────────────────────────────────────────────────────

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -99,19 +99,20 @@ pub async fn whatsapp_webhook(
     State(db): State<DbConn>,
     WebhookVerifiedJson(payload): WebhookVerifiedJson<WebhookPayload>,
 ) -> Result<(StatusCode, Json<WebhookResponse>), AppError> {
-    // `message_id` is the duplicate-detection key — refusing an empty value
-    // here keeps a malformed bot post from silently coalescing every
+    // Required identifier fields. The module-level contract is that every
+    // verification/validation failure on the webhook path collapses to 401
+    // so a probing caller cannot distinguish "valid signature, bad payload"
+    // from "bad signature" (avoiding a signature/probing oracle). These
+    // checks therefore return `Unauthorized`, not `BadRequest`.
+    //
+    // `message_id` is also the duplicate-detection key — refusing an empty
+    // value here keeps a malformed bot post from silently coalescing every
     // unrelated message under "" in the index.
-    if payload.message_id.trim().is_empty() {
-        return Err(AppError::BadRequest("messageId must not be empty".into()));
-    }
-    if payload.chat_id.trim().is_empty() {
-        return Err(AppError::BadRequest("chatId must not be empty".into()));
-    }
-    if payload.sender_phone.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "senderPhone must not be empty".into(),
-        ));
+    if payload.message_id.trim().is_empty()
+        || payload.chat_id.trim().is_empty()
+        || payload.sender_phone.trim().is_empty()
+    {
+        return Err(AppError::Unauthorized);
     }
 
     let parsed = ParsedReceipt {

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -1,0 +1,159 @@
+//! Inbound webhook endpoints.
+//!
+//! Slice 5 adds `POST /api/webhooks/whatsapp`. The bot signs the payload
+//! with `WA_WEBHOOK_SECRET` (HMAC-SHA256 over `timestamp + "." + body`,
+//! same scheme as the NextAuth backend channel) and posts a flat JSON
+//! payload describing one receipt message. This handler converts the
+//! payload into an [`IngestionInput`] and delegates to the existing
+//! `ingestion::ingest_receipt` pipeline — so the matcher logic, duplicate
+//! detection, and `IngestionOutcome` shape are unchanged.
+//!
+//! Authentication is fail-closed at the extractor: the secret env var must
+//! be set and non-empty, the timestamp must be within ±60 s of server
+//! time, and the signature must verify constant-time. Any deviation
+//! collapses to 401, so a probing caller cannot tell which gate failed.
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::api::models::AppError;
+use crate::auth::hmac::WebhookVerifiedJson;
+use crate::db::DbConn;
+use crate::ingestion::{self, IngestionInput, IngestionOutcome};
+use crate::models::ParsedReceipt;
+
+/// JSON shape posted by the WhatsApp bot for a single receipt event.
+///
+/// camelCase across the wire to match the bot's existing Node code, with
+/// snake_case Rust field names mapped via `serde(rename_all)`. Every field
+/// has a single, narrow purpose — see the inline comments. Optional
+/// fields default to `None` so a slimmer payload from a future bot
+/// version still deserialises (the matcher gracefully degrades when
+/// optional context is missing).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookPayload {
+    /// WhatsApp group chat id (`<digits>@g.us`). Routes to the linked pool.
+    pub chat_id: String,
+    /// Sender JID or raw digits. The ingestion pipeline strips any `@…`
+    /// suffix before phone matching.
+    pub sender_phone: String,
+    /// Unique WhatsApp message id. Used by the duplicate-detection gate.
+    pub message_id: String,
+    /// Raw text or caption — the OCR/parse layer ran upstream in the bot.
+    #[serde(default)]
+    pub ocr_text: String,
+    /// Bot-parsed fields (sender label, bank label, amount string).
+    /// All optional; the matcher falls back to phone-only when missing.
+    #[serde(default)]
+    pub parsed: WebhookParsedFields,
+    /// ISO 8601 timestamp the bot stamped when it observed the message.
+    /// Stored on the receipt as `received_at`.
+    pub received_at: String,
+    /// Direct URL to the WhatsApp screenshot (HANDOFF §4). Persisted on
+    /// the receipt so admins can review the artefact in the FE modal.
+    #[serde(default)]
+    pub raw_image_url: Option<String>,
+}
+
+/// Parsed fields the bot supplies alongside the raw OCR text. Mirrors the
+/// internal `ParsedReceipt` so we do not perform any extra parsing on the
+/// API side — the bot owns OCR/regex extraction, the API owns persistence
+/// and matching.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookParsedFields {
+    #[serde(default)]
+    pub sender: Option<String>,
+    #[serde(default)]
+    pub bank: Option<String>,
+    #[serde(default)]
+    pub amount: Option<String>,
+}
+
+/// Wire shape of the success response. The bot uses `outcome` to decide
+/// whether to post a quoted acknowledgement reply, and `receiptId` (when
+/// the outcome is `ingested`) to link future updates back to the row.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookResponse {
+    /// Canonical outcome slug — one of `"not_linked"`, `"duplicate"`,
+    /// `"ingested"`. Stable for the bot to switch on.
+    pub outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt_id: Option<String>,
+    /// Whether the matcher resolved the sender phone to a member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_matched: Option<bool>,
+}
+
+/// Handler: verifies the HMAC, dispatches to the shared ingestion pipeline,
+/// and projects the outcome to the bot-facing response shape.
+///
+/// All ingestion outcomes (linked / unlinked / duplicate) return 200 with
+/// a body the bot can switch on — only auth or storage failures bubble up
+/// as error statuses. That mirrors the contract the bot already expects
+/// from the existing Green API polling code path.
+pub async fn whatsapp_webhook(
+    State(db): State<DbConn>,
+    WebhookVerifiedJson(payload): WebhookVerifiedJson<WebhookPayload>,
+) -> Result<(StatusCode, Json<WebhookResponse>), AppError> {
+    // `message_id` is the duplicate-detection key — refusing an empty value
+    // here keeps a malformed bot post from silently coalescing every
+    // unrelated message under "" in the index.
+    if payload.message_id.trim().is_empty() {
+        return Err(AppError::BadRequest("messageId must not be empty".into()));
+    }
+    if payload.chat_id.trim().is_empty() {
+        return Err(AppError::BadRequest("chatId must not be empty".into()));
+    }
+    if payload.sender_phone.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "senderPhone must not be empty".into(),
+        ));
+    }
+
+    let parsed = ParsedReceipt {
+        sender: payload.parsed.sender,
+        bank: payload.parsed.bank,
+        amount: payload.parsed.amount,
+    };
+
+    let input = IngestionInput {
+        chat_id: &payload.chat_id,
+        sender_phone: &payload.sender_phone,
+        message_id: &payload.message_id,
+        ocr_text: &payload.ocr_text,
+        parsed: &parsed,
+        received_at: payload.received_at,
+        raw_image_url: payload.raw_image_url,
+    };
+
+    let outcome = ingestion::ingest_receipt(&db, input).await?;
+    info!(
+        chat_id = %payload.chat_id,
+        message_id = %payload.message_id,
+        ?outcome,
+        "Webhook ingest outcome"
+    );
+
+    let resp = match outcome {
+        IngestionOutcome::NotLinked => WebhookResponse {
+            outcome: "not_linked",
+            receipt_id: None,
+            member_matched: None,
+        },
+        IngestionOutcome::DuplicateMessage => WebhookResponse {
+            outcome: "duplicate",
+            receipt_id: None,
+            member_matched: None,
+        },
+        IngestionOutcome::Ingested(r) => WebhookResponse {
+            outcome: "ingested",
+            receipt_id: Some(r.receipt_id),
+            member_matched: Some(r.member_matched),
+        },
+    };
+    Ok((StatusCode::OK, Json(resp)))
+}

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -1,10 +1,19 @@
-//! HMAC-SHA256 request authentication for NextAuth → backend calls.
+//! HMAC-SHA256 request authentication.
 //!
-//! The NextAuth app signs each request with a shared secret. We verify:
+//! Two secret bindings ride the same machinery:
+//!   - [`HmacVerifiedJson`]  — `NEXTAUTH_BACKEND_SECRET` (NextAuth → backend)
+//!   - [`WebhookVerifiedJson`] — `WA_WEBHOOK_SECRET`     (WhatsApp bot → backend)
+//!
+//! Every verified path enforces:
 //!   - `X-Signature: sha256=<hex>` over `timestamp + "." + raw_body`
-//!   - `X-Timestamp` within ±60 s of server time (prevents replay)
+//!   - `X-Timestamp` within ±60 s of server time (replay window)
+//!   - Body ≤ 1 MiB
 //!
-//! The extractor re-serialises the body for downstream JSON deserialisation.
+//! Both extractors fail closed (401) when their bound env var is unset, empty,
+//! or whitespace-only — so a misconfigured deployment cannot accept signed
+//! requests under an empty key. The exact reason for rejection is never
+//! leaked: every verification failure collapses to a single
+//! `AppError::Unauthorized`.
 
 use axum::{
     body::{Bytes, to_bytes},
@@ -20,16 +29,54 @@ use crate::api::models::AppError;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Max body size accepted by HMAC-protected endpoints (1 MiB — NextAuth
-/// payloads are a few hundred bytes at most).
+/// Max body size accepted by any HMAC-protected endpoint. NextAuth payloads
+/// are a few hundred bytes; WhatsApp webhook payloads carry a single image
+/// URL + parsed text, so the same 1 MiB ceiling fits both.
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
-/// Replay protection window in seconds.
+/// Replay protection window in seconds. Symmetric: rejects both stale
+/// timestamps (delivery delayed past the window) and future timestamps
+/// (clock skew or naive forgery).
 const TIMESTAMP_TOLERANCE_SECS: i64 = 60;
+
+/// Source of the shared HMAC secret for a particular extractor.
+///
+/// Implementors point at a single env var; the extractor resolves it on
+/// every request so an operator can rotate a secret without restarting the
+/// process. The resolver is also the place where empty / whitespace-only
+/// values fail closed — see [`resolve_secret`].
+pub trait HmacSecretSource {
+    /// Name of the env var the secret is read from. Reported in logs when
+    /// the var is missing so operators can trace misconfiguration without
+    /// leaking the secret itself.
+    fn env_var_name() -> &'static str;
+}
+
+/// Binds the NextAuth backend secret. The signed-body callers are the
+/// Next.js NextAuth handlers calling into this Rust API.
+pub struct NextAuthBackendSecret;
+
+impl HmacSecretSource for NextAuthBackendSecret {
+    fn env_var_name() -> &'static str {
+        "NEXTAUTH_BACKEND_SECRET"
+    }
+}
+
+/// Binds the WhatsApp webhook secret. The signed-body caller is the
+/// out-of-process WhatsApp bot posting receipts at
+/// `POST /api/webhooks/whatsapp`.
+pub struct WhatsappWebhookSecret;
+
+impl HmacSecretSource for WhatsappWebhookSecret {
+    fn env_var_name() -> &'static str {
+        "WA_WEBHOOK_SECRET"
+    }
+}
 
 /// Extractor: verifies the HMAC signature then deserialises the JSON body
 /// into `T`. Returns 401 for any signing/replay/body failure so the caller
-/// cannot probe which specific check failed.
+/// cannot probe which specific check failed. Bound to
+/// `NEXTAUTH_BACKEND_SECRET` for NextAuth → backend traffic.
 pub struct HmacVerifiedJson<T>(pub T);
 
 impl<S, T> FromRequest<S> for HmacVerifiedJson<T>
@@ -40,25 +87,66 @@ where
     type Rejection = AppError;
 
     async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
-        let secret = std::env::var("NEXTAUTH_BACKEND_SECRET").unwrap_or_default();
-        if secret.is_empty() {
-            tracing::error!("NEXTAUTH_BACKEND_SECRET is not set — rejecting HMAC request");
-            return Err(AppError::Unauthorized);
-        }
-
-        let (parts, body) = req.into_parts();
-        let timestamp = extract_timestamp(&parts.headers)?;
-        let signature_hex = extract_signature(&parts.headers)?;
-
-        let bytes = to_bytes(body, MAX_BODY_BYTES)
-            .await
-            .map_err(|_| AppError::Unauthorized)?;
-
-        verify_signature(&secret, timestamp, &bytes, &signature_hex)?;
-
-        let value: T = serde_json::from_slice(&bytes).map_err(|_| AppError::Unauthorized)?;
+        let value = verify_with::<NextAuthBackendSecret, T>(req).await?;
         Ok(HmacVerifiedJson(value))
     }
+}
+
+/// Extractor: same verification contract as [`HmacVerifiedJson`], but bound
+/// to `WA_WEBHOOK_SECRET`. Mounted on `POST /api/webhooks/whatsapp` so the
+/// WhatsApp bot cannot reach NextAuth-gated routes (and vice versa) even
+/// if one secret leaks.
+pub struct WebhookVerifiedJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for WebhookVerifiedJson<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = AppError;
+
+    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let value = verify_with::<WhatsappWebhookSecret, T>(req).await?;
+        Ok(WebhookVerifiedJson(value))
+    }
+}
+
+/// Core verification path shared by every HMAC-bound extractor. Generic
+/// over the secret source so a future signed endpoint can mount the same
+/// machinery against a different env var without duplicating the
+/// timestamp/signature/body logic (and risking drift).
+async fn verify_with<Src, T>(req: Request) -> Result<T, AppError>
+where
+    Src: HmacSecretSource,
+    T: DeserializeOwned,
+{
+    let secret = resolve_secret::<Src>()?;
+
+    let (parts, body) = req.into_parts();
+    let timestamp = extract_timestamp(&parts.headers)?;
+    let signature_hex = extract_signature(&parts.headers)?;
+
+    let bytes = to_bytes(body, MAX_BODY_BYTES)
+        .await
+        .map_err(|_| AppError::Unauthorized)?;
+
+    verify_signature(&secret, timestamp, &bytes, &signature_hex)?;
+
+    serde_json::from_slice(&bytes).map_err(|_| AppError::Unauthorized)
+}
+
+/// Read the secret env var for a given source, treating unset, empty, or
+/// whitespace-only values as misconfiguration. Logged once per failed
+/// request so a noisy 401 line surfaces in production even when the
+/// caller's request shape is otherwise plausible.
+fn resolve_secret<Src: HmacSecretSource>() -> Result<String, AppError> {
+    let name = Src::env_var_name();
+    let raw = std::env::var(name).unwrap_or_default();
+    if raw.trim().is_empty() {
+        tracing::error!(env_var = name, "HMAC secret is not set — rejecting request");
+        return Err(AppError::Unauthorized);
+    }
+    Ok(raw)
 }
 
 fn extract_timestamp(headers: &HeaderMap) -> Result<i64, AppError> {

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -156,7 +156,15 @@ fn extract_timestamp(headers: &HeaderMap) -> Result<i64, AppError> {
         .ok_or(AppError::Unauthorized)?;
     let ts: i64 = raw.parse().map_err(|_| AppError::Unauthorized)?;
     let now = chrono::Utc::now().timestamp();
-    if (now - ts).abs() > TIMESTAMP_TOLERANCE_SECS {
+    // Explicit saturating bounds rather than `(now - ts).abs()`: a near
+    // `i64::MIN` timestamp would wrap signed subtraction and `i64::MIN.abs()`
+    // is itself `i64::MIN` (overflow), which can slip past a naive
+    // `.abs() > TIMESTAMP_TOLERANCE_SECS` check at a narrow `now`. Saturating
+    // arithmetic clamps to the i64 range so out-of-window timestamps stay
+    // out-of-window regardless of how extreme the attacker-supplied value is.
+    let lower = now.saturating_sub(TIMESTAMP_TOLERANCE_SECS);
+    let upper = now.saturating_add(TIMESTAMP_TOLERANCE_SECS);
+    if ts < lower || ts > upper {
         return Err(AppError::Unauthorized);
     }
     Ok(ts)

--- a/src/db.rs
+++ b/src/db.rs
@@ -186,14 +186,13 @@ async fn define_tables(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
 /// Slice 5 additions to the receipt table.
 ///
 /// Two new optional fields:
-///   - `raw_image_url`     — direct URL to the WhatsApp screenshot, captured
-///                           by the bot and persisted so admins can review
-///                           the original artefact during confirm/reject.
-///   - `rejection_reason`  — short human note recorded when an admin rejects
-///                           or flags a receipt. Must NOT contain PII
-///                           (sender phone, OCR text, member name) — that
-///                           is a handler-side invariant; the schema is
-///                           open-ended so legacy rows stay readable.
+///   - `raw_image_url`: direct URL to the WhatsApp screenshot, captured by
+///     the bot and persisted so admins can review the original artefact
+///     during confirm/reject.
+///   - `rejection_reason`: short human note recorded when an admin rejects
+///     or flags a receipt. Must NOT contain PII (sender phone, OCR text,
+///     member name). That is a handler-side invariant; the schema stays
+///     open-ended so legacy rows remain readable.
 ///
 /// Two new indexes:
 ///   - `receipt_sender_received` over `(sender_phone, received_at)` powers

--- a/src/db.rs
+++ b/src/db.rs
@@ -176,7 +176,83 @@ async fn define_tables(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
     )
     .await?
     .check()?;
+
+    define_receipt_extensions(db).await?;
+    define_inbox_table(db).await?;
     define_auth_tables(db).await?;
+    Ok(())
+}
+
+/// Slice 5 additions to the receipt table.
+///
+/// Two new optional fields:
+///   - `raw_image_url`     — direct URL to the WhatsApp screenshot, captured
+///                           by the bot and persisted so admins can review
+///                           the original artefact during confirm/reject.
+///   - `rejection_reason`  — short human note recorded when an admin rejects
+///                           or flags a receipt. Must NOT contain PII
+///                           (sender phone, OCR text, member name) — that
+///                           is a handler-side invariant; the schema is
+///                           open-ended so legacy rows stay readable.
+///
+/// Two new indexes:
+///   - `receipt_sender_received` over `(sender_phone, received_at)` powers
+///     the "show every receipt this phone has ever sent" admin-side history
+///     lookups landing in the FE slice 5 modal.
+///   - `receipt_status_received` over `(status, received_at)` powers the
+///     admin queue's "pending, newest first" default sort without a table
+///     scan as receipt volume grows.
+///
+/// The receipt table itself stays SCHEMALESS so existing fixtures and
+/// in-flight writes are unaffected — new fields land as plain optional
+/// columns. SCHEMAFULL would force a destructive backfill on every
+/// existing row.
+async fn define_receipt_extensions(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
+    db.query(
+        "DEFINE FIELD IF NOT EXISTS raw_image_url ON receipt TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS rejection_reason ON receipt TYPE option<string>;
+         DEFINE INDEX IF NOT EXISTS receipt_sender_received
+             ON receipt FIELDS sender_phone, received_at;
+         DEFINE INDEX IF NOT EXISTS receipt_status_received
+             ON receipt FIELDS status, received_at;",
+    )
+    .await?
+    .check()?;
+    Ok(())
+}
+
+/// `inbox_item` is the per-user notification stream rendered by the FE
+/// `/inbox` route (HANDOFF §4 and §5.1). SCHEMAFULL because the `kind`
+/// vocabulary is contract-bearing: the FE switches presentation on the
+/// value, and an unknown kind would render as a blank row. The DB-side
+/// `ASSERT $value IN [...]` guarantees the contract holds even if a
+/// future handler forgets to validate.
+///
+/// Indexes:
+///   - `inbox_item_user_created` powers the "newest first" feed query —
+///     `WHERE user_id = $uid ORDER BY created_at DESC`.
+///   - `inbox_item_user_unread`  powers the inbox-bell unread count and the
+///     "you have N pending items" badges on the home page.
+async fn define_inbox_table(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
+    db.query(
+        "DEFINE TABLE IF NOT EXISTS inbox_item SCHEMAFULL;
+         DEFINE FIELD IF NOT EXISTS user_id ON inbox_item TYPE string;
+         DEFINE FIELD IF NOT EXISTS kind ON inbox_item TYPE string
+             ASSERT $value IN ['receipt_confirmed', 'cycle_starting', 'payout_scheduled', 'admin_message', 'overdue'];
+         DEFINE FIELD IF NOT EXISTS title ON inbox_item TYPE string;
+         DEFINE FIELD IF NOT EXISTS body ON inbox_item TYPE string;
+         DEFINE FIELD IF NOT EXISTS pool_id ON inbox_item TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS cycle_id ON inbox_item TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS receipt_id ON inbox_item TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS read_at ON inbox_item TYPE option<string>;
+         DEFINE FIELD IF NOT EXISTS created_at ON inbox_item TYPE string;
+         DEFINE INDEX IF NOT EXISTS inbox_item_user_created
+             ON inbox_item FIELDS user_id, created_at;
+         DEFINE INDEX IF NOT EXISTS inbox_item_user_unread
+             ON inbox_item FIELDS user_id, read_at;",
+    )
+    .await?
+    .check()?;
     Ok(())
 }
 
@@ -574,6 +650,8 @@ fn fixture_receipts() -> Vec<(&'static str, ReceiptContent)> {
                 ocr_text: Some("NGN 10,000.00\nFrom: Tunde Bakare\nBank: GTBank".into()),
                 sender_label: Some("Tunde Bakare".into()),
                 bank_label: Some("GTBank".into()),
+                raw_image_url: None,
+                rejection_reason: None,
                 received_at: "2026-03-02T10:29:45+00:00".into(),
                 created_at: created_at.into(),
                 updated_at: created_at.into(),
@@ -599,6 +677,8 @@ fn fixture_receipts() -> Vec<(&'static str, ReceiptContent)> {
                 ocr_text: Some("NGN 5,000.00\nFrom: Chukwuemeka Eze".into()),
                 sender_label: Some("Chukwuemeka Eze".into()),
                 bank_label: None,
+                raw_image_url: None,
+                rejection_reason: None,
                 received_at: "2026-03-03T14:15:00+00:00".into(),
                 created_at: "2026-03-03T14:15:30+00:00".into(),
                 updated_at: "2026-03-03T16:00:00+00:00".into(),

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -28,6 +28,11 @@ pub struct IngestionInput<'a> {
     pub ocr_text: &'a str,
     pub parsed: &'a ParsedReceipt,
     pub received_at: String,
+    /// Optional direct URL to the WhatsApp screenshot, captured by the bot.
+    /// Persisted on the receipt row so admins can review the original
+    /// artefact during confirm/reject in the slice 5 FE modal. Older
+    /// pipelines that pre-date this field still ingest correctly.
+    pub raw_image_url: Option<String>,
 }
 
 /// What happened with the ingestion attempt. Carries everything the reply
@@ -111,6 +116,8 @@ pub async fn ingest_receipt(
         ocr_text: Some(input.ocr_text.to_string()),
         sender_label: input.parsed.sender.clone(),
         bank_label: input.parsed.bank.clone(),
+        raw_image_url: input.raw_image_url,
+        rejection_reason: None,
         received_at: input.received_at,
         created_at: now.clone(),
         updated_at: now,

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,9 @@ async fn main() {
                                                     ocr_text: &text,
                                                     parsed: &parsed,
                                                     received_at: now_iso(),
+                                                    // Green API polling path does not capture
+                                                    // a raw image URL; the slice 5 webhook does.
+                                                    raw_image_url: None,
                                                 };
                                                 match ingestion::ingest_receipt(&surreal_db, input).await {
                                                     Ok(outcome) => {

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -2390,3 +2390,523 @@ async fn pagination_excludes_soft_deleted_receipts_from_total_count() {
         "soft-deleted rows must be excluded from the page"
     );
 }
+
+// ── PATCH /api/receipts/{id} (Slice 5) ────────────────────────────────────────
+//
+// Covers the unified action endpoint: confirm / reject / flag dispatch,
+// scope gating, payload validation, and the side effects (payment row +
+// inbox item on confirm; rejection_reason persistence; member-scoped
+// inbox message on reject/flag).
+
+/// Pull every `inbox_item` for one user_id. Used by the PATCH + inbox
+/// suites to assert side-effect rows landed where they should. The query
+/// flows through the same SurrealDB handle the API uses, so an index
+/// regression would fail the read here too.
+async fn fetch_inbox_for_user(
+    db: &poolpay::db::DbConn,
+    user_id: &str,
+) -> Vec<serde_json::Value> {
+    use surrealdb_types::SurrealValue;
+    #[derive(Debug, serde::Deserialize, SurrealValue)]
+    struct Row {
+        kind: String,
+        title: String,
+        body: String,
+        pool_id: Option<String>,
+        receipt_id: Option<String>,
+        read_at: Option<String>,
+    }
+    let rows: Vec<Row> = db
+        .query("SELECT * FROM inbox_item WHERE user_id = $uid ORDER BY created_at ASC")
+        .bind(("uid", user_id.to_string()))
+        .await
+        .expect("inbox query")
+        .take(0)
+        .expect("inbox rows");
+    rows.into_iter()
+        .map(|r| {
+            serde_json::json!({
+                "kind": r.kind,
+                "title": r.title,
+                "body": r.body,
+                "poolId": r.pool_id,
+                "receiptId": r.receipt_id,
+                "readAt": r.read_at,
+            })
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_returns_200_and_sets_confirmed_status() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(resp).await;
+    assert_eq!(body["status"], "confirmed");
+    assert_eq!(body["confirmedBy"], TEST_SUPER_ADMIN_SUB);
+}
+
+#[tokio::test]
+async fn patch_receipt_reject_returns_200_and_persists_reason() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "reject", "reason": "wrong amount"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(resp).await;
+    assert_eq!(body["status"], "rejected");
+    assert_eq!(body["rejectedBy"], TEST_SUPER_ADMIN_SUB);
+    assert_eq!(body["rejectionReason"], "wrong amount");
+}
+
+#[tokio::test]
+async fn patch_receipt_flag_returns_200_and_sets_flagged_status() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "flag", "reason": "needs review"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(resp).await;
+    assert_eq!(body["status"], "flagged");
+    assert_eq!(body["rejectedBy"], TEST_SUPER_ADMIN_SUB);
+    assert_eq!(body["rejectionReason"], "needs review");
+}
+
+#[tokio::test]
+async fn patch_receipt_missing_action_returns_400() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"reason": "nope"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_receipt_invalid_action_returns_400() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "destroy"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_receipt_scoped_admin_denied_cross_group_returns_403() {
+    // The scoped admin is granted access to group 1 only. Receipt 1 lives
+    // in group 1, so the scoped admin succeeds; to exercise the denied
+    // branch we need a receipt in a different group. Create a second
+    // group + a fresh receipt row directly via the SurrealDB handle.
+    use poolpay::api::models::{now_iso, ReceiptContent};
+    let (app, db) = test_app_with_auth_and_db().await;
+
+    // Create group 2 via the admin API (super-admin path).
+    let g = call(
+        app.clone(),
+        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Off-limits"})),
+    )
+    .await;
+    assert_eq!(g.status(), StatusCode::CREATED);
+    let new_group: serde_json::Value = json_body(g).await;
+    let other_group_id = new_group["id"].as_str().unwrap().to_string();
+
+    // Insert a pending receipt directly in that group.
+    let now = now_iso();
+    let other_receipt_id = "patch-foreign-receipt";
+    let content = ReceiptContent {
+        whatsapp_message_id: "WAMSG-FOREIGN".into(),
+        group_id: other_group_id,
+        chat_id: "0000@g.us".into(),
+        sender_phone: "0000".into(),
+        member_id: None,
+        cycle_id: None,
+        extracted_amount: None,
+        expected_amount: None,
+        amount_matches: None,
+        status: "pending".into(),
+        ocr_text: None,
+        sender_label: None,
+        bank_label: None,
+        raw_image_url: None,
+        rejection_reason: None,
+        received_at: now.clone(),
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+        confirmed_by: None,
+        rejected_by: None,
+        deleted_by: None,
+    };
+    let _: Option<poolpay::api::models::DbReceipt> = db
+        .upsert(("receipt", other_receipt_id))
+        .content(content)
+        .await
+        .expect("seed off-limits receipt");
+
+    let resp = call(
+        app,
+        patch_json_jwt_with(
+            &format!("/api/receipts/{other_receipt_id}"),
+            serde_json::json!({"action": "reject"}),
+            &scoped_admin_bearer(),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn patch_receipt_super_admin_allowed_cross_group() {
+    // Same setup as the denied case, but called with the super-admin
+    // bearer — must succeed regardless of which group the receipt lives in.
+    use poolpay::api::models::{now_iso, ReceiptContent};
+    let (app, db) = test_app_with_auth_and_db().await;
+    let g = call(
+        app.clone(),
+        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Other"})),
+    )
+    .await;
+    let new_group: serde_json::Value = json_body(g).await;
+    let other_group_id = new_group["id"].as_str().unwrap().to_string();
+
+    let now = now_iso();
+    let other_receipt_id = "patch-super-cross-receipt";
+    let content = ReceiptContent {
+        whatsapp_message_id: "WAMSG-CROSS".into(),
+        group_id: other_group_id,
+        chat_id: "0001@g.us".into(),
+        sender_phone: "0000".into(),
+        member_id: None,
+        cycle_id: None,
+        extracted_amount: None,
+        expected_amount: None,
+        amount_matches: None,
+        status: "pending".into(),
+        ocr_text: None,
+        sender_label: None,
+        bank_label: None,
+        raw_image_url: None,
+        rejection_reason: None,
+        received_at: now.clone(),
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+        confirmed_by: None,
+        rejected_by: None,
+        deleted_by: None,
+    };
+    let _: Option<poolpay::api::models::DbReceipt> = db
+        .upsert(("receipt", other_receipt_id))
+        .content(content)
+        .await
+        .expect("seed cross-group receipt");
+
+    let resp = call(
+        app,
+        patch_json_jwt(
+            &format!("/api/receipts/{other_receipt_id}"),
+            serde_json::json!({"action": "reject"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn patch_receipt_double_confirm_returns_409() {
+    let app = test_app_with_auth().await;
+    let first = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn patch_receipt_reason_persisted_on_reject() {
+    let (app, db) = test_app_with_auth_and_db().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "reject", "reason": "duplicate"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Read the row directly via Surreal to make sure the value really
+    // lives in the DB and is not just echoed back from the request body.
+    let row: Option<poolpay::api::models::DbReceipt> =
+        db.select(("receipt", "1")).await.expect("select receipt");
+    let row = row.expect("receipt row");
+    assert_eq!(row.status, "rejected");
+    assert_eq!(row.rejection_reason.as_deref(), Some("duplicate"));
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_creates_payment_and_inbox_item() {
+    let (app, db) = test_app_with_auth_and_db().await;
+
+    let payments_before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get("/api/payments")).await).await;
+    let baseline = payments_before.len();
+
+    let resp = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Payment row created.
+    let payments_after: Vec<serde_json::Value> =
+        json_body(call(app, get("/api/payments")).await).await;
+    assert_eq!(payments_after.len(), baseline + 1);
+
+    // Inbox item created for the matched member (member id "4" per fixtures).
+    let inbox = fetch_inbox_for_user(&db, "4").await;
+    assert!(
+        inbox.iter().any(|r| r["kind"] == "receipt_confirmed"),
+        "expected a receipt_confirmed inbox row for matched member, got {inbox:?}"
+    );
+}
+
+#[tokio::test]
+async fn patch_receipt_reason_too_long_returns_400() {
+    let app = test_app_with_auth().await;
+    let oversized = "a".repeat(281);
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "reject", "reason": oversized}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_rejects_reason_field() {
+    // `reason` is meaningless for confirm; surface a 400 so FE bugs that
+    // mis-route a reject body do not silently bury an admin's note.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/1",
+            serde_json::json!({"action": "confirm", "reason": "should not be here"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── inbox_item side effects (Slice 5) ─────────────────────────────────────────
+//
+// Verifies the new inbox_item table behaves end-to-end: rows materialise
+// on confirm, are scoped to the matched member, respect the SCHEMAFULL
+// kind ASSERT, are queryable via the index path, survive a soft-delete
+// of the underlying receipt, and surface a count the FE can gate on.
+
+#[tokio::test]
+async fn inbox_item_created_on_confirm() {
+    let (app, db) = test_app_with_auth_and_db().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let inbox = fetch_inbox_for_user(&db, "4").await;
+    assert_eq!(inbox.len(), 1, "exactly one inbox row should land on confirm");
+    assert_eq!(inbox[0]["kind"], "receipt_confirmed");
+}
+
+#[tokio::test]
+async fn inbox_item_scoped_to_matched_member_only() {
+    let (app, db) = test_app_with_auth_and_db().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Receipt 1's matched member is "4"; every other member must have an
+    // empty inbox. Pick member "1" (Adaeze) as the negative case.
+    let inbox_other = fetch_inbox_for_user(&db, "1").await;
+    assert!(
+        inbox_other.is_empty(),
+        "non-matched member must not receive an inbox row, got {inbox_other:?}"
+    );
+}
+
+#[tokio::test]
+async fn inbox_item_kind_enum_enforced_at_db_layer() {
+    // Insert directly via Surreal with an unsupported `kind`; the
+    // SCHEMAFULL ASSERT should reject it. Catches a future handler that
+    // forgets to validate.
+    use poolpay::api::models::{now_iso, InboxItemContent};
+    let (_app, db) = test_app_with_auth_and_db().await;
+    let now = now_iso();
+    let content = InboxItemContent {
+        user_id: "1".into(),
+        kind: "bogus_kind".into(),
+        title: "should fail".into(),
+        body: "".into(),
+        pool_id: None,
+        cycle_id: None,
+        receipt_id: None,
+        read_at: None,
+        created_at: now,
+    };
+    let result: Result<Option<poolpay::api::models::DbInboxItem>, _> =
+        db.create("inbox_item").content(content).await;
+    assert!(
+        result.is_err(),
+        "DB-side ASSERT must reject unknown inbox kinds; got Ok({:?})",
+        result.ok()
+    );
+}
+
+#[tokio::test]
+async fn inbox_item_queryable_via_user_index() {
+    // Confirms a receipt, then queries the index-backed (user_id) path
+    // and matches the row by receipt_id. Failing this would imply the
+    // schema's index never landed or the writer skipped a column.
+    let (app, db) = test_app_with_auth_and_db().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let inbox = fetch_inbox_for_user(&db, "4").await;
+    let row = inbox.first().expect("expected one row");
+    assert_eq!(row["receiptId"], "1");
+    assert_eq!(row["poolId"], "1");
+}
+
+#[tokio::test]
+async fn inbox_item_survives_receipt_soft_delete() {
+    // Inbox is the user-facing audit trail; even when the underlying
+    // receipt is soft-deleted later, the inbox row stays so the user can
+    // still see they were notified. Confirms the FK is logical, not
+    // enforced via cascade.
+    use poolpay::api::models::{now_iso, ReceiptContent};
+    let (app, db) = test_app_with_auth_and_db().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Soft-delete receipt 1 by replacing the row with deleted_at set.
+    let now = now_iso();
+    let updated = ReceiptContent {
+        whatsapp_message_id: "3EB0C123ABCD4567EF89".into(),
+        group_id: "1".into(),
+        chat_id: "2349000000001@g.us".into(),
+        sender_phone: "2348031234567".into(),
+        member_id: Some("4".into()),
+        cycle_id: Some("3".into()),
+        extracted_amount: Some(1_000_000),
+        expected_amount: Some(1_000_000),
+        amount_matches: Some(true),
+        status: "confirmed".into(),
+        ocr_text: None,
+        sender_label: None,
+        bank_label: None,
+        raw_image_url: None,
+        rejection_reason: None,
+        received_at: now.clone(),
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        deleted_at: Some(now),
+        confirmed_by: Some(TEST_SUPER_ADMIN_SUB.into()),
+        rejected_by: None,
+        deleted_by: Some(TEST_SUPER_ADMIN_SUB.into()),
+    };
+    let _: Option<poolpay::api::models::DbReceipt> = db
+        .upsert(("receipt", "1"))
+        .content(updated)
+        .await
+        .expect("soft-delete receipt");
+
+    let inbox = fetch_inbox_for_user(&db, "4").await;
+    assert_eq!(
+        inbox.len(),
+        1,
+        "inbox row must survive a soft-delete of the source receipt"
+    );
+}
+
+#[tokio::test]
+async fn inbox_count_gates_admin_landing_when_zero() {
+    // HANDOFF §5.3: if an admin has no pending receipts to review the FE
+    // lands them on /home instead of /admin/receipts. The backend
+    // contract supporting this is "GET /api/receipts?status=pending"
+    // returning an empty list when no pending rows exist. Confirms that
+    // after every pending fixture row is acted on, the queue drains.
+    let app = test_app_with_auth().await;
+
+    let before = call(app.clone(), get("/api/receipts?status=pending&limit=200")).await;
+    let pre: Vec<serde_json::Value> = json_body(before).await;
+    assert!(
+        !pre.is_empty(),
+        "fixture must seed at least one pending receipt"
+    );
+
+    for r in &pre {
+        let id = r["id"].as_str().unwrap();
+        let resp = call(
+            app.clone(),
+            patch_json_jwt(
+                &format!("/api/receipts/{id}"),
+                serde_json::json!({"action": "reject"}),
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK, "reject {id}");
+    }
+
+    let after = call(app, get("/api/receipts?status=pending&limit=200")).await;
+    let post: Vec<serde_json::Value> = json_body(after).await;
+    assert!(
+        post.is_empty(),
+        "queue must drain to zero so the admin lands on /home, got {post:?}"
+    );
+}

--- a/tests/ingestion_integration.rs
+++ b/tests/ingestion_integration.rs
@@ -54,6 +54,7 @@ fn input<'a>(
         ocr_text: "raw OCR text",
         parsed,
         received_at: now_iso(),
+        raw_image_url: None,
     }
 }
 

--- a/tests/webhook_integration.rs
+++ b/tests/webhook_integration.rs
@@ -1,0 +1,359 @@
+//! Integration tests for `POST /api/webhooks/whatsapp` (Slice 5 BE).
+//!
+//! Covers the HMAC gate (mounted on `WA_WEBHOOK_SECRET`), payload validation,
+//! and the bot-facing response shape produced by routing each
+//! `IngestionOutcome` variant. Every helper here lives in this file rather
+//! than the shared auth helpers because the webhook is signed with a
+//! distinct secret — mixing the two would let an integration test
+//! accidentally hide a secret-binding regression.
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    response::Response,
+    Router,
+};
+use http_body_util::BodyExt;
+use poolpay::{api, auth::hmac::sign_for_testing, db};
+use std::sync::{Mutex, OnceLock};
+use tower::ServiceExt;
+
+const WEBHOOK_SECRET: &str = "test-wa-webhook-secret-for-integration-only";
+
+/// Test-only chat id matching the seeded `group_link` row.
+const LINKED_CHAT_ID: &str = "2349000000001@g.us";
+
+/// Single global lock for env mutations across the whole binary.
+///
+/// `std::env::set_var` is `unsafe` and requires that no other thread
+/// reads or writes any env var concurrently. Per-test `OnceLock`s keep
+/// each helper's first-time setter to one call, but two distinct helpers
+/// firing under parallel `cargo test` would still race without this lock.
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// One-time env setup: pin `APP_ENV=test` (so the JWT verifier takes its
+/// ephemeral-key branch) and bind the webhook secret to a known value.
+/// Mirrors the pattern in `tests/auth_integration.rs`.
+fn init_env() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialised by `env_lock()` above; called once before any
+        // test reads these vars.
+        unsafe {
+            std::env::set_var("APP_ENV", "test");
+            std::env::set_var("WA_WEBHOOK_SECRET", WEBHOOK_SECRET);
+            std::env::remove_var("JWT_KEYS");
+        }
+    });
+}
+
+async fn webhook_app() -> Router {
+    init_env();
+    let conn = db::init_memory().await.expect("init test DB");
+    seed_link(&conn).await;
+    api::router(conn)
+}
+
+/// Seed a `group_link` for the fixture group so the matcher resolves
+/// `LINKED_CHAT_ID` → group `1` (and therefore can find the seeded members).
+/// Without this, every ingest path would short-circuit on `NotLinked`.
+async fn seed_link(db: &poolpay::db::DbConn) {
+    use poolpay::api::models::{GroupLinkContent, now_iso};
+    let now = now_iso();
+    let content = GroupLinkContent {
+        chat_id: LINKED_CHAT_ID.into(),
+        group_id: "1".into(),
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+    };
+    let _: Option<poolpay::api::models::DbGroupLink> =
+        db.create("group_link").content(content).await.expect("seed group_link");
+}
+
+fn now_ts() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Build a properly-signed webhook request.
+fn signed_request(body: &serde_json::Value) -> Request<Body> {
+    signed_request_with_ts(body, now_ts())
+}
+
+fn signed_request_with_ts(body: &serde_json::Value, ts: i64) -> Request<Body> {
+    let bytes = serde_json::to_vec(body).unwrap();
+    let sig = sign_for_testing(WEBHOOK_SECRET, ts, &bytes);
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/webhooks/whatsapp")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={sig}"))
+        .body(Body::from(bytes))
+        .unwrap()
+}
+
+async fn call(app: Router, req: Request<Body>) -> Response {
+    app.oneshot(req).await.unwrap()
+}
+
+async fn json_body<T: serde::de::DeserializeOwned>(resp: Response) -> T {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not valid JSON")
+}
+
+/// Helper: a payload from a phone that matches member 4 (Tunde Bakare) in
+/// the fixture group. Uses a fresh message id so each test can ingest
+/// independently.
+fn payload_matching_member(message_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "chatId": LINKED_CHAT_ID,
+        "senderPhone": "2348031234567",
+        "messageId": message_id,
+        "ocrText": "NGN 10,000.00\nFrom: Tunde Bakare",
+        "parsed": {
+            "sender": "Tunde Bakare",
+            "bank": "GTBank",
+            "amount": "10,000"
+        },
+        "receivedAt": "2026-03-10T10:00:00+00:00",
+        "rawImageUrl": "https://example.com/receipt.jpg"
+    })
+}
+
+// ── Auth gate (HMAC) ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn webhook_valid_hmac_ingests_returns_200() {
+    let app = webhook_app().await;
+    let resp = call(app, signed_request(&payload_matching_member("WAMSG-VALID-1"))).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value = json_body(resp).await;
+    assert_eq!(body["outcome"], "ingested");
+    assert!(body["receiptId"].as_str().is_some_and(|s| !s.is_empty()));
+}
+
+#[tokio::test]
+async fn webhook_missing_secret_returns_401() {
+    // Pinned scenario: the binary as a whole sets WA_WEBHOOK_SECRET on
+    // first use, so we cannot un-set it without racing every other test
+    // in this file. Instead simulate "missing secret" by signing with the
+    // wrong key — the resolver still loads the real secret, but the
+    // signature fails, which is the same 401 the caller would see for an
+    // unset secret (every failure path collapses to Unauthorized).
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-MISSING-SECRET");
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let ts = now_ts();
+    // Different secret — produces a non-matching signature.
+    let bad_sig = sign_for_testing("a-secret-the-server-does-not-have", ts, &bytes);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/webhooks/whatsapp")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={bad_sig}"))
+        .body(Body::from(bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_expired_timestamp_returns_401() {
+    // 5 minutes in the past — well outside the ±60 s replay window.
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-EXPIRED");
+    let resp = call(app, signed_request_with_ts(&body, now_ts() - 300)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_future_timestamp_returns_401() {
+    // 5 minutes in the future — outside the symmetric replay window.
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-FUTURE");
+    let resp = call(app, signed_request_with_ts(&body, now_ts() + 300)).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_bad_signature_returns_401() {
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-BAD-SIG");
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/webhooks/whatsapp")
+        .header("content-type", "application/json")
+        .header("x-timestamp", now_ts().to_string())
+        // Constant-length hex that is definitely not the real signature.
+        .header(
+            "x-signature",
+            "sha256=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        )
+        .body(Body::from(bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_oversized_body_returns_401() {
+    // Body just over the 1 MiB hard cap. `to_bytes` aborts before the
+    // signature check even runs, so the request collapses to 401. The
+    // 401 (not 413) is intentional — the cap is part of the auth gate.
+    let app = webhook_app().await;
+    let oversized = "x".repeat(1024 * 1024 + 8);
+    let body = serde_json::json!({
+        "chatId": LINKED_CHAT_ID,
+        "senderPhone": "2348031234567",
+        "messageId": "WAMSG-OVERSIZE",
+        "ocrText": oversized,
+        "receivedAt": "2026-03-10T10:00:00+00:00"
+    });
+    let ts = now_ts();
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let sig = sign_for_testing(WEBHOOK_SECRET, ts, &bytes);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/webhooks/whatsapp")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={sig}"))
+        .body(Body::from(bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn webhook_malformed_json_returns_401() {
+    // Garbage body, signed correctly. The HMAC verifies, but
+    // `serde_json::from_slice` fails — the extractor collapses that to
+    // 401 too, since exposing "valid sig but bad JSON" gives an attacker
+    // a probe oracle for valid secret guesses.
+    let app = webhook_app().await;
+    let ts = now_ts();
+    let bytes: Vec<u8> = b"{not-json".to_vec();
+    let sig = sign_for_testing(WEBHOOK_SECRET, ts, &bytes);
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/webhooks/whatsapp")
+        .header("content-type", "application/json")
+        .header("x-timestamp", ts.to_string())
+        .header("x-signature", format!("sha256={sig}"))
+        .body(Body::from(bytes))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── Matcher branches ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn webhook_unknown_chat_id_returns_not_linked() {
+    let app = webhook_app().await;
+    let body = serde_json::json!({
+        "chatId": "9999999999999@g.us",
+        "senderPhone": "2348031234567",
+        "messageId": "WAMSG-NO-LINK",
+        "ocrText": "",
+        "receivedAt": "2026-03-10T10:00:00+00:00"
+    });
+    let resp = call(app, signed_request(&body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["outcome"], "not_linked");
+}
+
+#[tokio::test]
+async fn webhook_duplicate_message_id_is_idempotent() {
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-DUP");
+
+    let first = call(app.clone(), signed_request(&body)).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let f: serde_json::Value = json_body(first).await;
+    assert_eq!(f["outcome"], "ingested");
+
+    let second = call(app, signed_request(&body)).await;
+    assert_eq!(second.status(), StatusCode::OK);
+    let s: serde_json::Value = json_body(second).await;
+    assert_eq!(s["outcome"], "duplicate");
+    assert!(s["receiptId"].is_null(), "duplicate must not echo a receipt id");
+}
+
+#[tokio::test]
+async fn webhook_sender_phone_matches_member() {
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-MATCH-MEMBER");
+    let resp = call(app, signed_request(&body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["outcome"], "ingested");
+    assert_eq!(
+        v["memberMatched"], true,
+        "member matching must surface when the phone hits a fixture member"
+    );
+}
+
+#[tokio::test]
+async fn webhook_sender_phone_no_match_still_ingests() {
+    let app = webhook_app().await;
+    let body = serde_json::json!({
+        "chatId": LINKED_CHAT_ID,
+        "senderPhone": "2340000000000",
+        "messageId": "WAMSG-NO-MATCH",
+        "ocrText": "NGN 10,000.00",
+        "parsed": {},
+        "receivedAt": "2026-03-10T10:00:00+00:00"
+    });
+    let resp = call(app, signed_request(&body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v: serde_json::Value = json_body(resp).await;
+    assert_eq!(v["outcome"], "ingested");
+    assert_eq!(
+        v["memberMatched"], false,
+        "unknown sender phone must ingest with memberMatched=false"
+    );
+}
+
+#[tokio::test]
+async fn webhook_persists_receipt_row_visible_to_admin_list() {
+    // End-to-end persistence check: a successful webhook ingest must show
+    // up in `GET /api/receipts`. Confirms the receipt row materialises
+    // through the same listing the FE admin queue consumes.
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-PERSIST");
+
+    let resp = call(app.clone(), signed_request(&body)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let webhook_resp: serde_json::Value = json_body(resp).await;
+    let receipt_id = webhook_resp["receiptId"]
+        .as_str()
+        .expect("ingested response must carry receiptId")
+        .to_string();
+
+    let list = call(
+        app,
+        Request::builder()
+            .method(Method::GET)
+            .uri("/api/receipts?limit=200")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(list.status(), StatusCode::OK);
+    let receipts: Vec<serde_json::Value> = json_body(list).await;
+    let row = receipts
+        .iter()
+        .find(|r| r["id"] == receipt_id)
+        .expect("ingested receipt must appear in /api/receipts");
+    assert_eq!(row["whatsappMessageId"], "WAMSG-PERSIST");
+    assert_eq!(row["rawImageUrl"], "https://example.com/receipt.jpg");
+}


### PR DESCRIPTION
## Summary

Adds the WhatsApp webhook ingestion path and the unified PATCH receipts endpoint. Pairs with `Sensei3k/poolpay-app` integration to main PR.

## Changes

- New `POST /api/webhooks/whatsapp` with HMAC validation via `WA_WEBHOOK_SECRET`
- New `PATCH /api/receipts/:id` body `{ action: 'confirm' | 'reject' | 'flag', reason?: string }` (legacy `POST /api/admin/receipts/:id/{confirm,reject}` stays live, deprecated for follow-up removal)
- New `inbox_item` SurrealDB table
- `ReceiptStatus::Flagged` enum extension
- `record_auth_event` audit rows on every success + reject branch
- HMAC timestamp wrap hardening + SECURITY: tag on inbox `user_id` placeholder (pre-merge security audit fixes)

## Quality gates

- 377/377 tests (347 baseline + 30 new, exactly on target)
- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all green

## Security

- Two-secret HMAC isolation (`WA_WEBHOOK_SECRET` != `NEXTAUTH_BACKEND_SECRET`)
- Fail-closed on unset / empty / whitespace env var
- Constant-time signature compare, +/- 60s replay window, 1 MiB body cap
- Opaque 401 for every failure (no oracle leakage)
- No PII in audit row `reason`; admin `reason` cap 280 chars

## Follow-ups (separate tickets after main merge)

- Add a migration runner (currently using idempotent `DEFINE ... IF NOT EXISTS`)
- Move public `GET /api/receipts` behind `AuthenticatedUser` and filter `raw_image_url` / OCR text from any unauthenticated response
- Drop legacy POST confirm/reject routes once FE caller migration confirmed
- BE-9: atomic `POST /api/admin/users/with-grants` for slice 4's create-then-grant orchestration

## Rollback

`git reset --hard pre-poolpay-redesign-api` on main, or `git revert -m 1 <merge-sha>` after merge.
