### PR TITLE
[CONFIG] - Build-speed tweaks and basic CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system libraries
+        # tesseract / leptonica-sys link against system libraries that
+        # aren't preinstalled on ubuntu-latest. clang is needed for the
+        # C++ bindings of librocksdb-sys (transitive via surrealdb).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libleptonica-dev \
+            libtesseract-dev \
+            libclang-dev
+
       - name: Install Rust toolchain
         # Respects the version + components pinned in rust-toolchain.toml,
         # so the CI compiler always matches local dev.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
   check:
     name: build / test / lint
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Cold-cache builds compile surrealdb, tesseract and reqwest from
+    # source and need ~25-30 min. Warm-cache runs finish well under 10
+    # min — 45 keeps headroom for both.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  check:
+    name: build / test / lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        # Respects the version + components pinned in rust-toolchain.toml,
+        # so the CI compiler always matches local dev.
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo build
+        run: cargo build --all-targets --locked
+
+      - name: cargo test
+        run: cargo test --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
 
 jobs:
   check:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Rust build artifacts
 /target
+# macOS Spotlight workaround: target/ renamed to target.noindex keeps
+# the indexer out of build outputs but is still local build state.
+/target.noindex
 
 # Environment — secrets and local config
 .env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,23 @@ rand = "0.8"
 tower = { version = "0.5", features = ["util"] }
 # Read axum response bodies in integration tests
 http-body-util = "0.1"
+
+# ── Build profile tweaks ──────────────────────────────────────────────────────
+#
+# Dev / test builds optimise for cycle time, not for pristine debuginfo.
+# `line-tables-only` keeps backtraces and panic locations useful while
+# dropping the heavier DWARF data — roughly 20–30% off a typical incremental
+# rebuild and noticeably less I/O on the `target/` directory.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"
+
+# Compile third-party dependencies with mild optimisation. The first cold
+# build is slightly slower; every subsequent dev cycle runs proc-macros
+# (serde / tracing / surrealdb derives) faster, and `cargo test` benefits
+# the most. Our own code stays at the default `opt-level = 0` so the inner
+# edit-compile loop is untouched.
+[profile.dev.package."*"]
+opt-level = 1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Unix"
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -21,24 +21,24 @@
 //! orphaned `user` row behind.
 
 use axum::{
-    Json,
     body::to_bytes,
     extract::{Path, Request, State},
     http::StatusCode,
+    Json,
 };
 use serde::{Deserialize, Serialize};
 use surrealdb::types::RecordId;
 
 use crate::api::models::{
-    AppError, DbGroup, DbGroupAdmin, DbUser, DbUserIdentity, EntityId, GroupAdminContent,
-    UserContent, UserIdentityContent, now_iso, record_id_to_string,
+    now_iso, record_id_to_string, AppError, DbGroup, DbGroupAdmin, DbUser, DbUserIdentity,
+    EntityId, GroupAdminContent, UserContent, UserIdentityContent,
 };
 use crate::auth::audit::record_auth_event;
 use crate::auth::extractors::SuperAdminUser;
 use crate::auth::password;
 use crate::auth::rate_limit::ClientIp;
 use crate::auth::refresh;
-use crate::db::{DbConn, is_unique_constraint_error};
+use crate::db::{is_unique_constraint_error, DbConn};
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
 const MAX_EMAIL_LEN: usize = 320;
@@ -177,9 +177,7 @@ pub async fn create_admin_user(
             Some(&ip),
         )
         .await;
-        return Err(AppError::Conflict(
-            "email already registered".into(),
-        ));
+        return Err(AppError::Conflict("email already registered".into()));
     }
 
     let password_hash = match password::hash(&req.initial_password) {
@@ -302,7 +300,10 @@ pub async fn create_admin_user(
     )
     .await;
 
-    Ok((StatusCode::CREATED, Json(AdminUserResponse::from_db(&created))))
+    Ok((
+        StatusCode::CREATED,
+        Json(AdminUserResponse::from_db(&created)),
+    ))
 }
 
 // ── PATCH /api/admin/users/:id ────────────────────────────────────────────────
@@ -406,9 +407,7 @@ pub async fn update_admin_user(
         // a concurrent writer advanced `version` or soft-deleted the row
         // between read and write. Surface as a version mismatch so the
         // caller refetches and retries.
-        AppError::Conflict(
-            "version mismatch — record was modified by another request".into(),
-        )
+        AppError::Conflict("version mismatch — record was modified by another request".into())
     })?;
 
     let ip = client_ip.to_string();
@@ -652,9 +651,7 @@ pub async fn grant_group_admin(
                 Some(&ip),
             )
             .await;
-            return Err(AppError::NotFound(format!(
-                "user {user_id} does not exist"
-            )));
+            return Err(AppError::NotFound(format!("user {user_id} does not exist")));
         }
     };
 
@@ -715,8 +712,7 @@ pub async fn grant_group_admin(
         created_at: now.clone(),
         created_by: caller.user_id.clone(),
     };
-    let insert: Result<Option<DbGroupAdmin>, _> =
-        db.create("group_admin").content(content).await;
+    let insert: Result<Option<DbGroupAdmin>, _> = db.create("group_admin").content(content).await;
     match insert {
         Ok(Some(_)) => {}
         Ok(None) => {
@@ -908,4 +904,3 @@ pub async fn revoke_group_admin(
 
     Ok(StatusCode::NO_CONTENT)
 }
-

--- a/src/api/auth_endpoints.rs
+++ b/src/api/auth_endpoints.rs
@@ -9,15 +9,15 @@
 //! becomes a deliberate, authenticated FE linking flow (not in BE-1).
 
 use axum::{
-    Extension, Json,
     body::to_bytes,
     extract::{Request, State},
+    Extension, Json,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::api::models::{
-    AppError, DbUser, DbUserIdentity, UserContent, UserIdentityContent, now_iso,
-    record_id_to_string,
+    now_iso, record_id_to_string, AppError, DbUser, DbUserIdentity, UserContent,
+    UserIdentityContent,
 };
 use crate::auth::audit::record_auth_event;
 use crate::auth::extractors::AuthenticatedUser;
@@ -26,7 +26,7 @@ use crate::auth::jwt::SharedVerifier;
 use crate::auth::password;
 use crate::auth::rate_limit::{ClientIp, CredentialFailureLimiter};
 use crate::auth::refresh::{self, RefreshError};
-use crate::db::{DbConn, is_unique_constraint_error};
+use crate::db::{is_unique_constraint_error, DbConn};
 use surrealdb::types::RecordId;
 
 const CREDENTIALS_PROVIDER: &str = "credentials";
@@ -398,8 +398,8 @@ pub async fn change_password(
     let body = to_bytes(http_req.into_body(), MAX_CHANGE_PASSWORD_BODY_BYTES)
         .await
         .map_err(|_| AppError::BadRequest("request body too large".into()))?;
-    let req: ChangePasswordRequest =
-        serde_json::from_slice(&body).map_err(|_| AppError::BadRequest("invalid JSON body".into()))?;
+    let req: ChangePasswordRequest = serde_json::from_slice(&body)
+        .map_err(|_| AppError::BadRequest("invalid JSON body".into()))?;
 
     if req.new_password.trim().is_empty() {
         return Err(AppError::BadRequest("newPassword required".into()));
@@ -552,14 +552,12 @@ async fn update_password_hash(
     new_hash: Option<&str>,
     now_rfc3339: &str,
 ) -> Result<(), AppError> {
-    db.query(
-        "UPDATE $id SET password_hash = $h, must_reset_password = false, updated_at = $now",
-    )
-    .bind(("id", RecordId::new("user", user_id.to_string())))
-    .bind(("h", new_hash.map(str::to_string)))
-    .bind(("now", now_rfc3339.to_string()))
-    .await?
-    .check()?;
+    db.query("UPDATE $id SET password_hash = $h, must_reset_password = false, updated_at = $now")
+        .bind(("id", RecordId::new("user", user_id.to_string())))
+        .bind(("h", new_hash.map(str::to_string)))
+        .bind(("now", now_rfc3339.to_string()))
+        .await?
+        .check()?;
     Ok(())
 }
 
@@ -792,8 +790,7 @@ pub async fn refresh_token_endpoint(
     let body = to_bytes(http_req.into_body(), MAX_REFRESH_BODY_BYTES)
         .await
         .map_err(|_| AppError::Unauthorized)?;
-    let req: RefreshRequest =
-        serde_json::from_slice(&body).map_err(|_| AppError::Unauthorized)?;
+    let req: RefreshRequest = serde_json::from_slice(&body).map_err(|_| AppError::Unauthorized)?;
     if req.refresh_token.is_empty() || req.refresh_token.len() > MAX_REFRESH_TOKEN_LEN {
         return Err(AppError::Unauthorized);
     }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -7,20 +7,20 @@ use serde::Deserialize;
 use surrealdb_types::SurrealValue;
 use tracing::error;
 
-use crate::auth::audit::record_auth_event;
-use crate::auth::extractors::{AuthenticatedUser, GroupScopedAdmin, OptionalAuth, SuperAdminUser};
 use crate::api::models::{
-    AppError, CreateCycleRequest, CreateGroupRequest, CreateMemberRequest, CreatePaymentRequest,
-    CreateWhatsappLinkRequest, Cycle, CycleContent, DbCycle, DbGroup, DbGroupLink, DbInboxItem,
-    DbMember, DbPayment, DbReceipt, EntityId, Group, GroupContent, GroupLink, GroupLinkContent,
-    InboxItemContent, InboxItemKind, Member, MemberContent, Payment, PaymentContent, Receipt,
-    ReceiptContent, ReceiptStatus, UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest,
-    now_iso, record_id_to_string,
+    now_iso, record_id_to_string, AppError, CreateCycleRequest, CreateGroupRequest,
+    CreateMemberRequest, CreatePaymentRequest, CreateWhatsappLinkRequest, Cycle, CycleContent,
+    DbCycle, DbGroup, DbGroupLink, DbInboxItem, DbMember, DbPayment, DbReceipt, EntityId, Group,
+    GroupContent, GroupLink, GroupLinkContent, InboxItemContent, InboxItemKind, Member,
+    MemberContent, Payment, PaymentContent, Receipt, ReceiptContent, ReceiptStatus,
+    UpdateCycleRequest, UpdateGroupRequest, UpdateMemberRequest,
 };
 use crate::api::pagination::{
     header_u32, Pagination, PaginationParams, HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT,
 };
-use crate::db::{DbConn, reseed};
+use crate::auth::audit::record_auth_event;
+use crate::auth::extractors::{AuthenticatedUser, GroupScopedAdmin, OptionalAuth, SuperAdminUser};
+use crate::db::{reseed, DbConn};
 
 // ── Query params ─────────────────────────────────────────────────────────────
 
@@ -333,7 +333,8 @@ pub async fn update_group(
     body.validate()?;
 
     let existing: Option<DbGroup> = db.select(("group", id.as_str())).await?;
-    let existing = existing.ok_or_else(|| AppError::NotFound(format!("group {id} does not exist")))?;
+    let existing =
+        existing.ok_or_else(|| AppError::NotFound(format!("group {id} does not exist")))?;
 
     if existing.version != body.version {
         return Err(AppError::Conflict(
@@ -342,7 +343,10 @@ pub async fn update_group(
     }
 
     let content = GroupContent {
-        name: body.name.map(|n| n.trim().to_string()).unwrap_or(existing.name),
+        name: body
+            .name
+            .map(|n| n.trim().to_string())
+            .unwrap_or(existing.name),
         status: body.status.unwrap_or(existing.status),
         description: body.description.or(existing.description),
         created_at: existing.created_at,
@@ -363,7 +367,8 @@ pub async fn delete_group(
     Path(id): Path<EntityId>,
 ) -> Result<StatusCode, AppError> {
     let existing: Option<DbGroup> = db.select(("group", id.as_str())).await?;
-    let existing = existing.ok_or_else(|| AppError::NotFound(format!("group {id} does not exist")))?;
+    let existing =
+        existing.ok_or_else(|| AppError::NotFound(format!("group {id} does not exist")))?;
 
     // Check for members in this group.
     let members: Vec<DbMember> = db
@@ -421,9 +426,15 @@ pub async fn create_member(
     // Verify group exists and is not soft-deleted.
     let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
     match &group {
-        None => return Err(AppError::NotFound(format!("group {group_id} does not exist"))),
+        None => {
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )))
+        }
         Some(g) if g.deleted_at.is_some() => {
-            return Err(AppError::NotFound(format!("group {group_id} does not exist")));
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )));
         }
         _ => {}
     }
@@ -432,7 +443,9 @@ pub async fn create_member(
     // matches the canonicalized value that will be stored.
     let phone_trimmed = body.phone.trim().to_string();
     let dupes: Vec<DbMember> = db
-        .query("SELECT * FROM member WHERE group_id = $gid AND phone = $phone AND deleted_at IS NONE")
+        .query(
+            "SELECT * FROM member WHERE group_id = $gid AND phone = $phone AND deleted_at IS NONE",
+        )
         .bind(("gid", group_id.clone()))
         .bind(("phone", phone_trimmed))
         .await?
@@ -507,8 +520,14 @@ pub async fn update_member(
     }
 
     let content = MemberContent {
-        name: body.name.map(|n| n.trim().to_string()).unwrap_or(existing.name),
-        phone: body.phone.map(|p| p.trim().to_string()).unwrap_or(existing.phone),
+        name: body
+            .name
+            .map(|n| n.trim().to_string())
+            .unwrap_or(existing.name),
+        phone: body
+            .phone
+            .map(|p| p.trim().to_string())
+            .unwrap_or(existing.phone),
         position: body.position.unwrap_or(existing.position),
         status: body.status.unwrap_or(existing.status),
         group_id: existing.group_id,
@@ -588,15 +607,23 @@ pub async fn create_cycle(
     // Verify group exists and is not soft-deleted.
     let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
     match &group {
-        None => return Err(AppError::NotFound(format!("group {group_id} does not exist"))),
+        None => {
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )))
+        }
         Some(g) if g.deleted_at.is_some() => {
-            return Err(AppError::NotFound(format!("group {group_id} does not exist")));
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )));
         }
         _ => {}
     }
 
     // Verify recipient is in the same group and is not soft-deleted.
-    let recipient: Option<DbMember> = db.select(("member", body.recipient_member_id.as_str())).await?;
+    let recipient: Option<DbMember> = db
+        .select(("member", body.recipient_member_id.as_str()))
+        .await?;
     match recipient {
         None => {
             return Err(AppError::NotFound(format!(
@@ -695,7 +722,9 @@ pub async fn update_cycle(
         }
     }
 
-    let contribution = body.contribution_per_member.unwrap_or(existing.contribution_per_member);
+    let contribution = body
+        .contribution_per_member
+        .unwrap_or(existing.contribution_per_member);
 
     // Recompute total_amount if contribution changed.
     let total_amount = if body.contribution_per_member.is_some() {
@@ -715,7 +744,10 @@ pub async fn update_cycle(
         end_date: body.end_date.unwrap_or(existing.end_date),
         contribution_per_member: contribution,
         total_amount,
-        recipient_member_id: body.recipient_member_id.clone().unwrap_or(existing.recipient_member_id),
+        recipient_member_id: body
+            .recipient_member_id
+            .clone()
+            .unwrap_or(existing.recipient_member_id),
         status: body.status.unwrap_or(existing.status),
         group_id: existing.group_id,
         notes: body.notes.or(existing.notes),
@@ -793,9 +825,8 @@ pub async fn create_payment(
         )));
     }
     let cycle: Option<DbCycle> = db.select(("cycle", body.cycle_id.as_str())).await?;
-    let cycle = cycle.ok_or_else(|| {
-        AppError::NotFound(format!("cycle {} does not exist", body.cycle_id))
-    })?;
+    let cycle = cycle
+        .ok_or_else(|| AppError::NotFound(format!("cycle {} does not exist", body.cycle_id)))?;
 
     if member.group_id != cycle.group_id {
         return Err(AppError::BadRequest(
@@ -926,7 +957,9 @@ fn receipt_content_from(
         bank_label: row.bank_label.clone(),
         raw_image_url: row.raw_image_url.clone(),
         // `None` on the patch means "keep prior value"; a `Some` overrides it.
-        rejection_reason: patch.rejection_reason.or_else(|| row.rejection_reason.clone()),
+        rejection_reason: patch
+            .rejection_reason
+            .or_else(|| row.rejection_reason.clone()),
         received_at: row.received_at.clone(),
         created_at: row.created_at.clone(),
         updated_at,
@@ -1205,9 +1238,7 @@ async fn confirm_receipt_inner(
     let payment_date = chrono::DateTime::parse_from_rfc3339(&receipt.received_at)
         .map(|dt| dt.format("%Y-%m-%d").to_string())
         .map_err(|_| {
-            AppError::Conflict(format!(
-                "receipt {id} has an invalid received_at timestamp"
-            ))
+            AppError::Conflict(format!("receipt {id} has an invalid received_at timestamp"))
         })?;
 
     let payment_content = PaymentContent {
@@ -1476,9 +1507,15 @@ pub async fn create_whatsapp_link(
     // Verify group exists and is not soft-deleted.
     let group: Option<DbGroup> = db.select(("group", group_id.as_str())).await?;
     match &group {
-        None => return Err(AppError::NotFound(format!("group {group_id} does not exist"))),
+        None => {
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )))
+        }
         Some(g) if g.deleted_at.is_some() => {
-            return Err(AppError::NotFound(format!("group {group_id} does not exist")));
+            return Err(AppError::NotFound(format!(
+                "group {group_id} does not exist"
+            )));
         }
         _ => {}
     }
@@ -1505,7 +1542,8 @@ pub async fn create_whatsapp_link(
     };
 
     let created: Option<DbGroupLink> = db.create("group_link").content(content).await?;
-    let created = created.ok_or_else(|| AppError::Internal("whatsapp link was not created".into()))?;
+    let created =
+        created.ok_or_else(|| AppError::Internal("whatsapp link was not created".into()))?;
 
     Ok((StatusCode::CREATED, Json(GroupLink::from(created))))
 }
@@ -1533,7 +1571,10 @@ pub async fn delete_whatsapp_link(
         updated_at: now.clone(),
         deleted_at: Some(now),
     };
-    let _: Option<DbGroupLink> = db.upsert(("group_link", id.as_str())).content(content).await?;
+    let _: Option<DbGroupLink> = db
+        .upsert(("group_link", id.as_str()))
+        .content(content)
+        .await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,7 +16,6 @@ use crate::api::pagination::{HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT};
 use crate::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
-use std::sync::{Arc, OnceLock};
 use handlers::{
     confirm_receipt, create_cycle, create_group, create_member, create_payment,
     create_whatsapp_link, delete_cycle, delete_group, delete_member, delete_payment,
@@ -24,6 +23,7 @@ use handlers::{
     get_whatsapp_links, patch_receipt, reject_receipt, reset_db, update_cycle, update_group,
     update_member,
 };
+use std::sync::{Arc, OnceLock};
 
 /// Build the Axum router with all API routes and CORS middleware.
 ///
@@ -44,9 +44,8 @@ pub fn shared_verifier() -> SharedVerifier {
     VERIFIER
         .get_or_init(|| {
             Arc::new(
-                StaticKeyVerifier::from_env(JwtConfig::from_env()).unwrap_or_else(|err| {
-                    panic!("Failed to initialise JWT verifier: {err}")
-                }),
+                StaticKeyVerifier::from_env(JwtConfig::from_env())
+                    .unwrap_or_else(|err| panic!("Failed to initialise JWT verifier: {err}")),
             )
         })
         .clone()
@@ -74,8 +73,14 @@ pub fn router_with_config(
             post(auth_endpoints::verify_credentials),
         )
         .route("/api/auth/ensure-user", post(auth_endpoints::ensure_user))
-        .route("/api/auth/issue", post(auth_endpoints::issue_token_endpoint))
-        .route("/api/auth/refresh", post(auth_endpoints::refresh_token_endpoint))
+        .route(
+            "/api/auth/issue",
+            post(auth_endpoints::issue_token_endpoint),
+        )
+        .route(
+            "/api/auth/refresh",
+            post(auth_endpoints::refresh_token_endpoint),
+        )
         .route("/api/auth/logout", post(auth_endpoints::logout_endpoint))
         .layer(rate_limit::build_per_ip_layer(&rate_cfg))
         .layer(Extension(credential_failure_limiter))
@@ -151,7 +156,10 @@ pub fn router_with_config(
     // APP_ENV is explicitly "development" or "test". If the env var is
     // misconfigured or missing on a staging/prod deploy, the endpoint stays
     // unreachable — previously an unset APP_ENV exposed it by default.
-    if matches!(std::env::var("APP_ENV").as_deref(), Ok("development" | "test")) {
+    if matches!(
+        std::env::var("APP_ENV").as_deref(),
+        Ok("development" | "test")
+    ) {
         router = router.route("/api/test/reset", post(reset_db));
     }
 
@@ -187,11 +195,7 @@ fn build_cors() -> CorsLayer {
             .allow_origin(parsed)
             .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
             .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
-            .expose_headers([
-                HEADER_TOTAL_COUNT,
-                HEADER_LIMIT,
-                HEADER_OFFSET,
-            ])
+            .expose_headers([HEADER_TOTAL_COUNT, HEADER_LIMIT, HEADER_OFFSET])
     } else {
         CorsLayer::permissive()
     }

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -73,7 +73,10 @@ impl IntoResponse for AppError {
             AppError::Forbidden(msg) => simple(StatusCode::FORBIDDEN, msg),
             AppError::Conflict(msg) => simple(StatusCode::CONFLICT, msg),
             AppError::TooManyRequests { retry_after_secs } => {
-                let mut resp = simple(StatusCode::TOO_MANY_REQUESTS, "too many requests".to_string());
+                let mut resp = simple(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "too many requests".to_string(),
+                );
                 if let Some(secs) = retry_after_secs {
                     if let Ok(v) = HeaderValue::from_str(&secs.to_string()) {
                         resp.headers_mut().insert(header::RETRY_AFTER, v);
@@ -547,7 +550,10 @@ impl TryFrom<DbGroup> for Group {
         Ok(Self {
             id: record_id_to_string(db.id),
             name: db.name,
-            status: db.status.parse().map_err(|e: String| AppError::Internal(e))?,
+            status: db
+                .status
+                .parse()
+                .map_err(|e: String| AppError::Internal(e))?,
             description: db.description,
             created_at: db.created_at,
             updated_at: db.updated_at,
@@ -565,7 +571,10 @@ impl TryFrom<DbMember> for Member {
             name: db.name,
             phone: db.phone,
             position: db.position,
-            status: db.status.parse().map_err(|e: String| AppError::Internal(e))?,
+            status: db
+                .status
+                .parse()
+                .map_err(|e: String| AppError::Internal(e))?,
             group_id: db.group_id,
             notes: db.notes,
             joined_at: db.joined_at,
@@ -588,7 +597,10 @@ impl TryFrom<DbCycle> for Cycle {
             contribution_per_member: db.contribution_per_member,
             total_amount: db.total_amount,
             recipient_member_id: db.recipient_member_id,
-            status: db.status.parse().map_err(|e: String| AppError::Internal(e))?,
+            status: db
+                .status
+                .parse()
+                .map_err(|e: String| AppError::Internal(e))?,
             group_id: db.group_id,
             notes: db.notes,
             created_at: db.created_at,
@@ -606,7 +618,10 @@ impl TryFrom<DbPayment> for Payment {
             member_id: db.member_id,
             cycle_id: db.cycle_id,
             amount: db.amount,
-            currency: db.currency.parse().map_err(|e: String| AppError::Internal(e))?,
+            currency: db
+                .currency
+                .parse()
+                .map_err(|e: String| AppError::Internal(e))?,
             payment_date: db.payment_date,
             payment_method: db.payment_method,
             reference: db.reference,
@@ -635,7 +650,10 @@ impl TryFrom<DbReceipt> for Receipt {
             extracted_amount: db.extracted_amount,
             expected_amount: db.expected_amount,
             amount_matches: db.amount_matches,
-            status: db.status.parse().map_err(|e: String| AppError::Internal(e))?,
+            status: db
+                .status
+                .parse()
+                .map_err(|e: String| AppError::Internal(e))?,
             ocr_text: db.ocr_text,
             sender_label: db.sender_label,
             bank_label: db.bank_label,
@@ -872,7 +890,9 @@ impl UpdateGroupRequest {
             }
         }
         if let Some(status) = &self.status {
-            status.parse::<GroupStatus>().map_err(AppError::BadRequest)?;
+            status
+                .parse::<GroupStatus>()
+                .map_err(AppError::BadRequest)?;
         }
         Ok(())
     }
@@ -946,7 +966,9 @@ impl UpdateMemberRequest {
             }
         }
         if let Some(status) = &self.status {
-            status.parse::<MemberStatus>().map_err(AppError::BadRequest)?;
+            status
+                .parse::<MemberStatus>()
+                .map_err(AppError::BadRequest)?;
         }
         if let Some(joined_at) = &self.joined_at {
             if !is_valid_date(joined_at) {
@@ -1054,7 +1076,9 @@ impl UpdateCycleRequest {
             }
         }
         if let Some(status) = &self.status {
-            status.parse::<CycleStatus>().map_err(AppError::BadRequest)?;
+            status
+                .parse::<CycleStatus>()
+                .map_err(AppError::BadRequest)?;
         }
         if let Some(recipient_id) = &self.recipient_member_id {
             if recipient_id.trim().is_empty() {
@@ -1093,14 +1117,10 @@ pub struct CreatePaymentRequest {
 impl CreatePaymentRequest {
     pub fn validate(&self) -> Result<(), AppError> {
         if self.member_id.trim().is_empty() {
-            return Err(AppError::BadRequest(
-                "memberId must not be empty".into(),
-            ));
+            return Err(AppError::BadRequest("memberId must not be empty".into()));
         }
         if self.cycle_id.trim().is_empty() {
-            return Err(AppError::BadRequest(
-                "cycleId must not be empty".into(),
-            ));
+            return Err(AppError::BadRequest("cycleId must not be empty".into()));
         }
         if self.amount <= 0 {
             return Err(AppError::BadRequest(
@@ -1272,4 +1292,3 @@ pub struct DbGroupAdmin {
     pub created_at: String,
     pub created_by: String,
 }
-

--- a/src/api/pagination.rs
+++ b/src/api/pagination.rs
@@ -97,8 +97,7 @@ fn parse_u32(raw: &str, field: &str) -> Result<u32, AppError> {
 /// header bytes, so the `from_str` call cannot fail in practice — the
 /// `expect` documents the invariant rather than papering over it.
 pub fn header_u32(value: u32) -> HeaderValue {
-    HeaderValue::from_str(&value.to_string())
-        .expect("decimal u32 is always a valid header value")
+    HeaderValue::from_str(&value.to_string()).expect("decimal u32 is always a valid header value")
 }
 
 #[cfg(test)]

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -233,9 +233,7 @@ fn is_http_or_https_url(url: &str) -> bool {
     // mean `http:///path` — no host). The authority slice runs from the end
     // of `://` to the first of `/`, `?`, or `#` so query- or fragment-only
     // inputs like `https://?x=1` and `https://#frag` are also rejected.
-    let host_end = rest
-        .find(|c: char| c == '/' || c == '?' || c == '#')
-        .unwrap_or(rest.len());
+    let host_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let authority = &rest[..host_end];
     if authority.is_empty() {
         return false;

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -143,11 +143,10 @@ pub async fn whatsapp_webhook(
     // `…+01:00` and `…+00:00` would sort lexicographically — breaking
     // absolute-time ordering of the admin queue. Converting to UTC makes the
     // lexicographic sort equivalent to a chronological sort.
-    let parsed_received_at =
-        chrono::DateTime::parse_from_rfc3339(&payload.received_at)
-            .map_err(|_| AppError::Unauthorized)?
-            .with_timezone(&chrono::Utc)
-            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let parsed_received_at = chrono::DateTime::parse_from_rfc3339(&payload.received_at)
+        .map_err(|_| AppError::Unauthorized)?
+        .with_timezone(&chrono::Utc)
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
     // `raw_image_url` is persisted verbatim and surfaced to admins in the FE
     // review modal. Reject anything that is not an absolute http(s) URL so a

--- a/src/auth/audit.rs
+++ b/src/auth/audit.rs
@@ -16,7 +16,7 @@
 //! The list is illustrative, not constraining — `event_type` is a free
 //! string on the DB side. New events land here without schema change.
 
-use crate::api::models::{AuthEventContent, DbAuthEvent, now_iso};
+use crate::api::models::{now_iso, AuthEventContent, DbAuthEvent};
 use crate::db::DbConn;
 
 /// Writes a single row to the `auth_event` table. Always returns `()`;

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -7,11 +7,11 @@ use surrealdb::types::RecordId;
 use tracing::{info, warn};
 
 use crate::api::models::{
-    AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbUser, DbUserIdentity,
-    GroupAdminContent, UserContent, UserIdentityContent, now_iso, record_id_to_string,
+    now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbUser,
+    DbUserIdentity, GroupAdminContent, UserContent, UserIdentityContent,
 };
 use crate::auth::password;
-use crate::db::{DbConn, FIXTURE_GROUP_ID, is_unique_constraint_error};
+use crate::db::{is_unique_constraint_error, DbConn, FIXTURE_GROUP_ID};
 
 const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
 const CREDENTIALS_PROVIDER: &str = "credentials";
@@ -41,10 +41,26 @@ struct DummyAdmin {
 }
 
 const DUMMY_ADMINS: [DummyAdmin; 4] = [
-    DummyAdmin { email: "admin1@poolpay.test", role: "admin",       grant_fixture_group: true  },
-    DummyAdmin { email: "admin2@poolpay.test", role: "admin",       grant_fixture_group: false },
-    DummyAdmin { email: "admin3@poolpay.test", role: "super_admin", grant_fixture_group: false },
-    DummyAdmin { email: "admin4@poolpay.test", role: "admin",       grant_fixture_group: false },
+    DummyAdmin {
+        email: "admin1@poolpay.test",
+        role: "admin",
+        grant_fixture_group: true,
+    },
+    DummyAdmin {
+        email: "admin2@poolpay.test",
+        role: "admin",
+        grant_fixture_group: false,
+    },
+    DummyAdmin {
+        email: "admin3@poolpay.test",
+        role: "super_admin",
+        grant_fixture_group: false,
+    },
+    DummyAdmin {
+        email: "admin4@poolpay.test",
+        role: "admin",
+        grant_fixture_group: false,
+    },
 ];
 
 /// Seed the initial admin account if none exists and the required env vars
@@ -424,8 +440,7 @@ async fn ensure_admin_fixture(
     // error. The user + identity rows are already persisted, so degrade to
     // a warn-and-continue on audit issues — matches the best-effort
     // contract documented on `seed_dummy_admins`.
-    let audit_result: Result<Option<DbAuthEvent>, _> =
-        db.create("auth_event").content(event).await;
+    let audit_result: Result<Option<DbAuthEvent>, _> = db.create("auth_event").content(event).await;
     if let Err(e) = audit_result {
         warn!(
             email_redacted = redact(email),
@@ -435,10 +450,7 @@ async fn ensure_admin_fixture(
         );
     }
 
-    info!(
-        email_redacted = redact(email),
-        "fixture admin created"
-    );
+    info!(email_redacted = redact(email), "fixture admin created");
     Ok(Some(user_id))
 }
 
@@ -546,8 +558,7 @@ async fn ensure_group_admin_grant(
         Ok(None) => {
             warn!(
                 user_id,
-                group_id,
-                "fixture group_admin grant returned no record — skipping audit event"
+                group_id, "fixture group_admin grant returned no record — skipping audit event"
             );
             Ok(())
         }

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -113,7 +113,11 @@ where
             return Err(AppError::Unauthorized);
         }
 
-        Ok(Self { user_id: claims.sub, role: user.role, token_version: user.token_version })
+        Ok(Self {
+            user_id: claims.sub,
+            role: user.role,
+            token_version: user.token_version,
+        })
     }
 }
 
@@ -164,7 +168,11 @@ where
         {
             return Ok(Self(None));
         }
-        Ok(Self(AuthenticatedUser::from_request_parts(parts, state).await.ok()))
+        Ok(Self(
+            AuthenticatedUser::from_request_parts(parts, state)
+                .await
+                .ok(),
+        ))
     }
 }
 
@@ -180,8 +188,7 @@ pub async fn require_group_scope(
     // "admin role required" vs "no access to this group" tells the caller
     // whether the JWT role is at least admin — cheap information we don't
     // need to give away.
-    let allowed =
-        user.role == "admin" && has_group_admin(db, &user.user_id, group_id).await?;
+    let allowed = user.role == "admin" && has_group_admin(db, &user.user_id, group_id).await?;
     if allowed {
         Ok(())
     } else {

--- a/src/auth/hmac.rs
+++ b/src/auth/hmac.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use std::sync::{Mutex, OnceLock};
 
 use axum::{
-    body::{Bytes, to_bytes},
+    body::{to_bytes, Bytes},
     extract::{FromRequest, Request},
     http::HeaderMap,
 };

--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -19,10 +19,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use jsonwebtoken::{
-    Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, decode_header, encode,
+    decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation,
 };
 use rand::RngCore;
 use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
@@ -135,10 +135,8 @@ pub struct JwtConfig {
 impl JwtConfig {
     pub fn from_env() -> Self {
         Self {
-            audience: std::env::var("JWT_AUDIENCE")
-                .unwrap_or_else(|_| "poolpay-api".to_string()),
-            issuer: std::env::var("JWT_ISSUER")
-                .unwrap_or_else(|_| "poolpay-nextauth".to_string()),
+            audience: std::env::var("JWT_AUDIENCE").unwrap_or_else(|_| "poolpay-api".to_string()),
+            issuer: std::env::var("JWT_ISSUER").unwrap_or_else(|_| "poolpay-nextauth".to_string()),
             // FE-side silent-refresh window is 360s (poolpay-app `auth.ts`
             // REFRESH_SKEW_SECS) — the FE proactively rotates when a token has
             // ≤360s of life left. Values at or below 360 cause the FE to refresh
@@ -240,7 +238,12 @@ impl StaticKeyVerifier {
             }
             keys.insert(
                 entry.kid.clone(),
-                KeyEntry { kid: entry.kid, encoding, decoding, active: entry.active },
+                KeyEntry {
+                    kid: entry.kid,
+                    encoding,
+                    decoding,
+                    active: entry.active,
+                },
             );
         }
 
@@ -282,7 +285,12 @@ impl StaticKeyVerifier {
         let mut keys = HashMap::new();
         keys.insert(
             kid.clone(),
-            KeyEntry { kid: kid.clone(), encoding: Some(encoding), decoding, active: true },
+            KeyEntry {
+                kid: kid.clone(),
+                encoding: Some(encoding),
+                decoding,
+                active: true,
+            },
         );
         Ok(Self {
             keys,
@@ -321,7 +329,6 @@ impl StaticKeyVerifier {
 
         encode(&header, &claims, encoding).map_err(|_| JwtError::Invalid)
     }
-
 }
 
 impl TokenVerifier for StaticKeyVerifier {
@@ -379,15 +386,19 @@ fn ephemeral_kid() -> String {
 // commits (active/kid are exercised by tests and the rotation path).
 impl KeyEntry {
     #[allow(dead_code)]
-    fn is_active(&self) -> bool { self.active }
+    fn is_active(&self) -> bool {
+        self.active
+    }
     #[allow(dead_code)]
-    fn kid(&self) -> &str { &self.kid }
+    fn kid(&self) -> &str {
+        &self.kid
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonwebtoken::{Algorithm, Header, encode};
+    use jsonwebtoken::{encode, Algorithm, Header};
 
     fn test_config() -> JwtConfig {
         JwtConfig {
@@ -561,7 +572,9 @@ mod tests {
             .to_pkcs8_pem(LineEnding::LF)
             .expect("priv encode")
             .to_string();
-        let pub_pem = public.to_public_key_pem(LineEnding::LF).expect("pub encode");
+        let pub_pem = public
+            .to_public_key_pem(LineEnding::LF)
+            .expect("pub encode");
         (priv_pem, pub_pem)
     }
 }

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -5,7 +5,7 @@
 //! distinguish "no such user" from "wrong password" by response latency.
 
 use argon2::{Algorithm, Argon2, Params, Version};
-use password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
+use password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use std::sync::OnceLock;
 
 use crate::api::models::AppError;
@@ -133,7 +133,7 @@ mod tests {
     /// speed. One hash + one verify; ~500 ms in debug mode.
     #[test]
     fn prod_params_round_trip() {
-        use password_hash::{PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng};
+        use password_hash::{rand_core::OsRng, PasswordHasher, PasswordVerifier, SaltString};
 
         let params = Params::new(
             ARGON2_PROD_M_COST_KIB,
@@ -149,6 +149,8 @@ mod tests {
             .expect("hash with prod params")
             .to_string();
         let parsed = PasswordHash::new(&hash).expect("parse PHC");
-        assert!(argon2.verify_password(b"prod-params-smoke", &parsed).is_ok());
+        assert!(argon2
+            .verify_password(b"prod-params-smoke", &parsed)
+            .is_ok());
     }
 }

--- a/src/auth/rate_limit.rs
+++ b/src/auth/rate_limit.rs
@@ -19,14 +19,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::{ConnectInfo, FromRequestParts};
-use axum::http::{Extensions, HeaderMap, Request, request::Parts};
+use axum::http::{request::Parts, Extensions, HeaderMap, Request};
 use governor::clock::{Clock, DefaultClock};
 use governor::state::keyed::DashMapStateStore;
 use governor::{NotUntil, Quota, RateLimiter};
-use tower_governor::GovernorLayer;
 use tower_governor::errors::GovernorError;
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
 use tower_governor::key_extractor::KeyExtractor;
+use tower_governor::GovernorLayer;
 
 // ── env keys & defaults ───────────────────────────────────────────────────────
 
@@ -70,10 +70,7 @@ impl RateLimitConfig {
         Self {
             per_ip_per_minute: parse_u32(ENV_PER_IP_PER_MINUTE, DEFAULT_PER_IP_PER_MINUTE),
             per_ip_burst: parse_u32(ENV_PER_IP_BURST, DEFAULT_PER_IP_BURST),
-            credential_failure_limit: parse_u32(
-                ENV_CRED_FAILURE_LIMIT,
-                DEFAULT_CRED_FAILURE_LIMIT,
-            ),
+            credential_failure_limit: parse_u32(ENV_CRED_FAILURE_LIMIT, DEFAULT_CRED_FAILURE_LIMIT),
             credential_failure_window_secs: parse_u64(
                 ENV_CRED_FAILURE_WINDOW_SECS,
                 DEFAULT_CRED_FAILURE_WINDOW_SECS,
@@ -237,8 +234,8 @@ pub type AuthGovernorConfig =
 /// auth surface.
 pub fn build_per_ip_config(cfg: &RateLimitConfig) -> Arc<AuthGovernorConfig> {
     let burst = NonZeroU32::new(cfg.per_ip_burst).expect("AUTH_RATE_LIMIT_BURST must be > 0");
-    let per_min = NonZeroU32::new(cfg.per_ip_per_minute)
-        .expect("AUTH_RATE_LIMIT_PER_MINUTE must be > 0");
+    let per_min =
+        NonZeroU32::new(cfg.per_ip_per_minute).expect("AUTH_RATE_LIMIT_PER_MINUTE must be > 0");
 
     // `tower_governor`'s builder takes a replenish-period + burst-size. Convert
     // "N requests per minute, burst B" into "replenish one cell every 60/N
@@ -268,11 +265,8 @@ pub fn build_per_ip_layer(
 /// the caller to match the identity-lookup path used in `verify_credentials`.
 pub type CredentialFailureKey = (IpAddr, String);
 
-type CredentialFailureRateLimiter = RateLimiter<
-    CredentialFailureKey,
-    DashMapStateStore<CredentialFailureKey>,
-    DefaultClock,
->;
+type CredentialFailureRateLimiter =
+    RateLimiter<CredentialFailureKey, DashMapStateStore<CredentialFailureKey>, DefaultClock>;
 
 /// Charges one quota slot per failed credential attempt per `(ip, email)` pair.
 /// Successful logins never call `charge_failure`, so they never consume quota.

--- a/src/auth/refresh.rs
+++ b/src/auth/refresh.rs
@@ -14,16 +14,16 @@
 //!   This follows OAuth 2.0 Security BCP (RFC 9700) section 4.12.
 //! * Logout revokes every row in the family in one shot.
 
-use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use surrealdb::types::RecordId;
 use tracing::warn;
 
 use crate::api::models::{
-    AuthEventContent, DbAuthEvent, DbRefreshToken, DbUser, RefreshTokenContent, now_iso,
-    record_id_to_string,
+    now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbRefreshToken, DbUser,
+    RefreshTokenContent,
 };
 use crate::db::DbConn;
 
@@ -63,7 +63,9 @@ impl std::fmt::Display for RefreshError {
 impl std::error::Error for RefreshError {}
 
 impl From<surrealdb::Error> for RefreshError {
-    fn from(e: surrealdb::Error) -> Self { Self::Db(e) }
+    fn from(e: surrealdb::Error) -> Self {
+        Self::Db(e)
+    }
 }
 
 /// Issue a brand-new refresh token for `user_id`. Used at login time and by
@@ -93,7 +95,11 @@ pub async fn issue(db: &DbConn, user_id: &str) -> Result<IssuedRefreshToken, Ref
             "refresh token create returned no record".to_string(),
         ));
     }
-    Ok(IssuedRefreshToken { plaintext, family_id, expires_at })
+    Ok(IssuedRefreshToken {
+        plaintext,
+        family_id,
+        expires_at,
+    })
 }
 
 /// Rotate a presented refresh token. Happy path: revoke the presented row
@@ -108,7 +114,9 @@ pub async fn rotate(
     presented: &str,
 ) -> Result<(IssuedRefreshToken, String), RefreshError> {
     let hashed = hash_token(presented);
-    let row = load_by_hash(db, &hashed).await?.ok_or(RefreshError::NotFound)?;
+    let row = load_by_hash(db, &hashed)
+        .await?
+        .ok_or(RefreshError::NotFound)?;
 
     // Cheap pre-checks. These are not the authoritative guard — the atomic
     // revoke below is — but they short-circuit the obvious cases without
@@ -142,11 +150,14 @@ pub async fn rotate(
         revoked_at: None,
         replaced_by: None,
     };
-    let new_row: Option<DbRefreshToken> =
-        db.create("refresh_token").content(new_content).await?;
+    let new_row: Option<DbRefreshToken> = db.create("refresh_token").content(new_content).await?;
     let new_id = match new_row {
         Some(r) => record_id_to_string(r.id),
-        None => return Err(RefreshError::Internal("new refresh_token row not returned".into())),
+        None => {
+            return Err(RefreshError::Internal(
+                "new refresh_token row not returned".into(),
+            ))
+        }
     };
 
     // Atomic guard: only one concurrent rotate per row can win the
@@ -179,7 +190,11 @@ pub async fn rotate(
     }
 
     Ok((
-        IssuedRefreshToken { plaintext: new_plain, family_id: row.family_id, expires_at },
+        IssuedRefreshToken {
+            plaintext: new_plain,
+            family_id: row.family_id,
+            expires_at,
+        },
         row.user_id,
     ))
 }
@@ -188,11 +203,13 @@ pub async fn rotate(
 /// event_type (`logout` vs `refresh_reuse_detected`).
 pub async fn revoke_family(db: &DbConn, family_id: &str) -> Result<(), RefreshError> {
     let now = now_iso();
-    db.query("UPDATE refresh_token SET revoked_at = $now WHERE family_id = $fid AND revoked_at IS NONE")
-        .bind(("now", now))
-        .bind(("fid", family_id.to_string()))
-        .await?
-        .check()?;
+    db.query(
+        "UPDATE refresh_token SET revoked_at = $now WHERE family_id = $fid AND revoked_at IS NONE",
+    )
+    .bind(("now", now))
+    .bind(("fid", family_id.to_string()))
+    .await?
+    .check()?;
     Ok(())
 }
 
@@ -203,22 +220,23 @@ pub async fn revoke_family(db: &DbConn, family_id: &str) -> Result<(), RefreshEr
 /// access-TTL and holders of old refresh tokens cannot mint replacements.
 pub async fn revoke_all_for_user(db: &DbConn, user_id: &str) -> Result<(), RefreshError> {
     let now = now_iso();
-    db.query("UPDATE refresh_token SET revoked_at = $now WHERE user_id = $uid AND revoked_at IS NONE")
-        .bind(("now", now))
-        .bind(("uid", user_id.to_string()))
-        .await?
-        .check()?;
+    db.query(
+        "UPDATE refresh_token SET revoked_at = $now WHERE user_id = $uid AND revoked_at IS NONE",
+    )
+    .bind(("now", now))
+    .bind(("uid", user_id.to_string()))
+    .await?
+    .check()?;
     Ok(())
 }
 
 /// Revoke the family of a presented refresh token. Used by `/api/auth/logout`.
 /// Returns the `user_id` so the caller can audit under the right subject.
-pub async fn revoke_by_presented(
-    db: &DbConn,
-    presented: &str,
-) -> Result<String, RefreshError> {
+pub async fn revoke_by_presented(db: &DbConn, presented: &str) -> Result<String, RefreshError> {
     let hashed = hash_token(presented);
-    let row = load_by_hash(db, &hashed).await?.ok_or(RefreshError::NotFound)?;
+    let row = load_by_hash(db, &hashed)
+        .await?
+        .ok_or(RefreshError::NotFound)?;
     revoke_family(db, &row.family_id).await?;
     Ok(row.user_id)
 }
@@ -245,7 +263,11 @@ async fn handle_reuse(db: &DbConn, stolen: &DbRefreshToken) {
         reason: Some(format!("family_id={}", stolen.family_id)),
         created_at: now_iso(),
     };
-    if let Err(e) = db.create::<Option<DbAuthEvent>>("auth_event").content(event).await {
+    if let Err(e) = db
+        .create::<Option<DbAuthEvent>>("auth_event")
+        .content(event)
+        .await
+    {
         warn!(error = %e, "Failed to record refresh_reuse_detected auth_event");
     }
 }
@@ -263,10 +285,7 @@ pub async fn bump_token_version(db: &DbConn, user_id: &str) -> Result<(), Refres
     Ok(())
 }
 
-async fn load_by_hash(
-    db: &DbConn,
-    hashed: &str,
-) -> Result<Option<DbRefreshToken>, RefreshError> {
+async fn load_by_hash(db: &DbConn, hashed: &str) -> Result<Option<DbRefreshToken>, RefreshError> {
     let mut resp = db
         .query("SELECT * FROM refresh_token WHERE hashed_token = $h LIMIT 1")
         .bind(("h", hashed.to_string()))

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use surrealdb::Surreal;
-use surrealdb::engine::any::{Any, connect};
+use surrealdb::engine::any::{connect, Any};
 use surrealdb::opt::auth::Root;
+use surrealdb::Surreal;
 use tracing::info;
 
 use crate::api::models::{
@@ -445,8 +445,9 @@ pub(crate) fn is_unique_constraint_error(message: &str) -> bool {
 pub(crate) const FIXTURE_GROUP_ID: &str = "1";
 
 fn fixture_groups() -> Vec<(&'static str, GroupContent)> {
-    vec![
-        (FIXTURE_GROUP_ID, GroupContent {
+    vec![(
+        FIXTURE_GROUP_ID,
+        GroupContent {
             name: "PoolPay Group Alpha".into(),
             status: "active".into(),
             description: Some("First PoolPay savings group — 6 members, ₦10k monthly".into()),
@@ -454,20 +455,110 @@ fn fixture_groups() -> Vec<(&'static str, GroupContent)> {
             updated_at: "2025-06-15T00:00:00+00:00".into(),
             deleted_at: None,
             version: 1,
-        }),
-    ]
+        },
+    )]
 }
 
 fn fixture_members() -> Vec<(&'static str, MemberContent)> {
     let group_id = FIXTURE_GROUP_ID.to_string();
     let created_at = "2025-06-15T00:00:00+00:00";
     vec![
-        ("1", MemberContent { name: "Adaeze Okonkwo".into(),  phone: "2348101234567".into(), position: 1, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("2", MemberContent { name: "Chukwuemeka Eze".into(), phone: "2347031234567".into(), position: 2, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("3", MemberContent { name: "Ngozi Adeyemi".into(),   phone: "2349061234567".into(), position: 3, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("4", MemberContent { name: "Tunde Bakare".into(),    phone: "2348031234567".into(), position: 4, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("5", MemberContent { name: "Amaka Nwosu".into(),     phone: "2348161234567".into(), position: 5, status: "active".into(), group_id: group_id.clone(), notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
-        ("6", MemberContent { name: "Seun Okafor".into(),     phone: "2347061234567".into(), position: 6, status: "active".into(), group_id, notes: None, joined_at: Some("2025-06-15".into()), created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None, version: 1 }),
+        (
+            "1",
+            MemberContent {
+                name: "Adaeze Okonkwo".into(),
+                phone: "2348101234567".into(),
+                position: 1,
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
+        (
+            "2",
+            MemberContent {
+                name: "Chukwuemeka Eze".into(),
+                phone: "2347031234567".into(),
+                position: 2,
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
+        (
+            "3",
+            MemberContent {
+                name: "Ngozi Adeyemi".into(),
+                phone: "2349061234567".into(),
+                position: 3,
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
+        (
+            "4",
+            MemberContent {
+                name: "Tunde Bakare".into(),
+                phone: "2348031234567".into(),
+                position: 4,
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
+        (
+            "5",
+            MemberContent {
+                name: "Amaka Nwosu".into(),
+                phone: "2348161234567".into(),
+                position: 5,
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
+        (
+            "6",
+            MemberContent {
+                name: "Seun Okafor".into(),
+                phone: "2347061234567".into(),
+                position: 6,
+                status: "active".into(),
+                group_id,
+                notes: None,
+                joined_at: Some("2025-06-15".into()),
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                deleted_at: None,
+                version: 1,
+            },
+        ),
     ]
 }
 
@@ -476,107 +567,247 @@ fn fixture_cycles() -> Vec<(&'static str, CycleContent)> {
     let created_at = "2025-06-15T00:00:00+00:00";
     vec![
         // Round 1: Jul–Dec 2025 (cycles 1–6, full rotation of all 6 members)
-        ("4", CycleContent {
-            cycle_number: 1, start_date: "2025-07-01".into(), end_date: "2025-07-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "1".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("5", CycleContent {
-            cycle_number: 2, start_date: "2025-08-01".into(), end_date: "2025-08-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "2".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("6", CycleContent {
-            cycle_number: 3, start_date: "2025-09-01".into(), end_date: "2025-09-30".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "3".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("7", CycleContent {
-            cycle_number: 4, start_date: "2025-10-01".into(), end_date: "2025-10-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "4".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("8", CycleContent {
-            cycle_number: 5, start_date: "2025-11-01".into(), end_date: "2025-11-30".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "5".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("9", CycleContent {
-            cycle_number: 6, start_date: "2025-12-01".into(), end_date: "2025-12-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "6".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
+        (
+            "4",
+            CycleContent {
+                cycle_number: 1,
+                start_date: "2025-07-01".into(),
+                end_date: "2025-07-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "1".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "5",
+            CycleContent {
+                cycle_number: 2,
+                start_date: "2025-08-01".into(),
+                end_date: "2025-08-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "2".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "6",
+            CycleContent {
+                cycle_number: 3,
+                start_date: "2025-09-01".into(),
+                end_date: "2025-09-30".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "3".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "7",
+            CycleContent {
+                cycle_number: 4,
+                start_date: "2025-10-01".into(),
+                end_date: "2025-10-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "4".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "8",
+            CycleContent {
+                cycle_number: 5,
+                start_date: "2025-11-01".into(),
+                end_date: "2025-11-30".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "5".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "9",
+            CycleContent {
+                cycle_number: 6,
+                start_date: "2025-12-01".into(),
+                end_date: "2025-12-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "6".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
         // Round 2: Jan–Mar 2026 (cycles 7–9, second rotation begins)
-        ("1", CycleContent {
-            cycle_number: 7, start_date: "2026-01-01".into(), end_date: "2026-01-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "1".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("2", CycleContent {
-            cycle_number: 8, start_date: "2026-02-01".into(), end_date: "2026-02-28".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "2".into(), status: "closed".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("3", CycleContent {
-            cycle_number: 9, start_date: "2026-03-01".into(), end_date: "2026-03-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "3".into(), status: "active".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
+        (
+            "1",
+            CycleContent {
+                cycle_number: 7,
+                start_date: "2026-01-01".into(),
+                end_date: "2026-01-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "1".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "2",
+            CycleContent {
+                cycle_number: 8,
+                start_date: "2026-02-01".into(),
+                end_date: "2026-02-28".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "2".into(),
+                status: "closed".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "3",
+            CycleContent {
+                cycle_number: 9,
+                start_date: "2026-03-01".into(),
+                end_date: "2026-03-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "3".into(),
+                status: "active".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
         // Round 2 upcoming: Apr–Jun 2026 (cycles 10–12, pending). Scheduled
         // but not yet started — gives the dashboard a `pending` cycle state
         // to render alongside closed/active, and extends the rotation preview
         // through end-of-round without disturbing the active-cycle id (3).
-        ("10", CycleContent {
-            cycle_number: 10, start_date: "2026-04-01".into(), end_date: "2026-04-30".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "4".into(), status: "pending".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("11", CycleContent {
-            cycle_number: 11, start_date: "2026-05-01".into(), end_date: "2026-05-31".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "5".into(), status: "pending".into(), group_id: group_id.clone(), notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
-        ("12", CycleContent {
-            cycle_number: 12, start_date: "2026-06-01".into(), end_date: "2026-06-30".into(),
-            contribution_per_member: 1_000_000, total_amount: 6_000_000,
-            recipient_member_id: "6".into(), status: "pending".into(), group_id, notes: None,
-            created_at: created_at.into(), updated_at: created_at.into(), version: 1,
-        }),
+        (
+            "10",
+            CycleContent {
+                cycle_number: 10,
+                start_date: "2026-04-01".into(),
+                end_date: "2026-04-30".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "4".into(),
+                status: "pending".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "11",
+            CycleContent {
+                cycle_number: 11,
+                start_date: "2026-05-01".into(),
+                end_date: "2026-05-31".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "5".into(),
+                status: "pending".into(),
+                group_id: group_id.clone(),
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
+        (
+            "12",
+            CycleContent {
+                cycle_number: 12,
+                start_date: "2026-06-01".into(),
+                end_date: "2026-06-30".into(),
+                contribution_per_member: 1_000_000,
+                total_amount: 6_000_000,
+                recipient_member_id: "6".into(),
+                status: "pending".into(),
+                group_id,
+                notes: None,
+                created_at: created_at.into(),
+                updated_at: created_at.into(),
+                version: 1,
+            },
+        ),
     ]
 }
 
 fn fixture_payments() -> Vec<(&'static str, PaymentContent)> {
     let created_at = "2025-06-15T00:00:00+00:00";
     let payment = |member_id: &str, cycle_id: &str, date: &str| PaymentContent {
-        member_id: member_id.into(), cycle_id: cycle_id.into(), amount: 1_000_000,
-        currency: "NGN".into(), payment_date: date.into(),
-        payment_method: None, reference: None,
-        confirmed_at: None, confirmed_by: None,
-        created_at: created_at.into(), updated_at: created_at.into(), deleted_at: None,
-        rejected_by: None, deleted_by: None,
+        member_id: member_id.into(),
+        cycle_id: cycle_id.into(),
+        amount: 1_000_000,
+        currency: "NGN".into(),
+        payment_date: date.into(),
+        payment_method: None,
+        reference: None,
+        confirmed_at: None,
+        confirmed_by: None,
+        created_at: created_at.into(),
+        updated_at: created_at.into(),
+        deleted_at: None,
+        rejected_by: None,
+        deleted_by: None,
     };
     vec![
         // Cycle 3 — March 2026 (Ngozi excluded as recipient; 3 of 5 contributing paid)
-        ("1",  payment("1", "3", "2026-03-02")),
-        ("2",  payment("2", "3", "2026-03-03")),
-        ("4",  payment("5", "3", "2026-03-07")),
+        ("1", payment("1", "3", "2026-03-02")),
+        ("2", payment("2", "3", "2026-03-03")),
+        ("4", payment("5", "3", "2026-03-07")),
         // Cycle 1 — January 2026 (all 6 members paid)
-        ("5",  payment("1", "1", "2026-01-02")),
-        ("6",  payment("2", "1", "2026-01-03")),
-        ("7",  payment("3", "1", "2026-01-04")),
-        ("8",  payment("4", "1", "2026-01-05")),
-        ("9",  payment("5", "1", "2026-01-06")),
+        ("5", payment("1", "1", "2026-01-02")),
+        ("6", payment("2", "1", "2026-01-03")),
+        ("7", payment("3", "1", "2026-01-04")),
+        ("8", payment("4", "1", "2026-01-05")),
+        ("9", payment("5", "1", "2026-01-06")),
         ("10", payment("6", "1", "2026-01-08")),
         // Cycle 2 — February 2026 (all 6 members paid)
         ("11", payment("1", "2", "2026-02-02")),
@@ -738,8 +969,7 @@ mod tests {
     /// for the full mutate → run → cleanup window makes that precondition hold
     /// across parallel tests in this binary.
     fn env_lock() -> &'static std::sync::Mutex<()> {
-        static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
-            std::sync::OnceLock::new();
+        static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         ENV_LOCK.get_or_init(|| std::sync::Mutex::new(()))
     }
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -4,9 +4,7 @@ use tracing::{error, info};
 
 /// Runs Tesseract OCR on the image file at the given path and returns the extracted text.
 pub fn ocr_image(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let path_str = path
-        .to_str()
-        .ok_or("file path contains invalid UTF-8")?;
+    let path_str = path.to_str().ok_or("file path contains invalid UTF-8")?;
     let text = tesseract::ocr(path_str, "eng")?;
     Ok(text)
 }
@@ -29,9 +27,7 @@ pub fn ocr_pdf(pdf_path: &Path) -> Result<String, Box<dyn std::error::Error>> {
         .to_str()
         .ok_or("prefix path contains invalid UTF-8")?;
 
-    let pdf_path_str = pdf_path
-        .to_str()
-        .ok_or("PDF path contains invalid UTF-8")?;
+    let pdf_path_str = pdf_path.to_str().ok_or("PDF path contains invalid UTF-8")?;
 
     // Convert all PDF pages to JPEG: produces <prefix>-1.jpg, <prefix>-2.jpg, etc.
     let status = Command::new("pdftoppm")

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -8,7 +8,7 @@
 
 use tracing::info;
 
-use crate::api::models::{AppError, EntityId, ReceiptContent, now_iso};
+use crate::api::models::{now_iso, AppError, EntityId, ReceiptContent};
 use crate::db::DbConn;
 use crate::models::ParsedReceipt;
 use crate::parser;
@@ -67,7 +67,10 @@ pub async fn ingest_receipt(
     input: IngestionInput<'_>,
 ) -> Result<IngestionOutcome, AppError> {
     let Some(group) = routing::find_group_by_chat_id(db, input.chat_id).await? else {
-        info!(chat_id = input.chat_id, "Ingestion skipped: chat not linked to a group");
+        info!(
+            chat_id = input.chat_id,
+            "Ingestion skipped: chat not linked to a group"
+        );
         return Ok(IngestionOutcome::NotLinked);
     };
     let group_id = crate::api::models::record_id_to_string(group.id);
@@ -76,7 +79,10 @@ pub async fn ingest_receipt(
         .await?
         .is_some()
     {
-        info!(message_id = input.message_id, "Ingestion skipped: duplicate message id");
+        info!(
+            message_id = input.message_id,
+            "Ingestion skipped: duplicate message id"
+        );
         return Ok(IngestionOutcome::DuplicateMessage);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
+use poolpay::api::models::now_iso;
 use poolpay::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use poolpay::auth::rate_limit::RateLimitConfig;
 use poolpay::{api, auth, db, extractor, ingestion, parser, replies, whatsapp};
-use poolpay::api::models::now_iso;
 use std::sync::Arc;
 
 use dotenv::dotenv;
@@ -23,11 +23,10 @@ async fn main() {
         )
         .init();
 
-    let instance_id = env::var("GREEN_API_INSTANCE_ID")
-        .expect("GREEN_API_INSTANCE_ID must be set in .env");
+    let instance_id =
+        env::var("GREEN_API_INSTANCE_ID").expect("GREEN_API_INSTANCE_ID must be set in .env");
 
-    let api_token = env::var("GREEN_API_TOKEN")
-        .expect("GREEN_API_TOKEN must be set in .env");
+    let api_token = env::var("GREEN_API_TOKEN").expect("GREEN_API_TOKEN must be set in .env");
 
     // HMAC strength depends on key entropy. hmac.rs only rejects an empty
     // secret, so a 6-char value would silently pass. Fail fast on anything
@@ -52,7 +51,9 @@ async fn main() {
             if env::var("APP_ENV").as_deref() == Ok("production") {
                 panic!("NEXTAUTH_BACKEND_SECRET must be set in production");
             } else {
-                warn!("NEXTAUTH_BACKEND_SECRET is not set — HMAC endpoints will reject all requests");
+                warn!(
+                    "NEXTAUTH_BACKEND_SECRET is not set — HMAC endpoints will reject all requests"
+                );
             }
         }
     }
@@ -92,9 +93,7 @@ async fn main() {
     auth::password::prewarm();
 
     // Initialise embedded SurrealDB and, if SEED_ON_EMPTY=true and the DB is empty, seed fixture data.
-    let surreal_db = db::init()
-        .await
-        .expect("Failed to initialise SurrealDB");
+    let surreal_db = db::init().await.expect("Failed to initialise SurrealDB");
 
     if let Err(e) = auth::bootstrap::ensure_admin_user(&surreal_db).await {
         error!(error = %e, "Bootstrap admin seeding failed");
@@ -133,7 +132,10 @@ async fn main() {
         }
     });
 
-    info!(receipt_poll_secs = RECEIPT_POLL_SECS, "Receipt engine started");
+    info!(
+        receipt_poll_secs = RECEIPT_POLL_SECS,
+        "Receipt engine started"
+    );
 
     // Watchdog: if the API server task dies, exit rather than silently
     // continuing with a broken API.
@@ -157,8 +159,7 @@ async fn main() {
 
                 if let Some(msg) = &notification.body.message_data {
                     if let Some(file_data) = &msg.file_message_data {
-                        let is_pdf =
-                            file_data.mime_type.as_deref() == Some("application/pdf");
+                        let is_pdf = file_data.mime_type.as_deref() == Some("application/pdf");
 
                         info!(
                             file_type = if is_pdf { "PDF" } else { "Image" },

--- a/src/models.rs
+++ b/src/models.rs
@@ -138,7 +138,10 @@ mod tests {
         }"#;
 
         let notification: Notification = serde_json::from_str(json).unwrap();
-        assert_eq!(notification.body.id_message.as_deref(), Some("BAE5F4886F532D01"));
+        assert_eq!(
+            notification.body.id_message.as_deref(),
+            Some("BAE5F4886F532D01")
+        );
     }
 
     // Confirms that a notification without idMessage (e.g. a delivery receipt event)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,10 +33,8 @@ static FALLBACK_SENDER_RE: LazyLock<Regex> = LazyLock::new(|| {
     // of letters and spaces (e.g. a garbled paragraph), the match stops at 41 chars
     // and the excess is silently dropped. This is a known limitation — it protects
     // against runaway captures at the cost of truncating unusually long names.
-    Regex::new(
-        r"(?i)(?:sender(?:\s+name)?|from|originator)\s*[:\-]?\s*([A-Za-z][A-Za-z ]{2,40})",
-    )
-    .unwrap()
+    Regex::new(r"(?i)(?:sender(?:\s+name)?|from|originator)\s*[:\-]?\s*([A-Za-z][A-Za-z ]{2,40})")
+        .unwrap()
 });
 
 static KNOWN_BANKS_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -105,7 +103,11 @@ pub fn parse_receipt(text: &str) -> ParsedReceipt {
             .map(|m| m.as_str().trim().to_string());
     }
 
-    ParsedReceipt { sender, bank, amount }
+    ParsedReceipt {
+        sender,
+        bank,
+        amount,
+    }
 }
 
 /// Converts a normalised amount string (as produced by `parse_receipt`) into

--- a/src/whatsapp.rs
+++ b/src/whatsapp.rs
@@ -176,13 +176,15 @@ pub fn print_notification(n: &Notification) {
     let body = &n.body;
     let webhook_type = &body.type_webhook;
 
-    let (sender_name, sender) = body.sender_data.as_ref().map_or(
-        ("unknown", "unknown"),
-        |s| (
-            s.sender_name.as_deref().unwrap_or("unknown"),
-            s.sender.as_deref().unwrap_or("unknown"),
-        ),
-    );
+    let (sender_name, sender) = body
+        .sender_data
+        .as_ref()
+        .map_or(("unknown", "unknown"), |s| {
+            (
+                s.sender_name.as_deref().unwrap_or("unknown"),
+                s.sender.as_deref().unwrap_or("unknown"),
+            )
+        });
 
     let msg_type = body
         .message_data
@@ -192,10 +194,7 @@ pub fn print_notification(n: &Notification) {
 
     info!(
         webhook_type,
-        sender_name,
-        sender,
-        msg_type,
-        "Notification received"
+        sender_name, sender, msg_type, "Notification received"
     );
 
     if let Some(msg) = &body.message_data {

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -107,7 +107,7 @@ const TEST_SCOPED_ADMIN_GROUP: &str = "1";
 ///   canonical 403 fixture for both `SuperAdminUser` and
 ///   `GroupScopedAdmin` handlers.
 async fn seed_test_admin_users(db: &poolpay::db::DbConn) {
-    use poolpay::api::models::{DbUser, UserContent, now_iso};
+    use poolpay::api::models::{now_iso, DbUser, UserContent};
 
     for (sub, role) in [
         (TEST_SUPER_ADMIN_SUB, "super_admin"),
@@ -215,7 +215,10 @@ fn mint_user_jwt(sub: &str, role: &str) -> String {
 }
 
 fn super_admin_bearer() -> String {
-    format!("Bearer {}", mint_user_jwt(TEST_SUPER_ADMIN_SUB, "super_admin"))
+    format!(
+        "Bearer {}",
+        mint_user_jwt(TEST_SUPER_ADMIN_SUB, "super_admin")
+    )
 }
 
 fn admin_bearer() -> String {
@@ -354,7 +357,10 @@ async fn create_group_super_admin_jwt_proceeds() {
     let app = test_app_with_auth().await;
     let resp = call(
         app,
-        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "New Group"})),
+        post_json_jwt(
+            "/api/admin/groups",
+            serde_json::json!({"name": "New Group"}),
+        ),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::CREATED);
@@ -370,7 +376,11 @@ async fn create_group_admin_role_jwt_returns_403() {
     let app = test_app_with_auth().await;
     let resp = call(
         app,
-        post_json_jwt_with("/api/admin/groups", serde_json::json!({"name": "x"}), &admin_bearer()),
+        post_json_jwt_with(
+            "/api/admin/groups",
+            serde_json::json!({"name": "x"}),
+            &admin_bearer(),
+        ),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -412,7 +422,10 @@ async fn create_group_returns_201_with_body() {
     let app = test_app_with_auth().await;
     let resp = call(
         app,
-        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Beta Circle"})),
+        post_json_jwt(
+            "/api/admin/groups",
+            serde_json::json!({"name": "Beta Circle"}),
+        ),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::CREATED);
@@ -597,7 +610,10 @@ async fn create_member_same_phone_different_group_allowed() {
     // Create a second group first.
     let resp = call(
         app.clone(),
-        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Second Group"})),
+        post_json_jwt(
+            "/api/admin/groups",
+            serde_json::json!({"name": "Second Group"}),
+        ),
     )
     .await;
     let new_group: serde_json::Value = json_body(resp).await;
@@ -713,8 +729,7 @@ async fn delete_member_not_recipient_returns_204() {
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
     // Verify soft delete — member no longer in default list.
-    let members: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/members")).await).await;
+    let members: Vec<serde_json::Value> = json_body(call(app, get("/api/members")).await).await;
     assert_eq!(members.len(), 5);
 }
 
@@ -758,9 +773,15 @@ async fn get_cycles_response_shape() {
     assert!(c.get("cycleNumber").is_some(), "missing cycleNumber");
     assert!(c.get("startDate").is_some(), "missing startDate");
     assert!(c.get("endDate").is_some(), "missing endDate");
-    assert!(c.get("contributionPerMember").is_some(), "missing contributionPerMember");
+    assert!(
+        c.get("contributionPerMember").is_some(),
+        "missing contributionPerMember"
+    );
     assert!(c.get("totalAmount").is_some(), "missing totalAmount");
-    assert!(c.get("recipientMemberId").is_some(), "missing recipientMemberId");
+    assert!(
+        c.get("recipientMemberId").is_some(),
+        "missing recipientMemberId"
+    );
     assert!(c.get("status").is_some(), "missing status");
     assert!(c.get("groupId").is_some(), "missing groupId");
     assert!(c.get("createdAt").is_some(), "missing createdAt");
@@ -838,7 +859,10 @@ async fn create_cycle_recipient_wrong_group_returns_400() {
     // Create a second group.
     let resp = call(
         app.clone(),
-        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Other Group"})),
+        post_json_jwt(
+            "/api/admin/groups",
+            serde_json::json!({"name": "Other Group"}),
+        ),
     )
     .await;
     let other_group: serde_json::Value = json_body(resp).await;
@@ -1001,7 +1025,10 @@ async fn get_payments_filter_by_cycle_id_returns_subset() {
     let payments: Vec<serde_json::Value> = json_body(resp).await;
     assert_eq!(payments.len(), 3, "cycle 3 should have 3 fixture payments");
     for p in &payments {
-        assert_eq!(p["cycleId"], "3", "all returned payments must belong to cycle 3");
+        assert_eq!(
+            p["cycleId"], "3",
+            "all returned payments must belong to cycle 3"
+        );
     }
 }
 
@@ -1017,7 +1044,10 @@ async fn get_payments_filter_unknown_cycle_returns_empty() {
     let resp = call(test_app().await, get("/api/payments?cycleId=999")).await;
     assert_eq!(resp.status(), StatusCode::OK);
     let payments: Vec<serde_json::Value> = json_body(resp).await;
-    assert!(payments.is_empty(), "unknown cycle should return empty array");
+    assert!(
+        payments.is_empty(),
+        "unknown cycle should return empty array"
+    );
 }
 
 // ── POST /api/payments ──────────────────────────────────────────────────────
@@ -1374,17 +1404,19 @@ async fn reset_restores_payments_to_fixture_count() {
 
     call(app.clone(), post_empty("/api/test/reset")).await;
 
-    let payments: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/payments")).await).await;
-    assert_eq!(payments.len(), 49, "reset should restore 49 fixture payments");
+    let payments: Vec<serde_json::Value> = json_body(call(app, get("/api/payments")).await).await;
+    assert_eq!(
+        payments.len(),
+        49,
+        "reset should restore 49 fixture payments"
+    );
 }
 
 #[tokio::test]
 async fn reset_restores_members() {
     let app = test_app().await;
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let members: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/members")).await).await;
+    let members: Vec<serde_json::Value> = json_body(call(app, get("/api/members")).await).await;
     assert_eq!(members.len(), 6);
 }
 
@@ -1392,8 +1424,7 @@ async fn reset_restores_members() {
 async fn reset_restores_cycles() {
     let app = test_app().await;
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let cycles: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/cycles")).await).await;
+    let cycles: Vec<serde_json::Value> = json_body(call(app, get("/api/cycles")).await).await;
     assert_eq!(cycles.len(), 12);
 }
 
@@ -1401,8 +1432,7 @@ async fn reset_restores_cycles() {
 async fn reset_restores_groups() {
     let app = test_app().await;
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let groups: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/groups")).await).await;
+    let groups: Vec<serde_json::Value> = json_body(call(app, get("/api/groups")).await).await;
     assert_eq!(groups.len(), 1);
 }
 
@@ -1424,7 +1454,10 @@ async fn bad_request_error_has_json_error_field() {
     .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body: serde_json::Value = json_body(resp).await;
-    assert!(body.get("error").is_some(), "400 must have an 'error' field");
+    assert!(
+        body.get("error").is_some(),
+        "400 must have an 'error' field"
+    );
     assert!(body["error"].is_string(), "'error' must be a string");
 }
 
@@ -1434,7 +1467,10 @@ async fn not_found_error_has_json_error_field() {
     let resp = call(app, delete_req_jwt("/api/payments/999/999")).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     let body: serde_json::Value = json_body(resp).await;
-    assert!(body.get("error").is_some(), "404 must have an 'error' field");
+    assert!(
+        body.get("error").is_some(),
+        "404 must have an 'error' field"
+    );
 }
 
 #[tokio::test]
@@ -1447,7 +1483,10 @@ async fn unauthorized_error_has_json_error_field() {
     .await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let body: serde_json::Value = json_body(resp).await;
-    assert!(body.get("error").is_some(), "401 must have an 'error' field");
+    assert!(
+        body.get("error").is_some(),
+        "401 must have an 'error' field"
+    );
 }
 
 #[tokio::test]
@@ -1456,7 +1495,10 @@ async fn conflict_error_has_json_error_field() {
     let resp = call(app, delete_req_jwt("/api/admin/groups/1")).await;
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let body: serde_json::Value = json_body(resp).await;
-    assert!(body.get("error").is_some(), "409 must have an 'error' field");
+    assert!(
+        body.get("error").is_some(),
+        "409 must have an 'error' field"
+    );
 }
 
 // ── WhatsApp links (admin CRUD) ─────────────────────────────────────────────
@@ -1576,7 +1618,11 @@ async fn create_whatsapp_link_duplicate_chat_id_returns_409() {
     let app = test_app_with_auth().await;
     let body = serde_json::json!({"chatId": "2349000000003@g.us", "groupId": "1"});
 
-    let first = call(app.clone(), post_json_jwt("/api/admin/whatsapp-links", body.clone())).await;
+    let first = call(
+        app.clone(),
+        post_json_jwt("/api/admin/whatsapp-links", body.clone()),
+    )
+    .await;
     assert_eq!(first.status(), StatusCode::CREATED);
 
     let second = call(app, post_json_jwt("/api/admin/whatsapp-links", body)).await;
@@ -1791,8 +1837,9 @@ async fn get_receipts_excludes_soft_deleted() {
     let resp = call(app, get("/api/receipts")).await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(
-        receipts.iter().all(|r| r.get("deletedAt").is_none()
-            || r["deletedAt"].is_null()),
+        receipts
+            .iter()
+            .all(|r| r.get("deletedAt").is_none() || r["deletedAt"].is_null()),
         "soft-deleted receipts must not be returned"
     );
 }
@@ -1804,8 +1851,7 @@ async fn reset_restores_receipts_to_fixture_count() {
         json_body(call(app.clone(), get("/api/receipts")).await).await;
     let baseline = before.len();
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let after: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/receipts")).await).await;
+    let after: Vec<serde_json::Value> = json_body(call(app, get("/api/receipts")).await).await;
     assert_eq!(after.len(), baseline);
 }
 
@@ -1930,7 +1976,11 @@ async fn confirm_receipt_requires_auth() {
 #[tokio::test]
 async fn confirm_receipt_unknown_id_returns_404() {
     let app = test_app_with_auth().await;
-    let resp = call(app, post_empty_jwt("/api/admin/receipts/does-not-exist/confirm")).await;
+    let resp = call(
+        app,
+        post_empty_jwt("/api/admin/receipts/does-not-exist/confirm"),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
@@ -2359,7 +2409,10 @@ async fn confirm_receipt_unknown_id_denies_non_scoped_admin_opaquely() {
     let app = test_app_with_auth().await;
     let resp = call(
         app,
-        post_empty_jwt_with("/api/admin/receipts/does-not-exist/confirm", &admin_bearer()),
+        post_empty_jwt_with(
+            "/api/admin/receipts/does-not-exist/confirm",
+            &admin_bearer(),
+        ),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -2558,10 +2611,7 @@ async fn pagination_excludes_soft_deleted_receipts_from_total_count() {
 /// suites to assert side-effect rows landed where they should. The query
 /// flows through the same SurrealDB handle the API uses, so an index
 /// regression would fail the read here too.
-async fn fetch_inbox_for_user(
-    db: &poolpay::db::DbConn,
-    user_id: &str,
-) -> Vec<serde_json::Value> {
+async fn fetch_inbox_for_user(db: &poolpay::db::DbConn, user_id: &str) -> Vec<serde_json::Value> {
     use surrealdb_types::SurrealValue;
     #[derive(Debug, serde::Deserialize, SurrealValue)]
     struct Row {
@@ -2662,10 +2712,7 @@ async fn patch_receipt_invalid_action_returns_400() {
     let app = test_app_with_auth().await;
     let resp = call(
         app,
-        patch_json_jwt(
-            "/api/receipts/1",
-            serde_json::json!({"action": "destroy"}),
-        ),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "destroy"})),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -2683,7 +2730,10 @@ async fn patch_receipt_scoped_admin_denied_cross_group_returns_403() {
     // Create group 2 via the admin API (super-admin path).
     let g = call(
         app.clone(),
-        post_json_jwt("/api/admin/groups", serde_json::json!({"name": "Off-limits"})),
+        post_json_jwt(
+            "/api/admin/groups",
+            serde_json::json!({"name": "Off-limits"}),
+        ),
     )
     .await;
     assert_eq!(g.status(), StatusCode::CREATED);
@@ -2908,7 +2958,11 @@ async fn inbox_item_created_on_confirm() {
     .await;
     assert_eq!(resp.status(), StatusCode::OK);
     let inbox = fetch_inbox_for_user(&db, "4").await;
-    assert_eq!(inbox.len(), 1, "exactly one inbox row should land on confirm");
+    assert_eq!(
+        inbox.len(),
+        1,
+        "exactly one inbox row should land on confirm"
+    );
     assert_eq!(inbox[0]["kind"], "receipt_confirmed");
 }
 

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -8,13 +8,13 @@ use axum::{
     response::Response,
     Router,
 };
-use http_body_util::BodyExt;
 use axum::{
     extract::{Path, State},
     http::StatusCode as AxumStatus,
     routing::get,
     Extension as AxumExtension,
 };
+use http_body_util::BodyExt;
 use poolpay::{
     api,
     auth::{
@@ -761,11 +761,7 @@ fn issue_req(user_id: &str) -> Request<Body> {
     hmac_request("/api/auth/issue", &body)
 }
 
-async fn count_auth_events(
-    db: &poolpay::db::DbConn,
-    user_id: &str,
-    event_type: &str,
-) -> i64 {
+async fn count_auth_events(db: &poolpay::db::DbConn, user_id: &str, event_type: &str) -> i64 {
     let mut resp = db
         .query(
             "SELECT count() FROM auth_event \
@@ -920,8 +916,7 @@ async fn issue_disabled_user_returns_401_and_writes_failure_event() {
     let resp = call(app, issue_req(&user_id)).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let failures =
-        count_auth_events(&db, &user_id, "token_issue_failure").await;
+    let failures = count_auth_events(&db, &user_id, "token_issue_failure").await;
     assert_eq!(failures, 1);
     // And no success row was written.
     let successes = count_auth_events(&db, &user_id, "token_issued").await;
@@ -945,8 +940,7 @@ async fn issue_soft_deleted_user_returns_401() {
     let resp = call(app, issue_req(&user_id)).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
-    let failures =
-        count_auth_events(&db, &user_id, "token_issue_failure").await;
+    let failures = count_auth_events(&db, &user_id, "token_issue_failure").await;
     assert_eq!(failures, 1);
     let successes = count_auth_events(&db, &user_id, "token_issued").await;
     assert_eq!(successes, 0);
@@ -1066,7 +1060,9 @@ async fn bootstrap_admin_id(db: &poolpay::db::DbConn) -> String {
         .check()
         .unwrap();
     let rows: Vec<String> = resp.take(0).unwrap_or_default();
-    rows.into_iter().next().expect("bootstrap admin row must exist")
+    rows.into_iter()
+        .next()
+        .expect("bootstrap admin row must exist")
 }
 
 #[tokio::test]
@@ -1311,7 +1307,11 @@ async fn change_password_rotates_hash_bumps_token_version_and_clears_must_reset(
         "email": BOOTSTRAP_EMAIL,
         "password": "brand-new-secret-passphrase",
     });
-    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    let verify_resp = call(
+        app,
+        hmac_request("/api/auth/verify-credentials", &verify_body),
+    )
+    .await;
     assert_eq!(verify_resp.status(), StatusCode::OK);
 }
 
@@ -1330,8 +1330,7 @@ async fn change_password_wrong_current_returns_400_bad_current_and_does_not_muta
 
     let hash_before = user_password_hash(&db, &admin_id).await;
     let version_before = user_token_version(&db, &admin_id).await;
-    let failures_before =
-        count_auth_events(&db, &admin_id, "password_change_failure").await;
+    let failures_before = count_auth_events(&db, &admin_id, "password_change_failure").await;
 
     let body = serde_json::json!({
         "currentPassword": "this-is-not-the-real-password",
@@ -1467,7 +1466,11 @@ async fn change_password_sets_hash_for_social_upgrade_without_current_password()
         "email": "social1@example.com",
         "password": "first-time-password-set",
     });
-    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    let verify_resp = call(
+        app,
+        hmac_request("/api/auth/verify-credentials", &verify_body),
+    )
+    .await;
     assert_eq!(verify_resp.status(), StatusCode::OK);
 }
 
@@ -1542,7 +1545,11 @@ async fn change_password_writes_password_changed_auth_event() {
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
     let after = count_auth_events(&db, &admin_id, "password_changed").await;
-    assert_eq!(after, before + 1, "expected exactly one password_changed event");
+    assert_eq!(
+        after,
+        before + 1,
+        "expected exactly one password_changed event"
+    );
 }
 
 /// `user.email_normalised` is intentionally non-unique, so two social users
@@ -1559,7 +1566,10 @@ async fn change_password_set_path_refuses_when_another_user_owns_credentials_ide
     let shared_email = "shared-credentials@example.com";
     let user_a = seed_member(&app, "sub-shared-a", shared_email).await;
     let user_b = seed_member(&app, "sub-shared-b", shared_email).await;
-    assert_ne!(user_a, user_b, "distinct providerSubjects must produce distinct users");
+    assert_ne!(
+        user_a, user_b,
+        "distinct providerSubjects must produce distinct users"
+    );
 
     // User A sets a password first — this inserts the single credentials
     // identity row for `shared_email`.
@@ -1589,7 +1599,11 @@ async fn change_password_set_path_refuses_when_another_user_owns_credentials_ide
         "email": shared_email,
         "password": "owner-password",
     });
-    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    let verify_resp = call(
+        app,
+        hmac_request("/api/auth/verify-credentials", &verify_body),
+    )
+    .await;
     assert_eq!(verify_resp.status(), StatusCode::OK);
 }
 
@@ -1682,7 +1696,9 @@ async fn user_deleted_at(db: &poolpay::db::DbConn, user_id: &str) -> Option<Stri
 async fn create_admin_user_happy_path_returns_201_and_allows_signin() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "new-admin@example.com",
@@ -1715,7 +1731,11 @@ async fn create_admin_user_happy_path_returns_201_and_allows_signin() {
         "email": "new-admin@example.com",
         "password": "initial-secret-passphrase",
     });
-    let verify_resp = call(app, hmac_request("/api/auth/verify-credentials", &verify_body)).await;
+    let verify_resp = call(
+        app,
+        hmac_request("/api/auth/verify-credentials", &verify_body),
+    )
+    .await;
     assert_eq!(verify_resp.status(), StatusCode::OK);
     let vv: serde_json::Value = json_body(verify_resp).await;
     assert_eq!(vv["mustResetPassword"], true);
@@ -1726,7 +1746,9 @@ async fn create_admin_user_happy_path_returns_201_and_allows_signin() {
 async fn create_admin_user_allows_second_super_admin() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "second-super@example.com",
@@ -1743,7 +1765,9 @@ async fn create_admin_user_allows_second_super_admin() {
 async fn create_admin_user_rejects_member_role() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "not-an-admin@example.com",
@@ -1758,7 +1782,9 @@ async fn create_admin_user_rejects_member_role() {
 async fn create_admin_user_rejects_empty_email() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "   ",
@@ -1773,7 +1799,9 @@ async fn create_admin_user_rejects_empty_email() {
 async fn create_admin_user_rejects_oversized_email() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": format!("{}@example.com", "a".repeat(400)),
@@ -1788,7 +1816,9 @@ async fn create_admin_user_rejects_oversized_email() {
 async fn create_admin_user_rejects_empty_password() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "blank-pwd@example.com",
@@ -1803,7 +1833,9 @@ async fn create_admin_user_rejects_empty_password() {
 async fn create_admin_user_rejects_whitespace_only_password() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "ws-pwd@example.com",
@@ -1818,7 +1850,9 @@ async fn create_admin_user_rejects_whitespace_only_password() {
 async fn create_admin_user_rejects_oversized_password() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "huge-pwd@example.com",
@@ -1833,7 +1867,9 @@ async fn create_admin_user_rejects_oversized_password() {
 async fn create_admin_user_duplicate_email_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": "dupe@example.com",
@@ -1860,7 +1896,9 @@ async fn create_admin_user_collides_on_existing_bootstrap_email() {
     // request is the operator's first CRUD call.
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({
         "email": BOOTSTRAP_EMAIL,
@@ -1942,7 +1980,9 @@ async fn seed_admin_user(
 async fn update_admin_user_role_change_bumps_token_version_and_writes_audit() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "patch-role@example.com", "admin").await;
@@ -1974,7 +2014,9 @@ async fn update_admin_user_role_change_bumps_token_version_and_writes_audit() {
 async fn update_admin_user_role_change_rejects_in_flight_access_token() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "stale-token@example.com", "admin").await;
@@ -1986,7 +2028,11 @@ async fn update_admin_user_role_change_rejects_in_flight_access_token() {
 
     // Promote target to super_admin — bumps token_version.
     let body = serde_json::json!({ "role": "super_admin", "version": version });
-    let resp = call(app.clone(), admin_users_patch_req(&target_id, &super_token, &body)).await;
+    let resp = call(
+        app.clone(),
+        admin_users_patch_req(&target_id, &super_token, &body),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     // The target's pre-promotion access token must now fail the version
@@ -2004,7 +2050,9 @@ async fn update_admin_user_role_change_rejects_in_flight_access_token() {
 async fn update_admin_user_status_disable_revokes_refresh_tokens_and_audits() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "disable@example.com", "admin").await;
@@ -2014,7 +2062,11 @@ async fn update_admin_user_status_disable_revokes_refresh_tokens_and_audits() {
     let tv_before = user_token_version(&db, &target_id).await;
 
     let body = serde_json::json!({ "status": "disabled", "version": version });
-    let resp = call(app.clone(), admin_users_patch_req(&target_id, &super_token, &body)).await;
+    let resp = call(
+        app.clone(),
+        admin_users_patch_req(&target_id, &super_token, &body),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     assert_eq!(user_status(&db, &target_id).await, "disabled");
@@ -2034,20 +2086,30 @@ async fn update_admin_user_status_disable_revokes_refresh_tokens_and_audits() {
 async fn update_admin_user_reenable_emits_user_enabled_audit_event() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "reenable@example.com", "admin").await;
 
     // Disable first — produces a user_disabled event and bumps version to version+1.
     let disable = serde_json::json!({ "status": "disabled", "version": version });
-    let resp = call(app.clone(), admin_users_patch_req(&target_id, &super_token, &disable)).await;
+    let resp = call(
+        app.clone(),
+        admin_users_patch_req(&target_id, &super_token, &disable),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(user_status(&db, &target_id).await, "disabled");
 
     // Re-enable with the bumped version.
     let reenable = serde_json::json!({ "status": "active", "version": version + 1 });
-    let resp = call(app, admin_users_patch_req(&target_id, &super_token, &reenable)).await;
+    let resp = call(
+        app,
+        admin_users_patch_req(&target_id, &super_token, &reenable),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(user_status(&db, &target_id).await, "active");
 
@@ -2062,7 +2124,9 @@ async fn update_admin_user_reenable_emits_user_enabled_audit_event() {
 async fn update_admin_user_noop_patch_bumps_version_but_not_token_version() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "noop@example.com", "admin").await;
@@ -2087,7 +2151,9 @@ async fn update_admin_user_noop_patch_bumps_version_but_not_token_version() {
 async fn update_admin_user_version_mismatch_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "stale-version@example.com", "admin").await;
@@ -2101,10 +2167,16 @@ async fn update_admin_user_version_mismatch_returns_409() {
 async fn update_admin_user_unknown_id_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let body = serde_json::json!({ "role": "admin", "version": 1 });
-    let resp = call(app, admin_users_patch_req("nonexistent-id", &super_token, &body)).await;
+    let resp = call(
+        app,
+        admin_users_patch_req("nonexistent-id", &super_token, &body),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
@@ -2112,17 +2184,27 @@ async fn update_admin_user_unknown_id_returns_404() {
 async fn update_admin_user_rejects_unsupported_role_and_status() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "badvals@example.com", "admin").await;
 
     let bad_role = serde_json::json!({ "role": "owner", "version": version });
-    let r1 = call(app.clone(), admin_users_patch_req(&target_id, &super_token, &bad_role)).await;
+    let r1 = call(
+        app.clone(),
+        admin_users_patch_req(&target_id, &super_token, &bad_role),
+    )
+    .await;
     assert_eq!(r1.status(), StatusCode::BAD_REQUEST);
 
     let bad_status = serde_json::json!({ "status": "pending", "version": version });
-    let r2 = call(app, admin_users_patch_req(&target_id, &super_token, &bad_status)).await;
+    let r2 = call(
+        app,
+        admin_users_patch_req(&target_id, &super_token, &bad_status),
+    )
+    .await;
     assert_eq!(r2.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -2130,7 +2212,9 @@ async fn update_admin_user_rejects_unsupported_role_and_status() {
 async fn update_admin_user_self_mutation_returns_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let version = user_version(&db, &super_id).await;
     let body = serde_json::json!({ "role": "admin", "version": version });
@@ -2142,7 +2226,9 @@ async fn update_admin_user_self_mutation_returns_403() {
 async fn update_admin_user_rejects_non_super_admin_with_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "patch-forbid@example.com", "admin").await;
@@ -2157,7 +2243,9 @@ async fn update_admin_user_rejects_non_super_admin_with_403() {
 async fn update_admin_user_allows_demotion_to_member() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, version) =
         seed_admin_user(&app, &super_token, "demote@example.com", "admin").await;
@@ -2174,15 +2262,20 @@ async fn update_admin_user_allows_demotion_to_member() {
 async fn delete_admin_user_soft_deletes_and_bumps_token_version() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
-    let (target_id, _) =
-        seed_admin_user(&app, &super_token, "soft-del@example.com", "admin").await;
+    let (target_id, _) = seed_admin_user(&app, &super_token, "soft-del@example.com", "admin").await;
 
     let issued = refresh::issue(&db, &target_id).await.expect("issue");
     let tv_before = user_token_version(&db, &target_id).await;
 
-    let resp = call(app.clone(), admin_users_delete_req(&target_id, &super_token)).await;
+    let resp = call(
+        app.clone(),
+        admin_users_delete_req(&target_id, &super_token),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
 
     assert!(
@@ -2216,7 +2309,9 @@ async fn delete_admin_user_soft_deletes_and_bumps_token_version() {
 async fn delete_admin_user_self_delete_returns_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let resp = call(app, admin_users_delete_req(&super_id, &super_token)).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -2233,7 +2328,9 @@ async fn delete_admin_user_self_delete_returns_403() {
 async fn delete_admin_user_unknown_id_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let resp = call(app, admin_users_delete_req("nonexistent-id", &super_token)).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -2243,12 +2340,18 @@ async fn delete_admin_user_unknown_id_returns_404() {
 async fn delete_admin_user_already_deleted_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "double-del@example.com", "admin").await;
 
-    let first = call(app.clone(), admin_users_delete_req(&target_id, &super_token)).await;
+    let first = call(
+        app.clone(),
+        admin_users_delete_req(&target_id, &super_token),
+    )
+    .await;
     assert_eq!(first.status(), StatusCode::NO_CONTENT);
 
     let second = call(app, admin_users_delete_req(&target_id, &super_token)).await;
@@ -2259,7 +2362,9 @@ async fn delete_admin_user_already_deleted_returns_404() {
 async fn delete_admin_user_rejects_non_super_admin_with_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "del-forbid@example.com", "admin").await;
@@ -2297,11 +2402,7 @@ async fn seed_test_group(db: &poolpay::db::DbConn, id: &str) {
         .expect("group row returned");
 }
 
-async fn count_group_admin_rows(
-    db: &poolpay::db::DbConn,
-    user_id: &str,
-    group_id: &str,
-) -> i64 {
+async fn count_group_admin_rows(db: &poolpay::db::DbConn, user_id: &str, group_id: &str) -> i64 {
     let mut resp = db
         .query(
             "SELECT count() FROM group_admin \
@@ -2321,10 +2422,11 @@ async fn count_group_admin_rows(
 async fn grant_group_admin_happy_path_returns_201_and_inserts_row() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
-    let (target_id, _) =
-        seed_admin_user(&app, &super_token, "grant-hp@example.com", "admin").await;
+    let (target_id, _) = seed_admin_user(&app, &super_token, "grant-hp@example.com", "admin").await;
     seed_test_group(&db, "grant-hp-group").await;
 
     let resp = call(
@@ -2371,7 +2473,9 @@ async fn grant_group_admin_without_bearer_returns_401() {
 async fn grant_group_admin_rejects_non_super_admin_with_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "grant-forbid@example.com", "admin").await;
@@ -2390,7 +2494,9 @@ async fn grant_group_admin_rejects_non_super_admin_with_403() {
 async fn grant_group_admin_on_unknown_user_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
     seed_test_group(&db, "grant-unknown-user-group").await;
 
     let resp = call(
@@ -2405,7 +2511,9 @@ async fn grant_group_admin_on_unknown_user_returns_404() {
 async fn grant_group_admin_on_disabled_user_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "grant-disabled@example.com", "admin").await;
@@ -2428,15 +2536,12 @@ async fn grant_group_admin_on_disabled_user_returns_409() {
 async fn grant_group_admin_on_super_admin_target_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
-    let (target_id, _) = seed_admin_user(
-        &app,
-        &super_token,
-        "grant-super@example.com",
-        "super_admin",
-    )
-    .await;
+    let (target_id, _) =
+        seed_admin_user(&app, &super_token, "grant-super@example.com", "super_admin").await;
     seed_test_group(&db, "grant-super-group").await;
 
     let resp = call(
@@ -2451,7 +2556,9 @@ async fn grant_group_admin_on_super_admin_target_returns_409() {
 async fn grant_group_admin_on_member_target_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let member_id = seed_member(&app, "sub-grant-member", "grant-member@example.com").await;
     seed_test_group(&db, "grant-member-group").await;
@@ -2468,7 +2575,9 @@ async fn grant_group_admin_on_member_target_returns_409() {
 async fn grant_group_admin_on_unknown_group_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "grant-ghost-group@example.com", "admin").await;
@@ -2485,7 +2594,9 @@ async fn grant_group_admin_on_unknown_group_returns_404() {
 async fn grant_group_admin_duplicate_returns_409() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "grant-dup@example.com", "admin").await;
@@ -2524,7 +2635,9 @@ fn group_admin_delete_req(user_id: &str, group_id: &str, token: &str) -> Request
 async fn revoke_group_admin_happy_path_returns_204_and_removes_row() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "revoke-hp@example.com", "admin").await;
@@ -2558,7 +2671,9 @@ async fn revoke_group_admin_happy_path_returns_204_and_removes_row() {
 async fn revoke_group_admin_bumps_target_token_version() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "revoke-tv@example.com", "admin").await;
@@ -2598,7 +2713,9 @@ async fn revoke_group_admin_bumps_target_token_version() {
 async fn revoke_group_admin_invalidates_pre_revoke_access_token() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "kick-after-revoke@example.com", "admin").await;
@@ -2618,7 +2735,11 @@ async fn revoke_group_admin_invalidates_pre_revoke_access_token() {
     // through the AuthenticatedUser + require_group_scope pipeline
     // on a router that only mounts the extractor route.
     let test_app = extractor_app(db.clone(), verifier);
-    let before = call(test_app.clone(), bearer_get("/scope/kick-group", &target_token)).await;
+    let before = call(
+        test_app.clone(),
+        bearer_get("/scope/kick-group", &target_token),
+    )
+    .await;
     assert_eq!(before.status(), StatusCode::NO_CONTENT);
 
     let revoke = call(
@@ -2660,7 +2781,9 @@ async fn revoke_group_admin_without_bearer_returns_401() {
 async fn revoke_group_admin_rejects_non_super_admin_with_403() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "revoke-forbid@example.com", "admin").await;
@@ -2691,7 +2814,9 @@ async fn revoke_group_admin_rejects_non_super_admin_with_403() {
 async fn revoke_group_admin_unknown_grant_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "revoke-unknown@example.com", "admin").await;
@@ -2708,7 +2833,9 @@ async fn revoke_group_admin_unknown_grant_returns_404() {
 async fn revoke_group_admin_replay_after_success_returns_404() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;
-    let super_token = verifier.mint_access(&super_id, "super_admin", 0).expect("mint");
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
 
     let (target_id, _) =
         seed_admin_user(&app, &super_token, "revoke-replay@example.com", "admin").await;
@@ -2797,9 +2924,16 @@ async fn seed_dummy_admins_creates_all_fixtures_with_expected_roles_and_grants()
          ) GROUP ALL",
     )
     .await;
-    assert_eq!(admin1_grants, 1, "admin1 must receive exactly one fixture grant on group 1");
+    assert_eq!(
+        admin1_grants, 1,
+        "admin1 must receive exactly one fixture grant on group 1"
+    );
 
-    for email in ["admin2@poolpay.test", "admin3@poolpay.test", "admin4@poolpay.test"] {
+    for email in [
+        "admin2@poolpay.test",
+        "admin3@poolpay.test",
+        "admin4@poolpay.test",
+    ] {
         let grants = count_rows(
             &db,
             &format!(
@@ -2863,7 +2997,10 @@ async fn seed_dummy_admins_is_noop_without_flag() {
          GROUP ALL",
     )
     .await;
-    assert_eq!(admins, 0, "fixture admins must not be seeded without SEED_ON_EMPTY=true");
+    assert_eq!(
+        admins, 0,
+        "fixture admins must not be seeded without SEED_ON_EMPTY=true"
+    );
 }
 
 #[tokio::test]

--- a/tests/ingestion_integration.rs
+++ b/tests/ingestion_integration.rs
@@ -3,9 +3,9 @@
 //! Exercises `src/ingestion.rs` end-to-end against an in-memory SurrealDB
 //! seeded with fixtures, avoiding the Axum router and Green API entirely.
 
-use poolpay::api::models::{DbGroupLink, DbReceipt, GroupLinkContent, now_iso};
+use poolpay::api::models::{now_iso, DbGroupLink, DbReceipt, GroupLinkContent};
 use poolpay::db::{self, DbConn};
-use poolpay::ingestion::{IngestionInput, IngestionOutcome, ingest_receipt};
+use poolpay::ingestion::{ingest_receipt, IngestionInput, IngestionOutcome};
 use poolpay::models::ParsedReceipt;
 
 const FIXTURE_CHAT_ID: &str = "2349000000001@g.us";

--- a/tests/routing_integration.rs
+++ b/tests/routing_integration.rs
@@ -5,7 +5,7 @@
 //! go through the Axum router, so they isolate query behaviour from
 //! handler/auth concerns.
 
-use poolpay::api::models::{DbGroupLink, EntityId, GroupLinkContent, now_iso};
+use poolpay::api::models::{now_iso, DbGroupLink, EntityId, GroupLinkContent};
 use poolpay::db::{self, DbConn};
 use poolpay::routing::{
     find_active_cycle, find_group_by_chat_id, find_member_by_phone, find_receipt_by_message_id,
@@ -97,9 +97,7 @@ async fn member_by_phone_returns_match_in_group() {
 async fn member_by_phone_returns_none_for_unknown_phone() {
     let db = fresh_db().await;
     let group_id: EntityId = FIXTURE_GROUP_ID.into();
-    let m = find_member_by_phone(&db, &group_id, "999")
-        .await
-        .unwrap();
+    let m = find_member_by_phone(&db, &group_id, "999").await.unwrap();
     assert!(m.is_none());
 }
 

--- a/tests/webhook_integration.rs
+++ b/tests/webhook_integration.rs
@@ -62,7 +62,7 @@ async fn webhook_app() -> Router {
 /// `LINKED_CHAT_ID` → group `1` (and therefore can find the seeded members).
 /// Without this, every ingest path would short-circuit on `NotLinked`.
 async fn seed_link(db: &poolpay::db::DbConn) {
-    use poolpay::api::models::{GroupLinkContent, now_iso};
+    use poolpay::api::models::{now_iso, GroupLinkContent};
     let now = now_iso();
     let content = GroupLinkContent {
         chat_id: LINKED_CHAT_ID.into(),
@@ -71,8 +71,11 @@ async fn seed_link(db: &poolpay::db::DbConn) {
         updated_at: now,
         deleted_at: None,
     };
-    let _: Option<poolpay::api::models::DbGroupLink> =
-        db.create("group_link").content(content).await.expect("seed group_link");
+    let _: Option<poolpay::api::models::DbGroupLink> = db
+        .create("group_link")
+        .content(content)
+        .await
+        .expect("seed group_link");
 }
 
 fn now_ts() -> i64 {
@@ -130,7 +133,11 @@ fn payload_matching_member(message_id: &str) -> serde_json::Value {
 #[tokio::test]
 async fn webhook_valid_hmac_ingests_returns_200() {
     let app = webhook_app().await;
-    let resp = call(app, signed_request(&payload_matching_member("WAMSG-VALID-1"))).await;
+    let resp = call(
+        app,
+        signed_request(&payload_matching_member("WAMSG-VALID-1")),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
     let body: serde_json::Value = json_body(resp).await;
     assert_eq!(body["outcome"], "ingested");
@@ -285,7 +292,10 @@ async fn webhook_duplicate_message_id_is_idempotent() {
     assert_eq!(second.status(), StatusCode::OK);
     let s: serde_json::Value = json_body(second).await;
     assert_eq!(s["outcome"], "duplicate");
-    assert!(s["receiptId"].is_null(), "duplicate must not echo a receipt id");
+    assert!(
+        s["receiptId"].is_null(),
+        "duplicate must not echo a receipt id"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Five atomic commits, all configuration-only — no runtime behaviour change.

| Commit | What | Why |
|---|---|---|
| `[CONFIG] - Add dev profile and dep opt-level tweaks` | `profile.dev`, `profile.test`: `debug = "line-tables-only"` + `profile.dev.package."*"`: `opt-level = 1` | ~20–30% faster incremental dev builds; deps compile once with mild opt and stay cached |
| `[CONFIG] - Ignore target.noindex` | `/target.noindex` in `.gitignore` | macOS Spotlight workaround — keeps build artefacts unindexed but still local-only |
| `[CONFIG] - Pin rustfmt style` | `rustfmt.toml` (edition, max_width, indent, etc.) | Prevents cross-machine and cross-agent fmt drift — saw this leak into the webhook-audit branches |
| `[CONFIG] - Pin rust-toolchain to 1.93.1` | `rust-toolchain.toml` with `rustfmt`, `clippy` components | rustup auto-honours this; CI + dev machines use identical compiler + components |
| `[CONFIG] - Add CI workflow` | `.github/workflows/ci.yml` running fmt-check + clippy + build + test on every PR | First automated check pipeline on this repo |

## Why now
- The webhook-audit work just shipped three PRs (#55, #56, #57) with **no automated regression coverage**. CI closes that gap going forward.
- Cross-agent fmt drift caused commit-noise during the audit. Pinning `rustfmt` makes it deterministic.
- Multiple worktrees were duplicating build work this session. Profile tweaks + (locally configured) sccache reduce that.

## Out of scope (already done locally, not in PR)
- `sccache` was installed (`brew install sccache`) and wired into `~/.cargo/config.toml` as a global `rustc-wrapper`. Affects every Rust project on this machine; no project file change.

## Not done — deliberately
- **Workspace crate split**: codebase is still small enough that the per-crate compilation tax would outweigh incremental gains. Revisit if/when the binary outgrows the current shape (current Cargo.toml is ~88 lines, 596 transitive deps).
- **`mold`/`lld` linker**: macOS 26's `ld64` got fast enough that swapping linkers isn't an obvious win — would benchmark before adding.
- **`cargo-nextest`**: nice-to-have, but tests already run in ~8 sec — not the bottleneck right now.

## Test plan
- [ ] First CI run on this PR is green (this is the first time CI will ever run on this repo — expect to iterate if the lint baseline isn't clean)
- [ ] Local `cargo build` still works after the profile tweaks
- [ ] `cargo fmt --check` passes against the pinned `rustfmt.toml`