### PR TITLE
[FIX] - Add unique index on receipt.whatsapp_message_id to close TOCTOU duplicate window

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -194,7 +194,14 @@ async fn define_tables(db: &Surreal<Any>) -> Result<(), surrealdb::Error> {
 ///     member name). That is a handler-side invariant; the schema stays
 ///     open-ended so legacy rows remain readable.
 ///
-/// Two new indexes:
+/// Three indexes:
+///   - `receipt_whatsapp_message_id_unique` over `(whatsapp_message_id)` is
+///     the DB-side dedup gate. The ingest pipeline reads the existing row
+///     first as a fast path, but the read-then-write window leaves a TOCTOU
+///     race under concurrent webhook delivery (Green API retries, bot
+///     replays). The UNIQUE constraint closes that window: a colliding
+///     insert fails atomically and the handler maps the violation to the
+///     same `DuplicateMessage` outcome the pre-check returns.
 ///   - `receipt_sender_received` over `(sender_phone, received_at)` powers
 ///     the "show every receipt this phone has ever sent" admin-side history
 ///     lookups landing in the FE slice 5 modal.
@@ -213,6 +220,8 @@ async fn define_receipt_extensions(db: &Surreal<Any>) -> Result<(), surrealdb::E
     db.query(
         "DEFINE FIELD IF NOT EXISTS raw_image_url ON receipt TYPE option<string>;
          DEFINE FIELD IF NOT EXISTS rejection_reason ON receipt TYPE option<string>;
+         DEFINE INDEX IF NOT EXISTS receipt_whatsapp_message_id_unique
+             ON receipt FIELDS whatsapp_message_id UNIQUE;
          DEFINE INDEX IF NOT EXISTS receipt_sender_received
              ON receipt FIELDS sender_phone, received_at;
          DEFINE INDEX IF NOT EXISTS receipt_status_received

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -9,7 +9,7 @@
 use tracing::info;
 
 use crate::api::models::{AppError, EntityId, ReceiptContent, now_iso};
-use crate::db::DbConn;
+use crate::db::{DbConn, is_unique_constraint_error};
 use crate::models::ParsedReceipt;
 use crate::parser;
 use crate::routing;
@@ -128,8 +128,26 @@ pub async fn ingest_receipt(
     };
 
     // `create` returns the inserted row(s) so we can surface the generated id.
+    //
+    // The earlier `find_receipt_by_message_id` pre-check is a fast path, not a
+    // gate: two webhook deliveries of the same message id can both observe
+    // "no row" before either insert lands. The DB-side UNIQUE index on
+    // `receipt.whatsapp_message_id` closes that TOCTOU window, so collapse the
+    // constraint violation here to the same `DuplicateMessage` outcome the
+    // pre-check returns. Callers (and the WhatsApp reply layer) then see a
+    // single, consistent dedup signal regardless of which path caught it.
     let created: Option<crate::api::models::DbReceipt> =
-        db.create("receipt").content(content).await?;
+        match db.create("receipt").content(content).await {
+            Ok(row) => row,
+            Err(e) if is_unique_constraint_error(&e.to_string()) => {
+                info!(
+                    message_id = input.message_id,
+                    "Ingestion skipped: unique-constraint violation on whatsapp_message_id (concurrent duplicate)"
+                );
+                return Ok(IngestionOutcome::DuplicateMessage);
+            }
+            Err(e) => return Err(e.into()),
+        };
     let receipt_id = created
         .map(|r| crate::api::models::record_id_to_string(r.id))
         .ok_or_else(|| AppError::Internal("Failed to persist receipt".to_string()))?;

--- a/tests/webhook_integration.rs
+++ b/tests/webhook_integration.rs
@@ -289,6 +289,86 @@ async fn webhook_duplicate_message_id_is_idempotent() {
 }
 
 #[tokio::test]
+async fn webhook_concurrent_duplicate_deliveries_persist_single_row() {
+    // TOCTOU regression guard. The sequential-duplicate test above exercises
+    // the fast-path pre-check (`find_receipt_by_message_id`); this one fires
+    // two identical webhook deliveries in parallel so both reads observe "no
+    // row" before either insert lands. Without the DB-side UNIQUE index on
+    // `receipt.whatsapp_message_id`, both inserts succeed and the admin
+    // queue ends up with two pending rows for the same message. With the
+    // index in place, exactly one insert wins, the other collapses to the
+    // `Duplicate` outcome, and both clients still see a 200.
+    let app = webhook_app().await;
+    let body = payload_matching_member("WAMSG-CONCURRENT");
+    let req1 = signed_request(&body);
+    let req2 = signed_request(&body);
+
+    let (resp1, resp2) = tokio::join!(
+        call(app.clone(), req1),
+        call(app.clone(), req2),
+    );
+
+    assert_eq!(resp1.status(), StatusCode::OK, "first request must return 200");
+    assert_eq!(resp2.status(), StatusCode::OK, "second request must return 200");
+
+    let body1: serde_json::Value = json_body(resp1).await;
+    let body2: serde_json::Value = json_body(resp2).await;
+
+    // Exactly one side ingests; the other collapses to the duplicate outcome.
+    // Ordering is non-deterministic under `join!`, so accept either pairing.
+    let outcomes = [
+        body1["outcome"].as_str().unwrap_or(""),
+        body2["outcome"].as_str().unwrap_or(""),
+    ];
+    let ingested = outcomes.iter().filter(|o| **o == "ingested").count();
+    let duplicate = outcomes.iter().filter(|o| **o == "duplicate").count();
+    assert_eq!(
+        ingested, 1,
+        "exactly one concurrent webhook delivery must ingest (outcomes={outcomes:?})"
+    );
+    assert_eq!(
+        duplicate, 1,
+        "the other concurrent delivery must collapse to duplicate (outcomes={outcomes:?})"
+    );
+
+    // The duplicate side must match the existing duplicate response shape —
+    // no echoed receipt id, mirroring `webhook_duplicate_message_id_is_idempotent`.
+    let duplicate_body = if body1["outcome"] == "duplicate" {
+        &body1
+    } else {
+        &body2
+    };
+    assert!(
+        duplicate_body["receiptId"].is_null(),
+        "concurrent duplicate response must not echo a receiptId (body={duplicate_body})"
+    );
+
+    // And exactly one row must persist for the message id — the whole point
+    // of the unique index is that the second insert never lands.
+    let list = call(
+        app,
+        Request::builder()
+            .method(Method::GET)
+            .uri("/api/receipts?limit=200")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(list.status(), StatusCode::OK);
+    let receipts: Vec<serde_json::Value> = json_body(list).await;
+    let persisted: Vec<_> = receipts
+        .iter()
+        .filter(|r| r["whatsappMessageId"] == "WAMSG-CONCURRENT")
+        .collect();
+    assert_eq!(
+        persisted.len(),
+        1,
+        "exactly one receipt row must persist for the duplicate message id (found {})",
+        persisted.len()
+    );
+}
+
+#[tokio::test]
 async fn webhook_sender_phone_matches_member() {
     let app = webhook_app().await;
     let body = payload_matching_member("WAMSG-MATCH-MEMBER");


### PR DESCRIPTION
## Summary
- Adds UNIQUE INDEX on `receipt.whatsapp_message_id`
- Wraps ingest insert to map the constraint violation to the existing `Duplicate` outcome (read-then-write race-safe)
- Concurrent-delivery integration test asserts single insert + 200 on both responses

## Test plan
- [ ] `cargo test webhook` passes
- [ ] New concurrent-duplicate test green
- [ ] Schema migration applies cleanly to a fresh DB

Closes the TOCTOU half of WEBHOOK-AUDIT.md High #1.

## Notes for review
- `cargo fmt --check` and `cargo clippy -D warnings` both flag pre-existing drift on `origin/main` (mass import-order reorganisation; `manual_pattern_char_comparison` in `src/api/webhooks.rs`). Neither is introduced here; both pre-date this branch and are out of scope for this PR.
- The ingest pre-check (`find_receipt_by_message_id`) is intentionally retained as a fast path. It saves the constraint-collision round-trip on the common, non-racing duplicate case while the UNIQUE index alone now owns the correctness guarantee under concurrent delivery.