### PR TITLE
[FIX] - Split poll-loop ack from ingest outcome with bounded retry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod extractor;
 pub mod ingestion;
 pub mod models;
 pub mod parser;
+pub mod poll_retry;
 pub mod replies;
 pub mod routing;
 pub mod whatsapp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,11 +152,12 @@ async fn main() {
     // the loop cannot be moved into tokio::spawn.
     let client = reqwest::Client::new();
 
-    // Tracks consecutive ingest failures per `receiptId` so a transient
-    // SurrealDB blip does not silently drop a user receipt: we skip
-    // `deleteNotification` while the budget allows, letting Green API
-    // redeliver, and ack-with-discard once the budget is exhausted. See
-    // `poll_retry` for the memory bounds (TTL + hard capacity).
+    // Tracks consecutive processing failures (download / OCR / ingest)
+    // per `receiptId` so a transient hiccup does not silently drop a user
+    // receipt: we skip `deleteNotification` while the budget allows,
+    // letting Green API redeliver, and ack-with-discard once the budget
+    // is exhausted. See `poll_retry` for the memory bounds (TTL + hard
+    // capacity).
     let mut retry_tracker = AttemptTracker::with_defaults();
 
     loop {
@@ -288,8 +289,9 @@ async fn main() {
 
                 // Decide whether to ack the notification. On success we ack
                 // unconditionally. On failure we consult `retry_tracker` so a
-                // transient ingest error lets Green API redeliver the message
-                // (within the retry budget) instead of silently dropping it.
+                // transient processing failure (download / OCR / ingest) lets
+                // Green API redeliver the message (within the retry budget)
+                // instead of silently dropping it.
                 let should_ack = if processing_ok {
                     retry_tracker.record_success(notification.receipt_id);
                     true

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ async fn main() {
                                 receipt_id = notification.receipt_id,
                                 attempt,
                                 max_attempts = retry_tracker.max_attempts(),
-                                "Ingest failed; skipping ack so Green API redelivers"
+                                "Processing failed (download / OCR / ingest); skipping ack so Green API redelivers"
                             );
                             false
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,7 +254,7 @@ async fn main() {
                                                                 Err(e) => error!(
                                                                     error = %e,
                                                                     chat_id = cid,
-                                                                    "Failed to send reply (non-fatal; receipt already ingested)"
+                                                                    "Failed to send reply (non-fatal; processing already completed — outcome decided, receipt persisted when applicable)"
                                                                 ),
                                                             }
                                                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,14 @@ async fn main() {
                                                         if let Some(reply) =
                                                             replies::format_reply(&outcome, &parsed)
                                                         {
+                                                            // The receipt row is already persisted at this point;
+                                                            // failing to send the WhatsApp quoted reply is a UX
+                                                            // hiccup, not an ingest failure. Treat it as non-fatal so
+                                                            // we still ack the Green API notification and do not
+                                                            // burn redelivery attempts on a row that already exists.
+                                                            // The error is logged with `error!` so it is still
+                                                            // visible to operators; a future metric counter can
+                                                            // page on the rate.
                                                             match whatsapp::send_quoted_message(
                                                                 &client,
                                                                 &instance_id,
@@ -239,10 +247,11 @@ async fn main() {
                                                             .await
                                                             {
                                                                 Ok(_) => info!(chat_id = cid, "Reply sent"),
-                                                                Err(e) => {
-                                                                    error!(error = %e, "Failed to send reply");
-                                                                    processing_ok = false;
-                                                                }
+                                                                Err(e) => error!(
+                                                                    error = %e,
+                                                                    chat_id = cid,
+                                                                    "Failed to send reply (non-fatal; receipt already ingested)"
+                                                                ),
                                                             }
                                                         }
                                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,14 +331,25 @@ async fn main() {
                             // request itself failed we want the tracker entry
                             // to survive so the next redelivery continues
                             // counting against the existing budget instead of
-                            // starting fresh at attempt 1. `record_failure`
-                            // already cleared the entry on the AckGiveUp path,
-                            // so this is a no-op there.
+                            // starting fresh at attempt 1. Both the success
+                            // path and the `AckGiveUp` path clear here:
+                            // `record_success` for happy-path processing,
+                            // `record_acked` for the terminal give-up state
+                            // (which `record_failure` deliberately leaves in
+                            // place until the ack is confirmed).
                             if processing_ok {
                                 retry_tracker.record_success(notification.receipt_id);
+                            } else {
+                                retry_tracker.record_acked(notification.receipt_id);
                             }
                         }
                         Err(e) => {
+                            // Ack failed — leave the tracker entry alone.
+                            // For the `AckGiveUp` branch this means the next
+                            // Green API redelivery keeps returning
+                            // `AckGiveUp` without restarting the budget; for
+                            // the success branch there is no tracker state
+                            // to worry about.
                             warn!(error = %e, "Failed to delete notification");
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,14 +229,16 @@ async fn main() {
                                                         if let Some(reply) =
                                                             replies::format_reply(&outcome, &parsed)
                                                         {
-                                                            // The receipt row is already persisted at this point;
-                                                            // failing to send the WhatsApp quoted reply is a UX
-                                                            // hiccup, not an ingest failure. Treat it as non-fatal so
-                                                            // we still ack the Green API notification and do not
-                                                            // burn redelivery attempts on a row that already exists.
-                                                            // The error is logged with `error!` so it is still
-                                                            // visible to operators; a future metric counter can
-                                                            // page on the rate.
+                                                            // The ingestion outcome is already decided at this point
+                                                            // (and the receipt row is persisted when applicable —
+                                                            // e.g. NotLinked still returns a reply without persisting).
+                                                            // Failing to send the WhatsApp quoted reply is a UX
+                                                            // hiccup, not a processing failure. Treat it as non-fatal
+                                                            // so we still ack the Green API notification and do not
+                                                            // burn redelivery attempts on a receipt whose outcome is
+                                                            // already settled. The error is logged with `error!` so
+                                                            // it is still visible to operators; a future metric
+                                                            // counter can page on the rate.
                                                             match whatsapp::send_quoted_message(
                                                                 &client,
                                                                 &instance_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,6 @@ async fn main() {
                 // Green API redeliver the message (within the retry budget)
                 // instead of silently dropping it.
                 let should_ack = if processing_ok {
-                    retry_tracker.record_success(notification.receipt_id);
                     true
                 } else {
                     match retry_tracker.record_failure(notification.receipt_id) {
@@ -318,7 +317,7 @@ async fn main() {
                 };
 
                 if should_ack {
-                    if let Err(e) = whatsapp::delete_notification(
+                    match whatsapp::delete_notification(
                         &client,
                         &instance_id,
                         &api_token,
@@ -326,7 +325,22 @@ async fn main() {
                     )
                     .await
                     {
-                        warn!(error = %e, "Failed to delete notification");
+                        Ok(_) => {
+                            // Only clear the retry state after Green API has
+                            // actually acked the notification. If the ack
+                            // request itself failed we want the tracker entry
+                            // to survive so the next redelivery continues
+                            // counting against the existing budget instead of
+                            // starting fresh at attempt 1. `record_failure`
+                            // already cleared the entry on the AckGiveUp path,
+                            // so this is a no-op there.
+                            if processing_ok {
+                                retry_tracker.record_success(notification.receipt_id);
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Failed to delete notification");
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use poolpay::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use poolpay::auth::rate_limit::RateLimitConfig;
+use poolpay::poll_retry::{AttemptTracker, RetryDecision};
 use poolpay::{api, auth, db, extractor, ingestion, parser, replies, whatsapp};
 use poolpay::api::models::now_iso;
 use std::sync::Arc;
@@ -148,6 +149,14 @@ async fn main() {
     // Kept in the main thread: the error type (Box<dyn Error>) is not Send, so
     // the loop cannot be moved into tokio::spawn.
     let client = reqwest::Client::new();
+
+    // Tracks consecutive ingest failures per `receiptId` so a transient
+    // SurrealDB blip does not silently drop a user receipt: we skip
+    // `deleteNotification` while the budget allows, letting Green API
+    // redeliver, and ack-with-discard once the budget is exhausted. See
+    // `poll_retry` for the memory bounds (TTL + hard capacity).
+    let mut retry_tracker = AttemptTracker::with_defaults();
+
     loop {
         match whatsapp::receive_notification(&client, &instance_id, &api_token).await {
             Ok(Some(notification)) => {
@@ -265,24 +274,46 @@ async fn main() {
                     }
                 }
 
-                // Always acknowledge the notification to prevent infinite reprocessing.
-                // If processing failed, log a clear discard notice so nothing is silent.
-                if !processing_ok {
-                    warn!(
-                        receipt_id = notification.receipt_id,
-                        "Discarding receipt after processing failure — will not retry"
-                    );
-                }
+                // Decide whether to ack the notification. On success we ack
+                // unconditionally. On failure we consult `retry_tracker` so a
+                // transient ingest error lets Green API redeliver the message
+                // (within the retry budget) instead of silently dropping it.
+                let should_ack = if processing_ok {
+                    retry_tracker.record_success(notification.receipt_id);
+                    true
+                } else {
+                    match retry_tracker.record_failure(notification.receipt_id) {
+                        RetryDecision::Skip { attempt } => {
+                            warn!(
+                                receipt_id = notification.receipt_id,
+                                attempt,
+                                max_attempts = retry_tracker.max_attempts(),
+                                "Ingest failed; skipping ack so Green API redelivers"
+                            );
+                            false
+                        }
+                        RetryDecision::AckGiveUp => {
+                            error!(
+                                receipt_id = notification.receipt_id,
+                                max_attempts = retry_tracker.max_attempts(),
+                                "Retry budget exhausted — discarding receipt and acking notification"
+                            );
+                            true
+                        }
+                    }
+                };
 
-                if let Err(e) = whatsapp::delete_notification(
-                    &client,
-                    &instance_id,
-                    &api_token,
-                    notification.receipt_id,
-                )
-                .await
-                {
-                    warn!(error = %e, "Failed to delete notification");
+                if should_ack {
+                    if let Err(e) = whatsapp::delete_notification(
+                        &client,
+                        &instance_id,
+                        &api_token,
+                        notification.receipt_id,
+                    )
+                    .await
+                    {
+                        warn!(error = %e, "Failed to delete notification");
+                    }
                 }
             }
 

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -88,12 +88,15 @@ impl AttemptTracker {
     /// to at least 2: with the give-up boundary set to `attempts ==
     /// max_attempts`, a value of 1 would discard on the first failure
     /// and revert to the old always-ack behaviour. `capacity` is clamped
-    /// to at least 1 for the same kind of guard.
+    /// to at least 1 for the same kind of guard. `ttl` is clamped to at
+    /// least 1 second: a zero `Duration` would make `evict_stale_at`
+    /// drop every entry on every interaction, silently resetting the
+    /// retry budget on each failure.
     pub fn new(max_attempts: u32, ttl: Duration, capacity: usize) -> Self {
         Self {
             inner: HashMap::new(),
             max_attempts: max_attempts.max(2),
-            ttl,
+            ttl: ttl.max(Duration::from_secs(1)),
             capacity: capacity.max(1),
         }
     }

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -1,16 +1,17 @@
 //! Bounded retry tracking for the Green API poll loop.
 //!
 //! The poll loop (see `main.rs`) used to ack every notification it pulled
-//! off the queue, even when downstream ingest had failed. That worked while
-//! ingest was effectively infallible, but a transient SurrealDB blip would
+//! off the queue, even when downstream processing (download / OCR / ingest)
+//! had failed. That worked while processing was effectively infallible, but
+//! a transient SurrealDB blip — or an OCR / download hiccup — would
 //! silently drop a user receipt: Green API removes the notification on
 //! `deleteNotification`, so there is no second chance.
 //!
 //! [`AttemptTracker`] addresses that by gating the ack on a small retry
 //! budget. The poll loop calls [`AttemptTracker::record_failure`] when a
-//! receipt fails to ingest and skips the ack while the budget allows;
-//! after the budget is exhausted the notification is acked anyway so a
-//! permanently broken receipt cannot wedge the queue.
+//! receipt fails to process (download / OCR / ingest) and skips the ack
+//! while the budget allows; after the budget is exhausted the notification
+//! is acked anyway so a permanently broken receipt cannot wedge the queue.
 //!
 //! The tracker is intentionally a plain in-process `HashMap`:
 //!
@@ -71,8 +72,9 @@ struct AttemptEntry {
     last_seen: Instant,
 }
 
-/// In-process counter of consecutive ingest failures keyed by Green API
-/// `receiptId`. See module docs for the rationale and bounds.
+/// In-process counter of consecutive processing failures (download / OCR /
+/// ingest) keyed by Green API `receiptId`. See module docs for the
+/// rationale and bounds.
 #[derive(Debug)]
 pub struct AttemptTracker {
     inner: HashMap<u64, AttemptEntry>,
@@ -107,15 +109,17 @@ impl AttemptTracker {
         self.max_attempts
     }
 
-    /// Record an ingest failure for `receipt_id` and decide whether the
-    /// caller should skip the ack or ack-and-give-up.
+    /// Record a processing failure (download / OCR / ingest) for
+    /// `receipt_id` and decide whether the caller should skip the ack or
+    /// ack-and-give-up.
     pub fn record_failure(&mut self, receipt_id: u64) -> RetryDecision {
         self.record_failure_at(receipt_id, Instant::now())
     }
 
     /// Test-friendly variant of [`record_failure`] that takes the current
-    /// instant explicitly. Crate-visible only; production callers should
-    /// use [`record_failure`].
+    /// instant explicitly. Records a processing failure (download / OCR /
+    /// ingest). Crate-visible only; production callers should use
+    /// [`record_failure`].
     pub(crate) fn record_failure_at(&mut self, receipt_id: u64, now: Instant) -> RetryDecision {
         self.evict_stale_at(now);
 
@@ -148,8 +152,9 @@ impl AttemptTracker {
     }
 
     /// Clear any retry state for `receipt_id`. Called by the poll loop
-    /// after a successful ingest so a future failure for the same id
-    /// starts from attempt 1 rather than inheriting a stale counter.
+    /// after successful processing (download / OCR / ingest) so a future
+    /// failure for the same id starts from attempt 1 rather than
+    /// inheriting a stale counter.
     pub fn record_success(&mut self, receipt_id: u64) {
         self.inner.remove(&receipt_id);
     }

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -1,0 +1,185 @@
+//! Bounded retry tracking for the Green API poll loop.
+//!
+//! The poll loop (see `main.rs`) used to ack every notification it pulled
+//! off the queue, even when downstream ingest had failed. That worked while
+//! ingest was effectively infallible, but a transient SurrealDB blip would
+//! silently drop a user receipt: Green API removes the notification on
+//! `deleteNotification`, so there is no second chance.
+//!
+//! [`AttemptTracker`] addresses that by gating the ack on a small retry
+//! budget. The poll loop calls [`AttemptTracker::record_failure`] when a
+//! receipt fails to ingest and skips the ack while the budget allows;
+//! after the budget is exhausted the notification is acked anyway so a
+//! permanently broken receipt cannot wedge the queue.
+//!
+//! The tracker is intentionally a plain in-process `HashMap`:
+//!
+//! * Memory is bounded by both a time-to-live (stale entries are evicted
+//!   on every interaction) and a hard capacity (oldest-first eviction
+//!   when the cap is hit). Either bound alone would be enough in practice;
+//!   both together make the worst-case footprint obvious.
+//! * The poll loop is single-threaded (the surrounding error type is
+//!   `!Send`), so `&mut self` access is sufficient. No locking required.
+//! * No persistence: a process restart resets the retry budget. That is
+//!   intentional — Green API will redeliver any un-acked notification on
+//!   its own schedule, so we lose at most one in-flight attempt count.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Maximum number of times a single receipt may be redelivered before the
+/// poll loop gives up and acks the notification anyway. The first attempt
+/// counts towards this budget, so a value of 3 yields up to two
+/// redeliveries before we discard the receipt.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+
+/// How long a tracker entry may live before it is considered stale and
+/// evicted. Sized to comfortably outlast Green API's own redelivery
+/// interval (a few minutes) while still bounding memory if the queue
+/// stops draining.
+pub const DEFAULT_TTL: Duration = Duration::from_secs(600);
+
+/// Hard cap on the number of tracked receipts. When the cap is hit we
+/// evict the oldest entry to make room for the new one; the eviction
+/// resets that receipt's budget on its next failure, which is acceptable
+/// because hitting this cap already implies a systemic backlog.
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+/// Decision returned by [`AttemptTracker::record_failure`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecision {
+    /// Failure is within the retry budget. Caller must NOT delete the
+    /// notification from Green API so it is redelivered. `attempt` is the
+    /// 1-based attempt number that just failed (1..=`max_attempts`).
+    Skip { attempt: u32 },
+    /// Retry budget is exhausted. Caller should ack (delete) the
+    /// notification, drop the receipt, and emit a discard log so the
+    /// failure is not silent. The tracker has already cleared the entry.
+    AckGiveUp,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AttemptEntry {
+    attempts: u32,
+    first_seen: Instant,
+}
+
+/// In-process counter of consecutive ingest failures keyed by Green API
+/// `receiptId`. See module docs for the rationale and bounds.
+#[derive(Debug)]
+pub struct AttemptTracker {
+    inner: HashMap<u64, AttemptEntry>,
+    max_attempts: u32,
+    ttl: Duration,
+    capacity: usize,
+}
+
+impl AttemptTracker {
+    /// Construct a tracker with explicit bounds. `max_attempts` is clamped
+    /// to at least 1 (a tracker that gives up on the first attempt would
+    /// be no better than the old always-ack behaviour); `capacity` is
+    /// clamped to at least 1 for the same reason.
+    pub fn new(max_attempts: u32, ttl: Duration, capacity: usize) -> Self {
+        Self {
+            inner: HashMap::new(),
+            max_attempts: max_attempts.max(1),
+            ttl,
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Convenience constructor using the module-level defaults.
+    pub fn with_defaults() -> Self {
+        Self::new(DEFAULT_MAX_ATTEMPTS, DEFAULT_TTL, DEFAULT_CAPACITY)
+    }
+
+    /// Returns the configured retry budget. Useful in log lines so the
+    /// operator can see how close we are to giving up on a receipt.
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Record an ingest failure for `receipt_id` and decide whether the
+    /// caller should skip the ack or ack-and-give-up.
+    pub fn record_failure(&mut self, receipt_id: u64) -> RetryDecision {
+        self.record_failure_at(receipt_id, Instant::now())
+    }
+
+    /// Test-friendly variant of [`record_failure`] that takes the current
+    /// instant explicitly. Crate-visible only; production callers should
+    /// use [`record_failure`].
+    pub(crate) fn record_failure_at(
+        &mut self,
+        receipt_id: u64,
+        now: Instant,
+    ) -> RetryDecision {
+        self.evict_stale_at(now);
+
+        // If we are about to insert a brand-new entry and the map is full,
+        // make room by dropping the oldest. Doing this BEFORE the entry()
+        // call keeps the hot path branch-free for the common case
+        // (receipt already tracked).
+        if !self.inner.contains_key(&receipt_id) && self.inner.len() >= self.capacity {
+            self.evict_oldest();
+        }
+
+        let entry = self.inner.entry(receipt_id).or_insert(AttemptEntry {
+            attempts: 0,
+            first_seen: now,
+        });
+        entry.attempts += 1;
+
+        if entry.attempts <= self.max_attempts {
+            RetryDecision::Skip {
+                attempt: entry.attempts,
+            }
+        } else {
+            // Budget exhausted — drop the entry so a future receipt with
+            // the same id (e.g. after a process restart aligning to a
+            // Green API redelivery) starts fresh.
+            self.inner.remove(&receipt_id);
+            RetryDecision::AckGiveUp
+        }
+    }
+
+    /// Clear any retry state for `receipt_id`. Called by the poll loop
+    /// after a successful ingest so a future failure for the same id
+    /// starts from attempt 1 rather than inheriting a stale counter.
+    pub fn record_success(&mut self, receipt_id: u64) {
+        self.inner.remove(&receipt_id);
+    }
+
+    /// Number of receipts currently being tracked. Exposed primarily for
+    /// tests and operator-visible metrics.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// True when no receipts are being tracked.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    fn evict_stale_at(&mut self, now: Instant) {
+        let ttl = self.ttl;
+        self.inner
+            .retain(|_, entry| now.duration_since(entry.first_seen) < ttl);
+    }
+
+    fn evict_oldest(&mut self) {
+        if let Some(oldest) = self
+            .inner
+            .iter()
+            .min_by_key(|(_, entry)| entry.first_seen)
+            .map(|(id, _)| *id)
+        {
+            self.inner.remove(&oldest);
+        }
+    }
+}
+
+impl Default for AttemptTracker {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -14,10 +14,11 @@
 //!
 //! The tracker is intentionally a plain in-process `HashMap`:
 //!
-//! * Memory is bounded by both a time-to-live (stale entries are evicted
-//!   on every interaction) and a hard capacity (oldest-first eviction
-//!   when the cap is hit). Either bound alone would be enough in practice;
-//!   both together make the worst-case footprint obvious.
+//! * Memory is bounded by both an inactivity TTL (entries whose most
+//!   recent failure is older than `ttl` are evicted on every interaction)
+//!   and a hard capacity (least-recently-failed eviction when the cap is
+//!   hit). Either bound alone would be enough in practice; both together
+//!   make the worst-case footprint obvious.
 //! * The poll loop is single-threaded (the surrounding error type is
 //!   `!Send`), so `&mut self` access is sufficient. No locking required.
 //! * No persistence: a process restart resets the retry budget. That is
@@ -40,9 +41,10 @@ pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 pub const DEFAULT_TTL: Duration = Duration::from_secs(600);
 
 /// Hard cap on the number of tracked receipts. When the cap is hit we
-/// evict the oldest entry to make room for the new one; the eviction
-/// resets that receipt's budget on its next failure, which is acceptable
-/// because hitting this cap already implies a systemic backlog.
+/// evict the least-recently-failed entry to make room for the new one;
+/// the eviction resets that receipt's budget on its next failure, which
+/// is acceptable because hitting this cap already implies a systemic
+/// backlog.
 pub const DEFAULT_CAPACITY: usize = 1024;
 
 /// Decision returned by [`AttemptTracker::record_failure`].
@@ -61,7 +63,12 @@ pub enum RetryDecision {
 #[derive(Debug, Clone, Copy)]
 struct AttemptEntry {
     attempts: u32,
-    first_seen: Instant,
+    // Updated on every `record_failure_at` so the TTL behaves as an
+    // inactivity window rather than an absolute lifetime: a receipt that
+    // keeps failing within `ttl` of its previous failure stays tracked,
+    // and capacity eviction drops the entry that has been quiet the
+    // longest.
+    last_seen: Instant,
 }
 
 /// In-process counter of consecutive ingest failures keyed by Green API
@@ -122,9 +129,10 @@ impl AttemptTracker {
 
         let entry = self.inner.entry(receipt_id).or_insert(AttemptEntry {
             attempts: 0,
-            first_seen: now,
+            last_seen: now,
         });
         entry.attempts += 1;
+        entry.last_seen = now;
 
         if entry.attempts < self.max_attempts {
             RetryDecision::Skip {
@@ -160,14 +168,14 @@ impl AttemptTracker {
     fn evict_stale_at(&mut self, now: Instant) {
         let ttl = self.ttl;
         self.inner
-            .retain(|_, entry| now.duration_since(entry.first_seen) < ttl);
+            .retain(|_, entry| now.duration_since(entry.last_seen) < ttl);
     }
 
     fn evict_oldest(&mut self) {
         if let Some(oldest) = self
             .inner
             .iter()
-            .min_by_key(|(_, entry)| entry.first_seen)
+            .min_by_key(|(_, entry)| entry.last_seen)
             .map(|(id, _)| *id)
         {
             self.inner.remove(&oldest);
@@ -283,18 +291,90 @@ mod tests {
             tracker.record_failure_at(11, t0),
             RetryDecision::Skip { attempt: 1 }
         );
+        let t1 = t0 + Duration::from_secs(30);
         assert_eq!(
-            tracker.record_failure_at(11, t0 + Duration::from_secs(30)),
+            tracker.record_failure_at(11, t1),
             RetryDecision::Skip { attempt: 2 },
             "still within TTL — counter persists"
         );
-        // Push past the TTL boundary: the prior entry must be evicted before
-        // the new failure is recorded, so the attempt counter resets to 1.
-        let after_ttl = t0 + ttl + Duration::from_secs(1);
+        // Push the next failure past `ttl` from the MOST RECENT failure
+        // (t1), not from t0: with inactivity-window semantics every failure
+        // refreshes the TTL, so the gap that matters is `now - last_seen`.
+        let after_ttl = t1 + ttl + Duration::from_secs(1);
         assert_eq!(
             tracker.record_failure_at(11, after_ttl),
             RetryDecision::Skip { attempt: 1 },
-            "TTL elapsed — entry must be evicted and the counter must reset"
+            "inactivity exceeded TTL — entry must be evicted and the counter must reset"
+        );
+    }
+
+    #[test]
+    fn ttl_is_an_inactivity_window_not_an_absolute_lifetime() {
+        // A receipt that keeps failing within `ttl` of its previous failure
+        // must remain tracked even when total elapsed time exceeds `ttl`.
+        // Without this, hot entries silently reset mid-budget and the
+        // skip-then-ack contract degrades to skip-forever for any receipt
+        // whose redelivery cadence happens to align with the TTL.
+        let ttl = Duration::from_secs(60);
+        let mut tracker = AttemptTracker::new(5, ttl, 16);
+        let step = ttl / 2;
+        let mut now = Instant::now();
+
+        // First failure starts the counter.
+        assert_eq!(
+            tracker.record_failure_at(21, now),
+            RetryDecision::Skip { attempt: 1 }
+        );
+
+        // Three more failures, each a half-ttl after the previous one.
+        // Total elapsed: 1.5 * ttl — well past the absolute-lifetime
+        // boundary that the old `first_seen`-based TTL would have used.
+        for expected_attempt in 2..=4 {
+            now += step;
+            assert_eq!(
+                tracker.record_failure_at(21, now),
+                RetryDecision::Skip {
+                    attempt: expected_attempt
+                },
+                "failure at +{:?} must keep the entry alive",
+                step * (expected_attempt - 1),
+            );
+        }
+    }
+
+    #[test]
+    fn capacity_eviction_drops_least_recently_failed_not_first_inserted() {
+        // With inactivity-window semantics the eviction key is `last_seen`,
+        // so refreshing an older entry promotes it past a younger but
+        // untouched one. Guard against a regression to `first_seen`-based
+        // eviction that would drop the hot entry.
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(3600), 2);
+        let t0 = Instant::now();
+
+        // Receipt 100 inserted first, then 200.
+        tracker.record_failure_at(100, t0);
+        tracker.record_failure_at(200, t0 + Duration::from_millis(1));
+        assert_eq!(tracker.len(), 2);
+
+        // Refresh 100 — its last_seen now exceeds 200's. 100's counter is
+        // now at 2 under max_attempts=3.
+        tracker.record_failure_at(100, t0 + Duration::from_millis(10));
+
+        // Inserting 300 must evict the entry with the smallest last_seen,
+        // which is now 200 (t0+1ms), not 100 (t0+10ms).
+        tracker.record_failure_at(300, t0 + Duration::from_millis(20));
+        assert_eq!(tracker.len(), 2);
+
+        // Strong signal that 100 survived the eviction: its counter
+        // persisted across the capacity-induced eviction of 200, so the
+        // next failure exhausts the budget (attempt 3 of max 3).
+        //
+        // We check 100 BEFORE re-inserting 200 because re-inserting at
+        // capacity would itself trigger another eviction and confuse the
+        // signal.
+        assert_eq!(
+            tracker.record_failure_at(100, t0 + Duration::from_millis(30)),
+            RetryDecision::AckGiveUp,
         );
     }
 

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -183,3 +183,156 @@ impl Default for AttemptTracker {
         Self::with_defaults()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper that asserts the (n-1)th failure for `receipt_id` returns
+    /// `Skip { attempt }` and the boundary failure returns `AckGiveUp`.
+    /// Centralises the canonical retry-progression assertion used by
+    /// several tests below.
+    fn assert_skip_then_give_up(tracker: &mut AttemptTracker, receipt_id: u64) {
+        let max = tracker.max_attempts();
+        for attempt in 1..=max {
+            assert_eq!(
+                tracker.record_failure(receipt_id),
+                RetryDecision::Skip { attempt },
+                "attempt {attempt} should be Skip",
+            );
+        }
+        assert_eq!(
+            tracker.record_failure(receipt_id),
+            RetryDecision::AckGiveUp,
+            "attempt {} should be AckGiveUp",
+            max + 1,
+        );
+    }
+
+    #[test]
+    fn skip_three_times_then_give_up_on_attempt_four() {
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
+        assert_skip_then_give_up(&mut tracker, 42);
+    }
+
+    #[test]
+    fn give_up_clears_entry_so_subsequent_failures_start_fresh() {
+        let mut tracker = AttemptTracker::new(2, Duration::from_secs(60), 16);
+        // Burn through the budget.
+        assert_eq!(
+            tracker.record_failure(7),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(
+            tracker.record_failure(7),
+            RetryDecision::Skip { attempt: 2 }
+        );
+        assert_eq!(tracker.record_failure(7), RetryDecision::AckGiveUp);
+        // After give-up the entry is gone, so a new failure starts at attempt 1.
+        assert_eq!(
+            tracker.record_failure(7),
+            RetryDecision::Skip { attempt: 1 }
+        );
+    }
+
+    #[test]
+    fn record_success_resets_attempt_count() {
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
+        assert_eq!(
+            tracker.record_failure(99),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(
+            tracker.record_failure(99),
+            RetryDecision::Skip { attempt: 2 }
+        );
+        tracker.record_success(99);
+        assert!(tracker.is_empty(), "success must clear the entry");
+        assert_eq!(
+            tracker.record_failure(99),
+            RetryDecision::Skip { attempt: 1 }
+        );
+    }
+
+    #[test]
+    fn distinct_receipts_track_independently() {
+        let mut tracker = AttemptTracker::new(2, Duration::from_secs(60), 16);
+        assert_eq!(
+            tracker.record_failure(1),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(
+            tracker.record_failure(2),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(
+            tracker.record_failure(1),
+            RetryDecision::Skip { attempt: 2 }
+        );
+        assert_eq!(tracker.record_failure(1), RetryDecision::AckGiveUp);
+        // Receipt 2 is unaffected by receipt 1's give-up.
+        assert_eq!(
+            tracker.record_failure(2),
+            RetryDecision::Skip { attempt: 2 }
+        );
+    }
+
+    #[test]
+    fn ttl_eviction_resets_an_entry_that_outlived_its_window() {
+        let ttl = Duration::from_secs(60);
+        let mut tracker = AttemptTracker::new(3, ttl, 16);
+        let t0 = Instant::now();
+
+        assert_eq!(
+            tracker.record_failure_at(11, t0),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(
+            tracker.record_failure_at(11, t0 + Duration::from_secs(30)),
+            RetryDecision::Skip { attempt: 2 },
+            "still within TTL — counter persists"
+        );
+        // Push past the TTL boundary: the prior entry must be evicted before
+        // the new failure is recorded, so the attempt counter resets to 1.
+        let after_ttl = t0 + ttl + Duration::from_secs(1);
+        assert_eq!(
+            tracker.record_failure_at(11, after_ttl),
+            RetryDecision::Skip { attempt: 1 },
+            "TTL elapsed — entry must be evicted and the counter must reset"
+        );
+    }
+
+    #[test]
+    fn capacity_eviction_drops_the_oldest_entry_when_full() {
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(3600), 2);
+        let t0 = Instant::now();
+
+        // Fill to capacity with two distinct receipts.
+        tracker.record_failure_at(100, t0);
+        tracker.record_failure_at(200, t0 + Duration::from_millis(1));
+        assert_eq!(tracker.len(), 2);
+
+        // Inserting a third receipt must evict the oldest (100).
+        tracker.record_failure_at(300, t0 + Duration::from_millis(2));
+        assert_eq!(tracker.len(), 2);
+
+        // Receipt 100 was evicted, so its next failure starts at attempt 1.
+        assert_eq!(
+            tracker.record_failure_at(100, t0 + Duration::from_millis(3)),
+            RetryDecision::Skip { attempt: 1 }
+        );
+    }
+
+    #[test]
+    fn new_clamps_zero_max_attempts_to_one() {
+        // A tracker that gives up on the first attempt would be no better
+        // than the old always-ack behaviour. The constructor must clamp.
+        let mut tracker = AttemptTracker::new(0, Duration::from_secs(60), 16);
+        assert_eq!(tracker.max_attempts(), 1);
+        assert_eq!(
+            tracker.record_failure(1),
+            RetryDecision::Skip { attempt: 1 }
+        );
+        assert_eq!(tracker.record_failure(1), RetryDecision::AckGiveUp);
+    }
+}

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -57,7 +57,12 @@ pub enum RetryDecision {
     Skip { attempt: u32 },
     /// Retry budget is exhausted. Caller should ack (delete) the
     /// notification, drop the receipt, and emit a discard log so the
-    /// failure is not silent. The tracker has already cleared the entry.
+    /// failure is not silent. The tracker keeps the entry in place until
+    /// the caller confirms the ack via [`AttemptTracker::record_acked`];
+    /// repeat `record_failure` calls on the same id continue to return
+    /// `AckGiveUp` without restarting the budget, so a Green API
+    /// redelivery caused by a failed ack does not silently reset the
+    /// retry counter.
     AckGiveUp,
 }
 
@@ -123,6 +128,15 @@ impl AttemptTracker {
     /// instant explicitly. Records a processing failure (download / OCR /
     /// ingest). Crate-visible only; production callers should use
     /// [`record_failure`].
+    ///
+    /// Once a receipt's attempt count reaches `max_attempts` this returns
+    /// [`RetryDecision::AckGiveUp`] and **leaves the entry in place**.
+    /// Subsequent `record_failure` calls for the same id keep returning
+    /// `AckGiveUp` without incrementing the counter or restarting the
+    /// budget. The entry is only cleared when the caller confirms the
+    /// downstream ack via [`AttemptTracker::record_acked`]; this prevents
+    /// a failed `deleteNotification` (which triggers a Green API
+    /// redelivery) from silently resetting the retry budget to attempt 1.
     pub(crate) fn record_failure_at(&mut self, receipt_id: u64, now: Instant) -> RetryDecision {
         self.evict_stale_at(now);
 
@@ -138,20 +152,37 @@ impl AttemptTracker {
             attempts: 0,
             last_seen: now,
         });
-        entry.attempts += 1;
         entry.last_seen = now;
+
+        // Once we have hit the give-up boundary, stop bumping the counter
+        // and just keep reporting `AckGiveUp`. The entry survives until
+        // the caller calls `record_acked` after a successful ack; until
+        // then any Green API redelivery (caused by a previous ack failure)
+        // produces the same terminal decision instead of restarting the
+        // budget at attempt 1.
+        if entry.attempts >= self.max_attempts {
+            return RetryDecision::AckGiveUp;
+        }
+
+        entry.attempts += 1;
 
         if entry.attempts < self.max_attempts {
             RetryDecision::Skip {
                 attempt: entry.attempts,
             }
         } else {
-            // Budget exhausted — drop the entry so a future receipt with
-            // the same id (e.g. after a process restart aligning to a
-            // Green API redelivery) starts fresh.
-            self.inner.remove(&receipt_id);
             RetryDecision::AckGiveUp
         }
+    }
+
+    /// Clear retry state for `receipt_id` after the caller has confirmed
+    /// that Green API actually acked the notification (i.e.
+    /// `deleteNotification` returned `Ok`). This is the terminal cleanup
+    /// for the `AckGiveUp` branch: until it is called the tracker keeps
+    /// the entry pinned at `max_attempts` so an ack failure followed by a
+    /// Green API redelivery does not restart the retry budget.
+    pub(crate) fn record_acked(&mut self, receipt_id: u64) {
+        self.inner.remove(&receipt_id);
     }
 
     /// Clear any retry state for `receipt_id`. Called by the poll loop
@@ -232,10 +263,15 @@ mod tests {
     fn skip_twice_then_give_up_on_attempt_three() {
         let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
         assert_skip_then_give_up(&mut tracker, 42);
+        // The entry survives `AckGiveUp` until `record_acked` is called,
+        // so a subsequent failure (e.g. Green API redelivering because the
+        // ack itself failed) keeps returning `AckGiveUp` without resetting
+        // the budget.
+        assert_eq!(tracker.record_failure(42), RetryDecision::AckGiveUp);
     }
 
     #[test]
-    fn give_up_clears_entry_so_subsequent_failures_start_fresh() {
+    fn give_up_persists_until_record_acked_then_starts_fresh() {
         let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
         // Burn through the budget.
         assert_eq!(
@@ -247,7 +283,15 @@ mod tests {
             RetryDecision::Skip { attempt: 2 }
         );
         assert_eq!(tracker.record_failure(7), RetryDecision::AckGiveUp);
-        // After give-up the entry is gone, so a new failure starts at attempt 1.
+        // Repeat failures (e.g. a Green API redelivery after a failed
+        // `deleteNotification`) must keep returning `AckGiveUp` with the
+        // entry still in place — the budget is NOT restarted.
+        assert_eq!(tracker.record_failure(7), RetryDecision::AckGiveUp);
+        assert_eq!(tracker.len(), 1, "entry survives until record_acked");
+        // Confirming the ack clears the terminal state.
+        tracker.record_acked(7);
+        assert!(tracker.is_empty(), "record_acked must clear the entry");
+        // A fresh failure for the same id now starts at attempt 1.
         assert_eq!(
             tracker.record_failure(7),
             RetryDecision::Skip { attempt: 1 }

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -109,11 +109,7 @@ impl AttemptTracker {
     /// Test-friendly variant of [`record_failure`] that takes the current
     /// instant explicitly. Crate-visible only; production callers should
     /// use [`record_failure`].
-    pub(crate) fn record_failure_at(
-        &mut self,
-        receipt_id: u64,
-        now: Instant,
-    ) -> RetryDecision {
+    pub(crate) fn record_failure_at(&mut self, receipt_id: u64, now: Instant) -> RetryDecision {
         self.evict_stale_at(now);
 
         // If we are about to insert a brand-new entry and the map is full,

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -53,7 +53,9 @@ pub const DEFAULT_CAPACITY: usize = 1024;
 pub enum RetryDecision {
     /// Failure is within the retry budget. Caller must NOT delete the
     /// notification from Green API so it is redelivered. `attempt` is the
-    /// 1-based attempt number that just failed (1..=`max_attempts`).
+    /// 1-based attempt number that just failed and is always strictly less
+    /// than `max_attempts` (i.e. `1..max_attempts`); the `max_attempts`-th
+    /// failure returns [`RetryDecision::AckGiveUp`] instead.
     Skip { attempt: u32 },
     /// Retry budget is exhausted. Caller should ack (delete) the
     /// notification, drop the receipt, and emit a discard log so the
@@ -182,6 +184,7 @@ impl AttemptTracker {
     /// the entry pinned at `max_attempts` so an ack failure followed by a
     /// Green API redelivery does not restart the retry budget.
     pub fn record_acked(&mut self, receipt_id: u64) {
+        self.evict_stale_at(Instant::now());
         self.inner.remove(&receipt_id);
     }
 

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -76,13 +76,14 @@ pub struct AttemptTracker {
 
 impl AttemptTracker {
     /// Construct a tracker with explicit bounds. `max_attempts` is clamped
-    /// to at least 1 (a tracker that gives up on the first attempt would
-    /// be no better than the old always-ack behaviour); `capacity` is
-    /// clamped to at least 1 for the same reason.
+    /// to at least 2: with the give-up boundary set to `attempts ==
+    /// max_attempts`, a value of 1 would discard on the first failure
+    /// and revert to the old always-ack behaviour. `capacity` is clamped
+    /// to at least 1 for the same kind of guard.
     pub fn new(max_attempts: u32, ttl: Duration, capacity: usize) -> Self {
         Self {
             inner: HashMap::new(),
-            max_attempts: max_attempts.max(1),
+            max_attempts: max_attempts.max(2),
             ttl,
             capacity: capacity.max(1),
         }
@@ -129,7 +130,7 @@ impl AttemptTracker {
         });
         entry.attempts += 1;
 
-        if entry.attempts <= self.max_attempts {
+        if entry.attempts < self.max_attempts {
             RetryDecision::Skip {
                 attempt: entry.attempts,
             }
@@ -188,13 +189,13 @@ impl Default for AttemptTracker {
 mod tests {
     use super::*;
 
-    /// Helper that asserts the (n-1)th failure for `receipt_id` returns
-    /// `Skip { attempt }` and the boundary failure returns `AckGiveUp`.
-    /// Centralises the canonical retry-progression assertion used by
-    /// several tests below.
+    /// Helper that asserts the first `max - 1` failures for `receipt_id`
+    /// return `Skip { attempt }` and the `max`th failure returns
+    /// `AckGiveUp`. Centralises the canonical retry-progression
+    /// assertion used by several tests below.
     fn assert_skip_then_give_up(tracker: &mut AttemptTracker, receipt_id: u64) {
         let max = tracker.max_attempts();
-        for attempt in 1..=max {
+        for attempt in 1..max {
             assert_eq!(
                 tracker.record_failure(receipt_id),
                 RetryDecision::Skip { attempt },
@@ -204,20 +205,19 @@ mod tests {
         assert_eq!(
             tracker.record_failure(receipt_id),
             RetryDecision::AckGiveUp,
-            "attempt {} should be AckGiveUp",
-            max + 1,
+            "attempt {max} should be AckGiveUp",
         );
     }
 
     #[test]
-    fn skip_three_times_then_give_up_on_attempt_four() {
+    fn skip_twice_then_give_up_on_attempt_three() {
         let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
         assert_skip_then_give_up(&mut tracker, 42);
     }
 
     #[test]
     fn give_up_clears_entry_so_subsequent_failures_start_fresh() {
-        let mut tracker = AttemptTracker::new(2, Duration::from_secs(60), 16);
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
         // Burn through the budget.
         assert_eq!(
             tracker.record_failure(7),
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn distinct_receipts_track_independently() {
-        let mut tracker = AttemptTracker::new(2, Duration::from_secs(60), 16);
+        let mut tracker = AttemptTracker::new(3, Duration::from_secs(60), 16);
         assert_eq!(
             tracker.record_failure(1),
             RetryDecision::Skip { attempt: 1 }
@@ -324,11 +324,13 @@ mod tests {
     }
 
     #[test]
-    fn new_clamps_zero_max_attempts_to_one() {
+    fn new_clamps_zero_max_attempts_to_two() {
         // A tracker that gives up on the first attempt would be no better
-        // than the old always-ack behaviour. The constructor must clamp.
+        // than the old always-ack behaviour. With the give-up boundary
+        // at `attempts == max_attempts`, the smallest useful value is 2:
+        // one redelivery, then ack.
         let mut tracker = AttemptTracker::new(0, Duration::from_secs(60), 16);
-        assert_eq!(tracker.max_attempts(), 1);
+        assert_eq!(tracker.max_attempts(), 2);
         assert_eq!(
             tracker.record_failure(1),
             RetryDecision::Skip { attempt: 1 }

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -181,7 +181,7 @@ impl AttemptTracker {
     /// for the `AckGiveUp` branch: until it is called the tracker keeps
     /// the entry pinned at `max_attempts` so an ack failure followed by a
     /// Green API redelivery does not restart the retry budget.
-    pub(crate) fn record_acked(&mut self, receipt_id: u64) {
+    pub fn record_acked(&mut self, receipt_id: u64) {
         self.inner.remove(&receipt_id);
     }
 

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -156,6 +156,7 @@ impl AttemptTracker {
     /// failure for the same id starts from attempt 1 rather than
     /// inheriting a stale counter.
     pub fn record_success(&mut self, receipt_id: u64) {
+        self.evict_stale_at(Instant::now());
         self.inner.remove(&receipt_id);
     }
 

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -176,8 +176,14 @@ impl AttemptTracker {
 
     fn evict_stale_at(&mut self, now: Instant) {
         let ttl = self.ttl;
+        // `saturating_duration_since` rather than `duration_since`: if `now`
+        // is earlier than `entry.last_seen` — e.g. an out-of-order test
+        // instant or a monotonic clock that briefly went backwards on
+        // resume from sleep — `duration_since` would panic. Saturating to
+        // zero elapsed keeps the entry alive, which matches the intent of
+        // the inactivity window.
         self.inner
-            .retain(|_, entry| now.duration_since(entry.last_seen) < ttl);
+            .retain(|_, entry| now.saturating_duration_since(entry.last_seen) < ttl);
     }
 
     fn evict_oldest(&mut self) {

--- a/src/poll_retry.rs
+++ b/src/poll_retry.rs
@@ -16,7 +16,7 @@
 //! The tracker is intentionally a plain in-process `HashMap`:
 //!
 //! * Memory is bounded by both an inactivity TTL (entries whose most
-//!   recent failure is older than `ttl` are evicted on every interaction)
+//!   recent failure is at least `ttl` old are evicted on every interaction)
 //!   and a hard capacity (least-recently-failed eviction when the cap is
 //!   hit). Either bound alone would be enough in practice; both together
 //!   make the worst-case footprint obvious.
@@ -29,10 +29,10 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-/// Maximum number of times a single receipt may be redelivered before the
-/// poll loop gives up and acks the notification anyway. The first attempt
-/// counts towards this budget, so a value of 3 yields up to two
-/// redeliveries before we discard the receipt.
+/// Maximum number of processing attempts (including the first delivery)
+/// before the poll loop gives up and acks the notification anyway. A value
+/// of 3 therefore yields two redeliveries and discards the receipt on the
+/// 3rd failure.
 pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 
 /// How long a tracker entry may live before it is considered stale and
@@ -208,6 +208,10 @@ impl AttemptTracker {
         self.inner.is_empty()
     }
 
+    /// Drop entries whose inactivity has reached the TTL boundary. The
+    /// `retain` predicate keeps entries while `elapsed < ttl`, so any entry
+    /// with `elapsed >= ttl` (including exactly `ttl`) is treated as stale
+    /// and evicted.
     fn evict_stale_at(&mut self, now: Instant) {
         let ttl = self.ttl;
         // `saturating_duration_since` rather than `duration_since`: if `now`


### PR DESCRIPTION
## Summary
- Extracts a bounded retry tracker keyed on Green API `receiptId` (max attempts + TTL + capacity cap) into a new `src/poll_retry.rs` module.
- On transient ingest failure, skips `delete_notification` so Green API redelivers, within the retry budget. Acks (and gives up) only on success or exhausted attempts.
- Decouples `send_quoted_message` failure from the ingest outcome: the row stays persisted, the ack still fires, and the reply failure is logged separately.
- Unit coverage on the new tracker (Skip 1..max then AckGiveUp, success clears state, TTL eviction, capacity eviction, distinct receipts independent, zero-attempts clamp).

## Test plan
- [ ] `cargo test poll_retry` passes
- [ ] `cargo test webhook` and main-binary tests pass
- [ ] Manual: simulated DB error during ingest does NOT call `delete_notification` until the retry budget is exhausted
- [ ] Manual: ack-send failure after a successful ingest still acks the notification to Green API and logs the reply failure

## Findings closed
Closes the still-open High #2 (poll loop discards on transient failure) and the related Medium (ack failure poisons ingest outcome) from `WEBHOOK-AUDIT.md`.