### PR TITLE
[FEAT] - WhatsApp ingestion + receipt action endpoints (slice 5 BE, reopen)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1022,8 +1022,13 @@ pub async fn reject_receipt(
 //   3. any side effects (confirm creates a Payment, then an inbox item);
 //   4. an `auth_event` audit row attributing the change to the actor.
 //
-// Failures hit `record_auth_event(..., success=false, reason=Some(tag))`
-// before the error is returned, so every rejection branch is traceable.
+// Explicit post-auth validation branches (wrong status, missing member,
+// missing cycle, duplicate payment) emit
+// `record_auth_event(..., success=false, reason=Some(tag))` before
+// returning, so those rejection branches are traceable. Pre-auth
+// failures from `GroupScopedAdmin::ensure_or_deny` and any
+// `?`-propagated DB errors return without an audit row — the auth
+// extractor and DB layers own their own observability.
 
 async fn confirm_receipt_inner(
     user: AuthenticatedUser,

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -108,9 +108,18 @@ pub async fn whatsapp_webhook(
     // `message_id` is also the duplicate-detection key — refusing an empty
     // value here keeps a malformed bot post from silently coalescing every
     // unrelated message under "" in the index.
+    //
+    // `received_at` is persisted verbatim on the receipt and later parsed
+    // as RFC 3339 by `confirm_receipt` to derive the payment date. A
+    // malformed value would let ingest succeed but then 409 every confirm
+    // attempt forever — so we reject it here, collapsed to the same 401
+    // as every other webhook validation failure (no signature/probing
+    // oracle).
     if payload.message_id.trim().is_empty()
         || payload.chat_id.trim().is_empty()
         || payload.sender_phone.trim().is_empty()
+        || payload.received_at.trim().is_empty()
+        || chrono::DateTime::parse_from_rfc3339(&payload.received_at).is_err()
     {
         return Err(AppError::Unauthorized);
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -199,8 +199,10 @@ async fn define_tables(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
 ///     the "show every receipt this phone has ever sent" admin-side history
 ///     lookups landing in the FE slice 5 modal.
 ///   - `receipt_status_received` over `(status, received_at)` powers the
-///     admin queue's "pending, newest first" default sort without a table
-///     scan as receipt volume grows.
+///     admin queue's status-filtered listing (currently
+///     `ORDER BY received_at ASC` in `get_receipts`, i.e. oldest pending
+///     first so the FIFO queue stays stable) without a table scan as
+///     receipt volume grows.
 ///
 /// The receipt table itself stays SCHEMALESS so existing fixtures and
 /// in-flight writes are unaffected — new fields land as plain optional


### PR DESCRIPTION
## Summary

Re-opens the slice 5 BE integration → main after PR #47 was merged and reverted (PR #52, revert commit d1ce0a3). Paired with the poolpay-app integration re-open. Both ship together as the v2 design redesign rollout.

## Changes

- POST /api/webhooks/whatsapp with HMAC validation via WA_WEBHOOK_SECRET
- PATCH /api/receipts/:id unified action endpoint (legacy POST routes preserved, deprecated)
- inbox_item SurrealDB table
- ReceiptStatus::Flagged enum extension
- record_auth_event audit rows on every success and reject branch
- HMAC timestamp wrap hardening, SECURITY: tag on inbox user_id placeholder

## Quality gates

- 377/377 tests (347 baseline + 30 new)
- cargo build, cargo clippy --all-targets --all-features -- -D warnings, cargo test all green

## Security

- Two-secret HMAC isolation (WA_WEBHOOK_SECRET vs NEXTAUTH_BACKEND_SECRET)
- Fail-closed on unset, empty, or whitespace env var
- Constant-time signature compare, ±60s replay window, 1 MiB body cap
- Opaque 401 for every failure mode (no oracle leakage)
- No PII in audit row reason; admin reason capped at 280 chars

## Follow-ups (filed as issues, not blocking)

- #48 Atomic create-user-with-grants endpoint to collapse FE orchestration
- #49 Replace idempotent DEFINE statements with a real migration runner
- #50 Move GET /api/receipts behind AuthenticatedUser, filter bot-supplied fields
- #51 Drop deprecated POST confirm/reject receipt routes after FE migration confirmed

## Rollback

Single git revert -m 1 of this merge commit, or git reset --hard pre-poolpay-redesign-api on main.
