### PR TITLE
[FEAT] - Seed dev-only member fixture user linked to fixture pool member

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -485,6 +485,7 @@ pub async fn create_member(
         updated_at: now,
         deleted_at: None,
         version: 1,
+        user_id: None,
     };
 
     let db_member: Option<DbMember> = db.create("member").content(content).await?;
@@ -552,6 +553,7 @@ pub async fn update_member(
         updated_at: now_iso(),
         deleted_at: existing.deleted_at,
         version: existing.version + 1,
+        user_id: existing.user_id,
     };
 
     let updated: Option<DbMember> = db.upsert(("member", id.as_str())).content(content).await?;
@@ -602,6 +604,7 @@ pub async fn delete_member(
         updated_at: now.clone(),
         deleted_at: Some(now),
         version: existing.version + 1,
+        user_id: existing.user_id,
     };
     let _: Option<DbMember> = db.upsert(("member", id.as_str())).content(content).await?;
 

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -289,6 +289,8 @@ pub struct DbMember {
     pub updated_at: String,
     pub deleted_at: Option<String>,
     pub version: i64,
+    #[surreal(default)]
+    pub user_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, SurrealValue)]
@@ -725,6 +727,8 @@ pub struct MemberContent {
     pub updated_at: String,
     pub deleted_at: Option<String>,
     pub version: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, SurrealValue)]

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -727,7 +727,7 @@ pub struct MemberContent {
     pub updated_at: String,
     pub deleted_at: Option<String>,
     pub version: i64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
 }
 

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -635,15 +635,15 @@ async fn ensure_pool_member_link(
         .bind(("now", now_iso()))
         .await?
         .check()?;
-    let updated: Vec<DbMember> = resp
-        .take(0)
-        .expect("ensure_pool_member_link: failed to decode UPDATE response");
+    let updated: Vec<DbMember> = resp.take(0)?;
 
     if updated.is_empty() {
         // Either the link was already correct (idempotent silent success),
-        // or the row is soft-deleted / missing. Do a best-effort select to
-        // produce a more informative log line; if that secondary read fails
-        // we still return Ok — the fixture seed path is best-effort.
+        // or the row is soft-deleted / missing. Do a follow-up select to
+        // produce a more informative log line. Any error from the UPDATE
+        // decode or this select propagates via `?` to the caller
+        // (`seed_dummy_fixtures_with_flag`), which logs and continues
+        // without aborting startup.
         let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
         match member {
             Some(m) if m.user_id.as_deref() == Some(user_id) => {

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -7,8 +7,8 @@ use surrealdb::types::RecordId;
 use tracing::{info, warn};
 
 use crate::api::models::{
-    now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbUser,
-    DbUserIdentity, GroupAdminContent, UserContent, UserIdentityContent,
+    now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbMember,
+    DbUser, DbUserIdentity, GroupAdminContent, UserContent, UserIdentityContent,
 };
 use crate::auth::password;
 use crate::db::{is_unique_constraint_error, DbConn, FIXTURE_GROUP_ID};
@@ -21,10 +21,12 @@ const CREDENTIALS_PROVIDER: &str = "credentials";
 /// production boots cannot accidentally plant it.
 const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
 
-/// Declarative spec for the dev-only fixture admin accounts. Each row pairs
-/// an email with its role and whether to receive a `group_admin` grant on
-/// `FIXTURE_GROUP_ID` — lets us cover every role × grant combination the
-/// admin UI can render without branching inside the seed loop.
+/// Declarative spec for the dev-only fixture user accounts. Each row pairs
+/// an email with its role, whether to receive a `group_admin` grant on
+/// `FIXTURE_GROUP_ID`, and an optional `member` row id to stamp `user_id`
+/// onto — lets us cover every role × grant × pool-membership combination
+/// the admin UI and member dashboard can render without branching inside
+/// the seed loop.
 ///
 /// Current matrix:
 /// - admin1: `admin` + FIXTURE_GROUP_ID grant — typical group admin.
@@ -34,32 +36,50 @@ const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
 ///   the bootstrap account.
 /// - admin4: `admin`, no grant — stable "orphan admin" baseline that stays
 ///   ungranted even after admin2 gets manually granted during testing.
+/// - member1: `member`, no grant, linked to fixture pool member `1`
+///   (Adaeze Okonkwo) so the auth identity fronts a real pool participant
+///   with cycles + payments visible to the member dashboard.
 struct DummyAdmin {
     email: &'static str,
     role: &'static str,
     grant_fixture_group: bool,
+    /// When `Some(member_id)`, stamps the seeded user's id onto that
+    /// fixture row in the `member` table after the user is created. Only
+    /// the `member` role uses this today; admin/super_admin fixtures
+    /// leave it `None`.
+    link_pool_member_id: Option<&'static str>,
 }
 
-const DUMMY_ADMINS: [DummyAdmin; 4] = [
+const DUMMY_ADMINS: [DummyAdmin; 5] = [
     DummyAdmin {
         email: "admin1@poolpay.test",
         role: "admin",
         grant_fixture_group: true,
+        link_pool_member_id: None,
     },
     DummyAdmin {
         email: "admin2@poolpay.test",
         role: "admin",
         grant_fixture_group: false,
+        link_pool_member_id: None,
     },
     DummyAdmin {
         email: "admin3@poolpay.test",
         role: "super_admin",
         grant_fixture_group: false,
+        link_pool_member_id: None,
     },
     DummyAdmin {
         email: "admin4@poolpay.test",
         role: "admin",
         grant_fixture_group: false,
+        link_pool_member_id: None,
+    },
+    DummyAdmin {
+        email: "member1@poolpay.test",
+        role: "member",
+        grant_fixture_group: false,
+        link_pool_member_id: Some("1"),
     },
 ];
 
@@ -167,19 +187,17 @@ fn redact(email: &str) -> String {
     }
 }
 
-/// Dev-only: seed two fixture admin users so the admin-management UI has
-/// clickable targets without forcing manual `POST /api/admin/users` calls.
+/// Dev-only: seed the fixture admin + member users so both the admin
+/// management UI and the member dashboard have clickable targets without
+/// forcing manual `POST /api/admin/users` calls or social-signup flows.
 ///
-/// - `admin1@poolpay.test` — active admin with a `group_admin` grant on
-///   fixture group `1` (exercises the group-scoped extractor path).
-/// - `admin2@poolpay.test` — active admin with no grants (exercises the
-///   "grant a new group" flow).
-///
-/// Both use `must_reset_password: false` so login is one-shot, unlike the
-/// bootstrap super-admin. Idempotent on every email: a restart re-checks
-/// `user_identity`, skips already-present rows, and re-asserts admin1's
-/// fixture grant even when the user already existed (so a manual
-/// `group_admin` delete is restored by a restart). Gated on
+/// See `DUMMY_ADMINS` for the full matrix. All accounts share
+/// `DUMMY_ADMIN_PASSWORD` and use `must_reset_password: false` so login is
+/// one-shot, unlike the bootstrap super-admin. Idempotent on every email:
+/// a restart re-checks `user_identity`, skips already-present rows, and
+/// re-asserts every per-user side-effect (admin1's `group_admin` grant on
+/// fixture group `1`, member1's `user_id` stamp on fixture pool member
+/// `1`) so manual cleanup between restarts is restored. Gated on
 /// `SEED_ON_EMPTY=true` **and** `APP_ENV` ∈ {`development`, `test`} so any
 /// other deploy — including unset `APP_ENV` — fails closed. This mirrors
 /// the `/api/test/reset` gate in `src/api/mod.rs`.
@@ -233,13 +251,21 @@ pub async fn seed_dummy_admins_with_flag(
             &super_admin_id,
         )
         .await?;
+        // If the user couldn't be produced (skip case from
+        // `ensure_admin_fixture`), there's nothing to grant or link to.
+        let Some(user_id) = user_id else { continue };
         // Re-asserting the grant on every run (not just when the user was
         // created this run) restores it after manual cleanup / partial prior
         // runs; `ensure_group_admin_grant` is idempotent on unique conflict.
         if spec.grant_fixture_group {
-            if let Some(user_id) = user_id {
-                ensure_group_admin_grant(db, &user_id, FIXTURE_GROUP_ID, &super_admin_id).await?;
-            }
+            ensure_group_admin_grant(db, &user_id, FIXTURE_GROUP_ID, &super_admin_id).await?;
+        }
+        // Mirror the grant re-assertion above: stamp `user_id` onto the
+        // linked pool member row on every restart so manual cleanup that
+        // cleared the link is restored. The helper is idempotent — writing
+        // the same `user_id` twice is a no-op on the row.
+        if let Some(pool_member_id) = spec.link_pool_member_id {
+            ensure_pool_member_link(db, &user_id, pool_member_id).await?;
         }
     }
     Ok(())
@@ -275,10 +301,11 @@ async fn ensure_admin_fixture(
     // `DUMMY_ADMINS` `const`, but guard against a typo slipping in during
     // future edits so a bogus role can't be silently written to `user.role`
     // (where extractors + admin_users UPDATE queries compare against the
-    // exact strings `"admin"` / `"super_admin"`).
+    // exact strings `"admin"` / `"super_admin"` / `"member"` — matches the
+    // DB-level ASSERT in `db::define_user_table`).
     assert!(
-        matches!(role, "admin" | "super_admin"),
-        "fixture admin role must be 'admin' or 'super_admin', got {role:?}"
+        matches!(role, "admin" | "super_admin" | "member"),
+        "fixture user role must be 'admin', 'super_admin', or 'member', got {role:?}"
     );
     let email_normalised = email.to_lowercase();
 
@@ -304,7 +331,7 @@ async fn ensure_admin_fixture(
             Some(u)
                 if u.deleted_at.is_none()
                     && u.status == "active"
-                    && matches!(u.role.as_str(), "admin" | "super_admin") =>
+                    && matches!(u.role.as_str(), "admin" | "super_admin" | "member") =>
             {
                 // Reconcile drift: if the fixture spec now declares a role
                 // different from what's persisted (e.g. admin3 was demoted
@@ -320,12 +347,12 @@ async fn ensure_admin_fixture(
                         user_id = identity.user_id.as_str(),
                         from = u.role.as_str(),
                         to = role,
-                        "fixture admin role drifted from spec — reconciled"
+                        "fixture user role drifted from spec — reconciled"
                     );
                 } else {
                     info!(
                         email_redacted = redact(email),
-                        "fixture admin already seeded — reusing user_id"
+                        "fixture user already seeded — reusing user_id"
                     );
                 }
                 Ok(Some(identity.user_id))
@@ -334,7 +361,7 @@ async fn ensure_admin_fixture(
                 warn!(
                     email_redacted = redact(email),
                     user_id = identity.user_id.as_str(),
-                    "fixture admin identity points at a disabled/non-admin user — skipping grant"
+                    "fixture user identity points at a disabled/out-of-spec user — skipping grant"
                 );
                 Ok(None)
             }
@@ -571,4 +598,57 @@ async fn ensure_group_admin_grant(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Stamp `user_id` onto a fixture row in the `member` table so a seeded
+/// auth user fronts a real pool participant. Idempotent: writing the same
+/// `user_id` twice is a no-op on the row, and the helper bails cleanly
+/// when the target member row is missing or soft-deleted (e.g. a partial
+/// DB where `db::seed()` didn't run).
+///
+/// The `member` table is SCHEMALESS, so adding `user_id` here doesn't
+/// require a schema migration. Mirrors `ensure_group_admin_grant`: the
+/// linked state is re-asserted on every restart so manual cleanup between
+/// boots is restored without dropping data.
+async fn ensure_pool_member_link(
+    db: &DbConn,
+    user_id: &str,
+    pool_member_id: &str,
+) -> Result<(), surrealdb::Error> {
+    let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
+    if member.filter(|m| m.deleted_at.is_none()).is_none() {
+        info!(
+            pool_member_id,
+            "fixture pool member missing or deleted — skipping user_id link"
+        );
+        return Ok(());
+    }
+
+    // Capture the UPDATE result so a zero-rows write (the pool member was
+    // soft-deleted between the pre-flight `select` above and the UPDATE,
+    // i.e. TOCTOU) doesn't masquerade as a successful link in the logs.
+    // The `WHERE deleted_at IS NONE` guard is intentional defence-in-depth
+    // so a racing soft-delete can't be silently overwritten — but it also
+    // means the UPDATE can no-op without erroring, hence this check.
+    let mut resp = db
+        .query("UPDATE $mid SET user_id = $uid, updated_at = $now WHERE deleted_at IS NONE")
+        .bind(("mid", RecordId::new("member", pool_member_id.to_string())))
+        .bind(("uid", user_id.to_string()))
+        .bind(("now", now_iso()))
+        .await?
+        .check()?;
+    let updated: Vec<DbMember> = resp.take(0).unwrap_or_default();
+    if updated.is_empty() {
+        warn!(
+            user_id,
+            pool_member_id,
+            "fixture pool member vanished between pre-flight select and UPDATE — link skipped"
+        );
+        return Ok(());
+    }
+    info!(
+        user_id,
+        pool_member_id, "fixture pool member linked to fixture user"
+    );
+    Ok(())
 }

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -16,10 +16,10 @@ use crate::db::{is_unique_constraint_error, DbConn, FIXTURE_GROUP_ID};
 const BOOTSTRAP_EVENT_TYPE: &str = "bootstrap_admin_created";
 const CREDENTIALS_PROVIDER: &str = "credentials";
 
-/// Dev-only fixture password for `seed_dummy_admins`. Only applied when
+/// Dev-only fixture password for `seed_dummy_fixtures`. Only applied when
 /// `SEED_ON_EMPTY=true` **and** `APP_ENV` is `development` or `test`, so
 /// production boots cannot accidentally plant it.
-const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
+const DUMMY_FIXTURE_PASSWORD: &str = "PoolPayQA2026!";
 
 /// Declarative spec for the dev-only fixture user accounts. Each row pairs
 /// an email with its role, whether to receive a `group_admin` grant on
@@ -39,7 +39,7 @@ const DUMMY_ADMIN_PASSWORD: &str = "PoolPayQA2026!";
 /// - member1: `member`, no grant, linked to fixture pool member `1`
 ///   (Adaeze Okonkwo) so the auth identity fronts a real pool participant
 ///   with cycles + payments visible to the member dashboard.
-struct DummyAdmin {
+struct DummyFixtureUser {
     email: &'static str,
     role: &'static str,
     grant_fixture_group: bool,
@@ -50,32 +50,32 @@ struct DummyAdmin {
     link_pool_member_id: Option<&'static str>,
 }
 
-const DUMMY_ADMINS: [DummyAdmin; 5] = [
-    DummyAdmin {
+const DUMMY_FIXTURE_USERS: [DummyFixtureUser; 5] = [
+    DummyFixtureUser {
         email: "admin1@poolpay.test",
         role: "admin",
         grant_fixture_group: true,
         link_pool_member_id: None,
     },
-    DummyAdmin {
+    DummyFixtureUser {
         email: "admin2@poolpay.test",
         role: "admin",
         grant_fixture_group: false,
         link_pool_member_id: None,
     },
-    DummyAdmin {
+    DummyFixtureUser {
         email: "admin3@poolpay.test",
         role: "super_admin",
         grant_fixture_group: false,
         link_pool_member_id: None,
     },
-    DummyAdmin {
+    DummyFixtureUser {
         email: "admin4@poolpay.test",
         role: "admin",
         grant_fixture_group: false,
         link_pool_member_id: None,
     },
-    DummyAdmin {
+    DummyFixtureUser {
         email: "member1@poolpay.test",
         role: "member",
         grant_fixture_group: false,
@@ -187,12 +187,12 @@ fn redact(email: &str) -> String {
     }
 }
 
-/// Dev-only: seed the fixture admin + member users so both the admin
-/// management UI and the member dashboard have clickable targets without
-/// forcing manual `POST /api/admin/users` calls or social-signup flows.
+/// Dev-only: seed the fixture users so both the admin management UI and
+/// the member dashboard have clickable targets without forcing manual
+/// `POST /api/admin/users` calls or social-signup flows.
 ///
-/// See `DUMMY_ADMINS` for the full matrix. All accounts share
-/// `DUMMY_ADMIN_PASSWORD` and use `must_reset_password: false` so login is
+/// See `DUMMY_FIXTURE_USERS` for the full matrix. All accounts share
+/// `DUMMY_FIXTURE_PASSWORD` and use `must_reset_password: false` so login is
 /// one-shot, unlike the bootstrap super-admin. Idempotent on every email:
 /// a restart re-checks `user_identity`, skips already-present rows, and
 /// re-asserts every per-user side-effect (admin1's `group_admin` grant on
@@ -201,28 +201,28 @@ fn redact(email: &str) -> String {
 /// `SEED_ON_EMPTY=true` **and** `APP_ENV` ∈ {`development`, `test`} so any
 /// other deploy — including unset `APP_ENV` — fails closed. This mirrors
 /// the `/api/test/reset` gate in `src/api/mod.rs`.
-pub async fn seed_dummy_admins(db: &DbConn) -> Result<(), surrealdb::Error> {
+pub async fn seed_dummy_fixtures(db: &DbConn) -> Result<(), surrealdb::Error> {
     let flag_enabled = std::env::var("SEED_ON_EMPTY").as_deref() == Ok("true");
     let env_allows_fixtures = matches!(
         std::env::var("APP_ENV").as_deref(),
         Ok("development" | "test")
     );
-    seed_dummy_admins_with_flag(db, flag_enabled && env_allows_fixtures).await
+    seed_dummy_fixtures_with_flag(db, flag_enabled && env_allows_fixtures).await
 }
 
 /// Internal entry point that takes an explicit boolean instead of reading
-/// process env. `seed_dummy_admins` calls this after evaluating the
+/// process env. `seed_dummy_fixtures` calls this after evaluating the
 /// `SEED_ON_EMPTY` + `APP_ENV` gates; tests call it directly so they never
 /// have to mutate env vars at runtime (which would race with concurrent
 /// `std::env::var` reads elsewhere in the suite).
 ///
 /// Marked `#[doc(hidden)]` — `pub` is required because integration tests
 /// live in the external `tests/` crate, but it must not be treated as part
-/// of the public surface. Production code should call `seed_dummy_admins`
+/// of the public surface. Production code should call `seed_dummy_fixtures`
 /// so the env-based safety gates are always evaluated. Mirrors the pattern
 /// used by `auth::hmac::sign_for_testing`.
 #[doc(hidden)]
-pub async fn seed_dummy_admins_with_flag(
+pub async fn seed_dummy_fixtures_with_flag(
     db: &DbConn,
     enabled: bool,
 ) -> Result<(), surrealdb::Error> {
@@ -237,22 +237,22 @@ pub async fn seed_dummy_admins_with_flag(
     let super_admin_id = match find_super_admin_id(db).await? {
         Some(id) => id,
         None => {
-            info!("seed_dummy_admins: no super-admin present — skipping");
+            info!("seed_dummy_fixtures: no super-admin present — skipping");
             return Ok(());
         }
     };
 
-    for spec in DUMMY_ADMINS.iter() {
-        let user_id = ensure_admin_fixture(
+    for spec in DUMMY_FIXTURE_USERS.iter() {
+        let user_id = ensure_fixture_user(
             db,
             spec.email,
-            DUMMY_ADMIN_PASSWORD,
+            DUMMY_FIXTURE_PASSWORD,
             spec.role,
             &super_admin_id,
         )
         .await?;
         // If the user couldn't be produced (skip case from
-        // `ensure_admin_fixture`), there's nothing to grant or link to.
+        // `ensure_fixture_user`), there's nothing to grant or link to.
         let Some(user_id) = user_id else { continue };
         // Re-asserting the grant on every run (not just when the user was
         // created this run) restores it after manual cleanup / partial prior
@@ -284,13 +284,13 @@ async fn find_super_admin_id(db: &DbConn) -> Result<Option<String>, surrealdb::E
     Ok(users.into_iter().next().map(|u| record_id_to_string(u.id)))
 }
 
-/// Returns the fixture admin's user id whether the row was inserted this
+/// Returns the fixture user's user id whether the row was inserted this
 /// run or already existed. Callers use this id to re-assert follow-up
 /// writes (like admin1's `group_admin` grant) so idempotency holds even
 /// when the user row survived but a grant was manually deleted. `Ok(None)`
 /// is reserved for skip cases where we could not produce a usable id
 /// (e.g. password hash failed, `create` returned no record).
-async fn ensure_admin_fixture(
+async fn ensure_fixture_user(
     db: &DbConn,
     email: &str,
     password_plain: &str,
@@ -298,7 +298,7 @@ async fn ensure_admin_fixture(
     super_admin_id: &str,
 ) -> Result<Option<String>, surrealdb::Error> {
     // Defence-in-depth: `role` is only ever sourced from the in-module
-    // `DUMMY_ADMINS` `const`, but guard against a typo slipping in during
+    // `DUMMY_FIXTURE_USERS` `const`, but guard against a typo slipping in during
     // future edits so a bogus role can't be silently written to `user.role`
     // (where extractors + admin_users UPDATE queries compare against the
     // exact strings `"admin"` / `"super_admin"` / `"member"` — matches the
@@ -369,7 +369,7 @@ async fn ensure_admin_fixture(
                 warn!(
                     email_redacted = redact(email),
                     user_id = identity.user_id.as_str(),
-                    "fixture admin identity points at a missing user — skipping grant"
+                    "fixture user identity points at a missing user — skipping grant"
                 );
                 Ok(None)
             }
@@ -382,7 +382,7 @@ async fn ensure_admin_fixture(
             warn!(
                 error = ?e,
                 email_redacted = redact(email),
-                "fixture admin hash failed — skipping"
+                "fixture user hash failed — skipping"
             );
             return Ok(None);
         }
@@ -411,7 +411,7 @@ async fn ensure_admin_fixture(
         None => {
             warn!(
                 email_redacted = redact(email),
-                "fixture admin create returned no record — skipping"
+                "fixture user create returned no record — skipping"
             );
             return Ok(None);
         }
@@ -436,7 +436,7 @@ async fn ensure_admin_fixture(
             warn!(
                 email_redacted = redact(email),
                 user_id = user_id.as_str(),
-                "fixture admin identity create returned no record — rolling back user"
+                "fixture user identity create returned no record — rolling back user"
             );
             rollback_fixture_user(db, &user_id).await;
             return Ok(None);
@@ -446,7 +446,7 @@ async fn ensure_admin_fixture(
                 email_redacted = redact(email),
                 user_id = user_id.as_str(),
                 error = %e,
-                "fixture admin identity create failed — rolling back user"
+                "fixture user identity create failed — rolling back user"
             );
             rollback_fixture_user(db, &user_id).await;
             return Err(e);
@@ -466,18 +466,18 @@ async fn ensure_admin_fixture(
     // Fixture seeding must not fail startup on a transient audit-write
     // error. The user + identity rows are already persisted, so degrade to
     // a warn-and-continue on audit issues — matches the best-effort
-    // contract documented on `seed_dummy_admins`.
+    // contract documented on `seed_dummy_fixtures`.
     let audit_result: Result<Option<DbAuthEvent>, _> = db.create("auth_event").content(event).await;
     if let Err(e) = audit_result {
         warn!(
             email_redacted = redact(email),
             user_id = user_id.as_str(),
             error = %e,
-            "fixture admin auth_event insert failed — continuing"
+            "fixture user auth_event insert failed — continuing"
         );
     }
 
-    info!(email_redacted = redact(email), "fixture admin created");
+    info!(email_redacted = redact(email), "fixture user created");
     Ok(Some(user_id))
 }
 
@@ -491,14 +491,14 @@ async fn rollback_fixture_user(db: &DbConn, user_id: &str) {
         warn!(
             error = %e,
             user_id,
-            "fixture admin rollback failed after identity error — orphan user row"
+            "fixture user rollback failed after identity error — orphan user row"
         );
     }
 }
 
-/// Reconcile a persisted fixture admin's role to the spec. Used when
-/// `ensure_admin_fixture` detects that `user.role` has drifted from the
-/// `DUMMY_ADMINS` entry (typically because the UI was used to promote or
+/// Reconcile a persisted fixture user's role to the spec. Used when
+/// `ensure_fixture_user` detects that `user.role` has drifted from the
+/// `DUMMY_FIXTURE_USERS` entry (typically because the UI was used to promote or
 /// demote the fixture between restarts). Bumps `version` (OCC) and
 /// `token_version` (invalidates cached access tokens) to match the
 /// semantics of the real `PATCH /api/admin/users/:id` role-change path.

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -635,14 +635,16 @@ async fn ensure_pool_member_link(
         .bind(("now", now_iso()))
         .await?
         .check()?;
-    let updated: Vec<DbMember> = resp.take(0).unwrap_or_default();
+    let updated: Vec<DbMember> = resp
+        .take(0)
+        .expect("ensure_pool_member_link: failed to decode UPDATE response");
 
     if updated.is_empty() {
         // Either the link was already correct (idempotent silent success),
         // or the row is soft-deleted / missing. Do a best-effort select to
         // produce a more informative log line; if that secondary read fails
         // we still return Ok — the fixture seed path is best-effort.
-        let member: Option<DbMember> = db.select(("member", pool_member_id)).await.unwrap_or(None);
+        let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
         match member {
             Some(m) if m.user_id.as_deref() == Some(user_id) => {
                 // Already linked — nothing to do.

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use crate::api::models::{
     now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbMember,
-    DbUser, DbUserIdentity, GroupAdminContent, UserContent, UserIdentityContent,
+    DbUser, DbUserIdentity, GroupAdminContent, MemberContent, UserContent, UserIdentityContent,
 };
 use crate::auth::password;
 use crate::db::{is_unique_constraint_error, DbConn, FIXTURE_GROUP_ID};
@@ -302,7 +302,7 @@ async fn ensure_fixture_user(
     // future edits so a bogus role can't be silently written to `user.role`
     // (where extractors + admin_users UPDATE queries compare against the
     // exact strings `"admin"` / `"super_admin"` / `"member"` — matches the
-    // DB-level ASSERT in `db::define_user_table`).
+    // DB-level ASSERT in `db::define_user_table`.
     assert!(
         matches!(role, "admin" | "super_admin" | "member"),
         "fixture user role must be 'admin', 'super_admin', or 'member', got {role:?}"
@@ -361,7 +361,7 @@ async fn ensure_fixture_user(
                 warn!(
                     email_redacted = redact(email),
                     user_id = identity.user_id.as_str(),
-                    "fixture user identity points at a disabled/out-of-spec user — skipping grant"
+                    "fixture user identity points at a disabled/out-of-spec user — skipping fixture side-effects"
                 );
                 Ok(None)
             }
@@ -369,7 +369,7 @@ async fn ensure_fixture_user(
                 warn!(
                     email_redacted = redact(email),
                     user_id = identity.user_id.as_str(),
-                    "fixture user identity points at a missing user — skipping grant"
+                    "fixture user identity points at a missing user — skipping fixture side-effects"
                 );
                 Ok(None)
             }
@@ -601,48 +601,72 @@ async fn ensure_group_admin_grant(
 }
 
 /// Stamp `user_id` onto a fixture row in the `member` table so a seeded
-/// auth user fronts a real pool participant. Idempotent: writing the same
-/// `user_id` twice is a no-op on the row, and the helper bails cleanly
-/// when the target member row is missing or soft-deleted (e.g. a partial
-/// DB where `db::seed()` didn't run).
+/// auth user fronts a real pool participant. Truly idempotent: if the link
+/// is already correct the function returns without touching the row. Bails
+/// cleanly when the target member row is missing or soft-deleted (e.g. a
+/// partial DB where `db::seed()` didn't run).
 ///
-/// The `member` table is SCHEMALESS, so adding `user_id` here doesn't
-/// require a schema migration. Mirrors `ensure_group_admin_grant`: the
-/// linked state is re-asserted on every restart so manual cleanup between
-/// boots is restored without dropping data.
+/// Uses the typed `MemberContent` upsert path so the link survives future
+/// admin API updates of the member row — full-record replacement preserves
+/// `user_id` rather than silently dropping it as a raw `UPDATE` would if
+/// the schema is later enforced. Mirrors the OCC pattern (`version + 1`)
+/// used by every other member write path.
 async fn ensure_pool_member_link(
     db: &DbConn,
     user_id: &str,
     pool_member_id: &str,
 ) -> Result<(), surrealdb::Error> {
     let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
-    if member.filter(|m| m.deleted_at.is_none()).is_none() {
-        info!(
-            pool_member_id,
-            "fixture pool member missing or deleted — skipping user_id link"
-        );
+    let member = match member {
+        Some(m) if m.deleted_at.is_none() => m,
+        _ => {
+            info!(
+                pool_member_id,
+                "fixture pool member missing or deleted — skipping user_id link"
+            );
+            return Ok(());
+        }
+    };
+
+    // True idempotency: if the link is already correct, skip the write so
+    // `updated_at` and `version` are not bumped unnecessarily on every boot.
+    if member.user_id.as_deref() == Some(user_id) {
         return Ok(());
     }
 
-    // Capture the UPDATE result so a zero-rows write (the pool member was
-    // soft-deleted between the pre-flight `select` above and the UPDATE,
-    // i.e. TOCTOU) doesn't masquerade as a successful link in the logs.
-    // The `WHERE deleted_at IS NONE` guard is intentional defence-in-depth
-    // so a racing soft-delete can't be silently overwritten — but it also
-    // means the UPDATE can no-op without erroring, hence this check.
-    let mut resp = db
-        .query("UPDATE $mid SET user_id = $uid, updated_at = $now WHERE deleted_at IS NONE")
-        .bind(("mid", RecordId::new("member", pool_member_id.to_string())))
-        .bind(("uid", user_id.to_string()))
-        .bind(("now", now_iso()))
-        .await?
-        .check()?;
-    let updated: Vec<DbMember> = resp.take(0).unwrap_or_default();
-    if updated.is_empty() {
+    // Build a fresh content record preserving every existing field, then
+    // set the new `user_id` and bump version (OCC) + updated_at. Use the
+    // typed upsert path so future full-record replacements via the admin API
+    // also carry `user_id` forward and never silently drop the linkage.
+    let now = now_iso();
+    let content = MemberContent {
+        name: member.name,
+        phone: member.phone,
+        position: member.position,
+        status: member.status,
+        group_id: member.group_id,
+        notes: member.notes,
+        joined_at: member.joined_at,
+        created_at: member.created_at,
+        updated_at: now,
+        deleted_at: member.deleted_at,
+        version: member.version + 1,
+        user_id: Some(user_id.to_string()),
+    };
+
+    // TOCTOU guard: if the member was soft-deleted between the pre-flight
+    // select and this upsert, the upsert will still write (upsert has no
+    // WHERE guard). Accepting that narrow race is consistent with the rest
+    // of the fixture seed path which is best-effort and development-only.
+    let updated: Option<DbMember> = db
+        .upsert(("member", pool_member_id))
+        .content(content)
+        .await?;
+    if updated.is_none() {
         warn!(
             user_id,
             pool_member_id,
-            "fixture pool member vanished between pre-flight select and UPDATE — link skipped"
+            "fixture pool member upsert returned no record — link skipped"
         );
         return Ok(());
     }

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -323,9 +323,10 @@ async fn ensure_fixture_user(
         // Don't blindly trust the identity pointer — the underlying `user`
         // row may have been soft-deleted or disabled via the admin UI since
         // the fixture was first seeded. Reusing a stale pointer would let
-        // `ensure_group_admin_grant` award a grant to a non-admin, and
-        // silently mask a broken fixture. Verify the user is still an
-        // active admin before returning its id.
+        // `ensure_group_admin_grant` award a grant to an out-of-spec user,
+        // and silently mask a broken fixture. Verify the user is still an
+        // active, non-deleted, in-spec fixture user (admin / super_admin /
+        // member) before returning its id.
         let linked: Option<DbUser> = db.select(("user", identity.user_id.as_str())).await?;
         return match linked {
             Some(u)

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -641,9 +641,11 @@ async fn ensure_pool_member_link(
         // Either the link was already correct (idempotent silent success),
         // or the row is soft-deleted / missing. Do a follow-up select to
         // produce a more informative log line. Any error from the UPDATE
-        // decode or this select propagates via `?` to the caller
-        // (`seed_dummy_fixtures_with_flag`), which logs and continues
-        // without aborting startup.
+        // decode or this select propagates via `?` up the seed call chain
+        // (`seed_dummy_fixtures_with_flag` → `seed_dummy_fixtures`) to
+        // `main`, which logs the error and continues without aborting
+        // startup — preserves error visibility while honouring the
+        // best-effort fixture-seed contract.
         let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
         match member {
             Some(m) if m.user_id.as_deref() == Some(user_id) => {

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -656,7 +656,6 @@ async fn ensure_pool_member_link(
                     pool_member_id,
                     "fixture pool member is soft-deleted — skipping user_id link"
                 );
-                let _ = m; // suppress unused warning
             }
             None => {
                 info!(

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -665,8 +665,7 @@ async fn ensure_pool_member_link(
     if updated.is_none() {
         warn!(
             user_id,
-            pool_member_id,
-            "fixture pool member upsert returned no record — link skipped"
+            pool_member_id, "fixture pool member upsert returned no record — link skipped"
         );
         return Ok(());
     }

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use crate::api::models::{
     now_iso, record_id_to_string, AuthEventContent, DbAuthEvent, DbGroup, DbGroupAdmin, DbMember,
-    DbUser, DbUserIdentity, GroupAdminContent, MemberContent, UserContent, UserIdentityContent,
+    DbUser, DbUserIdentity, GroupAdminContent, UserContent, UserIdentityContent,
 };
 use crate::auth::password;
 use crate::db::{is_unique_constraint_error, DbConn, FIXTURE_GROUP_ID};
@@ -607,69 +607,70 @@ async fn ensure_group_admin_grant(
 /// cleanly when the target member row is missing or soft-deleted (e.g. a
 /// partial DB where `db::seed()` didn't run).
 ///
-/// Uses the typed `MemberContent` upsert path so the link survives future
-/// admin API updates of the member row — full-record replacement preserves
-/// `user_id` rather than silently dropping it as a raw `UPDATE` would if
-/// the schema is later enforced. Mirrors the OCC pattern (`version + 1`)
-/// used by every other member write path.
+/// Uses a conditional `UPDATE … WHERE deleted_at IS NONE AND …` so the write
+/// and the soft-delete guard are evaluated atomically inside SurrealDB,
+/// closing the TOCTOU window that an upsert with a pre-flight select leaves
+/// open. Mirrors the OCC pattern (`version + 1`) used by every other member
+/// write path.
 async fn ensure_pool_member_link(
     db: &DbConn,
     user_id: &str,
     pool_member_id: &str,
 ) -> Result<(), surrealdb::Error> {
-    let member: Option<DbMember> = db.select(("member", pool_member_id)).await?;
-    let member = match member {
-        Some(m) if m.deleted_at.is_none() => m,
-        _ => {
-            info!(
-                pool_member_id,
-                "fixture pool member missing or deleted — skipping user_id link"
-            );
-            return Ok(());
+    // Single conditional UPDATE: idempotency (user_id already correct) and
+    // soft-delete guard are both enforced atomically by the WHERE clause, so
+    // there is no TOCTOU window between a pre-flight read and the write.
+    let mut resp = db
+        .query(
+            "UPDATE $mid SET \
+                 user_id = $uid, \
+                 version = version + 1, \
+                 updated_at = $now \
+             WHERE deleted_at IS NONE \
+               AND (user_id IS NONE OR user_id != $uid) \
+             RETURN AFTER",
+        )
+        .bind(("mid", RecordId::new("member", pool_member_id.to_string())))
+        .bind(("uid", user_id.to_string()))
+        .bind(("now", now_iso()))
+        .await?
+        .check()?;
+    let updated: Vec<DbMember> = resp.take(0).unwrap_or_default();
+
+    if updated.is_empty() {
+        // Either the link was already correct (idempotent silent success),
+        // or the row is soft-deleted / missing. Do a best-effort select to
+        // produce a more informative log line; if that secondary read fails
+        // we still return Ok — the fixture seed path is best-effort.
+        let member: Option<DbMember> = db.select(("member", pool_member_id)).await.unwrap_or(None);
+        match member {
+            Some(m) if m.user_id.as_deref() == Some(user_id) => {
+                // Already linked — nothing to do.
+            }
+            Some(m) if m.deleted_at.is_some() => {
+                info!(
+                    pool_member_id,
+                    "fixture pool member is soft-deleted — skipping user_id link"
+                );
+                let _ = m; // suppress unused warning
+            }
+            None => {
+                info!(
+                    pool_member_id,
+                    "fixture pool member missing — skipping user_id link"
+                );
+            }
+            _ => {
+                warn!(
+                    user_id,
+                    pool_member_id,
+                    "fixture pool member UPDATE matched 0 rows for unknown reason — link skipped"
+                );
+            }
         }
-    };
-
-    // True idempotency: if the link is already correct, skip the write so
-    // `updated_at` and `version` are not bumped unnecessarily on every boot.
-    if member.user_id.as_deref() == Some(user_id) {
         return Ok(());
     }
 
-    // Build a fresh content record preserving every existing field, then
-    // set the new `user_id` and bump version (OCC) + updated_at. Use the
-    // typed upsert path so future full-record replacements via the admin API
-    // also carry `user_id` forward and never silently drop the linkage.
-    let now = now_iso();
-    let content = MemberContent {
-        name: member.name,
-        phone: member.phone,
-        position: member.position,
-        status: member.status,
-        group_id: member.group_id,
-        notes: member.notes,
-        joined_at: member.joined_at,
-        created_at: member.created_at,
-        updated_at: now,
-        deleted_at: member.deleted_at,
-        version: member.version + 1,
-        user_id: Some(user_id.to_string()),
-    };
-
-    // TOCTOU guard: if the member was soft-deleted between the pre-flight
-    // select and this upsert, the upsert will still write (upsert has no
-    // WHERE guard). Accepting that narrow race is consistent with the rest
-    // of the fixture seed path which is best-effort and development-only.
-    let updated: Option<DbMember> = db
-        .upsert(("member", pool_member_id))
-        .content(content)
-        .await?;
-    if updated.is_none() {
-        warn!(
-            user_id,
-            pool_member_id, "fixture pool member upsert returned no record — link skipped"
-        );
-        return Ok(());
-    }
     info!(
         user_id,
         pool_member_id, "fixture pool member linked to fixture user"

--- a/src/auth/bootstrap.rs
+++ b/src/auth/bootstrap.rs
@@ -302,7 +302,7 @@ async fn ensure_fixture_user(
     // future edits so a bogus role can't be silently written to `user.role`
     // (where extractors + admin_users UPDATE queries compare against the
     // exact strings `"admin"` / `"super_admin"` / `"member"` — matches the
-    // DB-level ASSERT in `db::define_user_table`.
+    // DB-level ASSERT in `db::define_auth_tables`.
     assert!(
         matches!(role, "admin" | "super_admin" | "member"),
         "fixture user role must be 'admin', 'super_admin', or 'member', got {role:?}"

--- a/src/db.rs
+++ b/src/db.rs
@@ -650,6 +650,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
         (
@@ -666,6 +667,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
         (
@@ -682,6 +684,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
         (
@@ -698,6 +701,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
         (
@@ -714,6 +718,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
         (
@@ -730,6 +735,7 @@ fn fixture_members() -> Vec<(&'static str, MemberContent)> {
                 updated_at: created_at.into(),
                 deleted_at: None,
                 version: 1,
+                user_id: None,
             },
         ),
     ]

--- a/src/db.rs
+++ b/src/db.rs
@@ -612,7 +612,7 @@ pub(crate) fn is_unique_constraint_error(message: &str) -> bool {
 // ── Fixture data ──────────────────────────────────────────────────────────────
 
 /// The seeded group ID used across all fixtures. Exposed `pub(crate)` so
-/// the dev-only `auth::bootstrap::seed_dummy_admins` path can target the
+/// the dev-only `auth::bootstrap::seed_dummy_fixtures` path can target the
 /// same group without a duplicated string literal — keeps both seed paths
 /// compile-break together if the fixture group id ever changes.
 pub(crate) const FIXTURE_GROUP_ID: &str = "1";

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,12 +100,12 @@ async fn main() {
         error!(error = %e, "Bootstrap admin seeding failed");
     }
 
-    // Dev-only fixture admins (admin1/admin2). Only runs when
+    // Dev-only fixture users (admin1..admin4 + member1). Only runs when
     // SEED_ON_EMPTY=true and APP_ENV is development or test, so production
     // boots never touch this path. Failures are logged but do not abort
     // startup — the real super-admin is already in place.
-    if let Err(e) = auth::bootstrap::seed_dummy_admins(&surreal_db).await {
-        error!(error = %e, "Dummy admin seeding failed");
+    if let Err(e) = auth::bootstrap::seed_dummy_fixtures(&surreal_db).await {
+        error!(error = %e, "Dummy fixture user seeding failed");
     }
 
     // Spawn the Axum HTTP server.

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2887,7 +2887,8 @@ where
     T: serde::de::DeserializeOwned + surrealdb_types::SurrealValue,
 {
     let mut resp = db.query(query).await.unwrap().check().unwrap();
-    resp.take(0).expect("query_values: failed to decode response")
+    resp.take(0)
+        .expect("query_values: failed to decode response")
 }
 
 #[tokio::test]
@@ -3001,10 +3002,7 @@ async fn seed_dummy_fixtures_is_idempotent_across_restarts() {
          GROUP ALL",
     )
     .await;
-    assert_eq!(
-        fixtures, 5,
-        "restart must not duplicate fixture user rows"
-    );
+    assert_eq!(fixtures, 5, "restart must not duplicate fixture user rows");
 
     let grants = count_rows(
         &db,

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -3152,3 +3152,85 @@ async fn seed_dummy_admins_reconciles_role_drift_on_restart() {
         "role reconciliation must bump token_version (before={tv_before}, after={tv_after})"
     );
 }
+
+#[tokio::test]
+async fn seed_dummy_admins_creates_member1_linked_to_fixture_pool_member() {
+    // member1 widens the seed matrix beyond admins so manual UI walkthroughs
+    // have a member-role login that fronts a real pool participant. Two
+    // invariants in one test: the auth row is correct (active, member,
+    // must_reset_password=false) and the pool member row carries the
+    // user_id back-pointer used by future join-aware queries.
+    let (_app, db) = test_app().await;
+    bootstrap::seed_dummy_admins_with_flag(&db, true)
+        .await
+        .expect("seed_dummy_admins");
+
+    let member_user_rows = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised = 'member1@poolpay.test' \
+         AND role = 'member' AND status = 'active' AND must_reset_password = false \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        member_user_rows, 1,
+        "member1 must be created as an active member-role user"
+    );
+
+    // The seeded user must not receive a group_admin grant — that join row
+    // is admin-only and would mis-classify member1 in the admin extractors.
+    let member_grants = count_rows(
+        &db,
+        "SELECT count() FROM group_admin \
+         WHERE user_id IN (\
+             SELECT VALUE meta::id(id) FROM user WHERE email_normalised = 'member1@poolpay.test'\
+         ) GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        member_grants, 0,
+        "member1 must not receive a group_admin grant"
+    );
+
+    // Pool member "1" (Adaeze Okonkwo) must carry the user_id back-pointer
+    // so any future endpoint that joins auth → pool membership resolves
+    // to the same row. Use `SELECT VALUE` so the row hydrates into a flat
+    // `Vec<String>` and we don't need an ad-hoc `SurrealValue` derive in
+    // the test crate.
+    let member_links: Vec<String> = db
+        .query(
+            "SELECT VALUE user_id FROM member \
+             WHERE meta::id(id) = '1' AND user_id != NONE",
+        )
+        .await
+        .unwrap()
+        .check()
+        .unwrap()
+        .take(0)
+        .unwrap();
+    assert_eq!(
+        member_links.len(),
+        1,
+        "fixture pool member 1 must carry a user_id link after seed"
+    );
+
+    // The link must resolve back to the member1 auth user (not some other
+    // seeded user, and not a stale id from a previous run).
+    let member1_user_id: Vec<String> = db
+        .query(
+            "SELECT VALUE meta::id(id) FROM user \
+             WHERE email_normalised = 'member1@poolpay.test'",
+        )
+        .await
+        .unwrap()
+        .check()
+        .unwrap()
+        .take(0)
+        .unwrap();
+    let expected = member1_user_id.first().expect("member1 user id").as_str();
+    assert_eq!(
+        member_links[0], expected,
+        "pool member 1 user_id must point at member1's auth user"
+    );
+}

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2887,7 +2887,7 @@ where
     T: serde::de::DeserializeOwned + surrealdb_types::SurrealValue,
 {
     let mut resp = db.query(query).await.unwrap().check().unwrap();
-    resp.take(0).unwrap_or_default()
+    resp.take(0).expect("query_values: failed to decode response")
 }
 
 #[tokio::test]

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2877,6 +2877,19 @@ async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
     rows.first().copied().unwrap_or(0)
 }
 
+/// Run a `SELECT VALUE …` query and return the flat result vector. Sibling
+/// of `count_rows` for the shape that doesn't fit the `count() GROUP ALL`
+/// mould — keeps fixture/link assertions to a single call site instead of
+/// the seven-stage `.query(…).await.unwrap().check().unwrap().take(0).unwrap()`
+/// chain that recurs across every member-facing test.
+async fn query_values<T>(db: &poolpay::db::DbConn, query: &str) -> Vec<T>
+where
+    T: serde::de::DeserializeOwned + surrealdb_types::SurrealValue,
+{
+    let mut resp = db.query(query).await.unwrap().check().unwrap();
+    resp.take(0).unwrap_or_default()
+}
+
 #[tokio::test]
 async fn seed_dummy_fixtures_creates_all_fixtures_with_expected_roles_and_grants() {
     let (_app, db) = test_app().await;
@@ -3195,20 +3208,13 @@ async fn seed_dummy_fixtures_creates_member1_linked_to_fixture_pool_member() {
 
     // Pool member "1" (Adaeze Okonkwo) must carry the user_id back-pointer
     // so any future endpoint that joins auth → pool membership resolves
-    // to the same row. Use `SELECT VALUE` so the row hydrates into a flat
-    // `Vec<String>` and we don't need an ad-hoc `SurrealValue` derive in
-    // the test crate.
-    let member_links: Vec<String> = db
-        .query(
-            "SELECT VALUE user_id FROM member \
-             WHERE meta::id(id) = '1' AND user_id != NONE",
-        )
-        .await
-        .unwrap()
-        .check()
-        .unwrap()
-        .take(0)
-        .unwrap();
+    // to the same row.
+    let member_links: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE user_id FROM member \
+         WHERE meta::id(id) = '1' AND user_id != NONE",
+    )
+    .await;
     assert_eq!(
         member_links.len(),
         1,
@@ -3217,17 +3223,12 @@ async fn seed_dummy_fixtures_creates_member1_linked_to_fixture_pool_member() {
 
     // The link must resolve back to the member1 auth user (not some other
     // seeded user, and not a stale id from a previous run).
-    let member1_user_id: Vec<String> = db
-        .query(
-            "SELECT VALUE meta::id(id) FROM user \
-             WHERE email_normalised = 'member1@poolpay.test'",
-        )
-        .await
-        .unwrap()
-        .check()
-        .unwrap()
-        .take(0)
-        .unwrap();
+    let member1_user_id: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE meta::id(id) FROM user \
+         WHERE email_normalised = 'member1@poolpay.test'",
+    )
+    .await;
     let expected = member1_user_id.first().expect("member1 user id").as_str();
     assert_eq!(
         member_links[0], expected,

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2878,11 +2878,11 @@ async fn count_rows(db: &poolpay::db::DbConn, query: &str) -> i64 {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_creates_all_fixtures_with_expected_roles_and_grants() {
+async fn seed_dummy_fixtures_creates_all_fixtures_with_expected_roles_and_grants() {
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
-        .expect("seed_dummy_admins");
+        .expect("seed_dummy_fixtures");
 
     // admin1, admin2, admin4 — regular `admin` role.
     let admin_role_rows = count_rows(
@@ -2949,12 +2949,12 @@ async fn seed_dummy_admins_creates_all_fixtures_with_expected_roles_and_grants()
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_is_idempotent_across_restarts() {
+async fn seed_dummy_fixtures_is_idempotent_across_restarts() {
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("first seed");
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("second seed (simulated restart)");
 
@@ -2979,13 +2979,13 @@ async fn seed_dummy_admins_is_idempotent_across_restarts() {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_is_noop_without_flag() {
+async fn seed_dummy_fixtures_is_noop_without_flag() {
     let (_app, db) = test_app().await;
     // Verify the guard short-circuits rather than relying on idempotency
     // alone, so a production boot without the flag is provably silent.
-    bootstrap::seed_dummy_admins_with_flag(&db, false)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, false)
         .await
-        .expect("seed_dummy_admins noop");
+        .expect("seed_dummy_fixtures noop");
 
     let admins = count_rows(
         &db,
@@ -3004,12 +3004,12 @@ async fn seed_dummy_admins_is_noop_without_flag() {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_restores_missing_admin1_grant_on_restart() {
+async fn seed_dummy_fixtures_restores_missing_admin1_grant_on_restart() {
     // Idempotency contract: if admin1 already exists but the `group_admin`
     // grant was manually deleted (partial cleanup, ops intervention), a
     // subsequent seed must restore the grant rather than silently skip it.
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("first seed");
 
@@ -3027,7 +3027,7 @@ async fn seed_dummy_admins_restores_missing_admin1_grant_on_restart() {
     .await;
     assert_eq!(grants_after_wipe, 0, "precondition: grant wiped");
 
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("second seed restores grant");
 
@@ -3040,14 +3040,14 @@ async fn seed_dummy_admins_restores_missing_admin1_grant_on_restart() {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_skips_grant_when_fixture_user_is_disabled() {
+async fn seed_dummy_fixtures_skips_grant_when_fixture_user_is_disabled() {
     // If the fixture admin1 was disabled via the admin UI (soft-deleted or
     // status=disabled) after the first seed, a subsequent seed must NOT
     // award a fresh `group_admin` grant to that disabled user — the fixture
     // is no longer in a usable state, and silently granting would mask the
     // fact that admin1 has been taken offline.
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("first seed");
 
@@ -3068,7 +3068,7 @@ async fn seed_dummy_admins_skips_grant_when_fixture_user_is_disabled() {
         .check()
         .unwrap();
 
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("second seed tolerates disabled fixture admin");
 
@@ -3084,14 +3084,14 @@ async fn seed_dummy_admins_skips_grant_when_fixture_user_is_disabled() {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_reconciles_role_drift_on_restart() {
+async fn seed_dummy_fixtures_reconciles_role_drift_on_restart() {
     // If a fixture admin was re-roled via the admin UI after first seed
     // (e.g. admin3 demoted from super_admin to admin), the next restart
-    // must restore the role declared in DUMMY_ADMINS so the fixture matrix
+    // must restore the role declared in DUMMY_FIXTURE_USERS so the fixture matrix
     // stays the source of truth. Also bumps token_version so any cached
     // access token the drifted user held is invalidated.
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("first seed");
 
@@ -3118,7 +3118,7 @@ async fn seed_dummy_admins_reconciles_role_drift_on_restart() {
     .check()
     .unwrap();
 
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
         .expect("second seed reconciles role");
 
@@ -3154,16 +3154,16 @@ async fn seed_dummy_admins_reconciles_role_drift_on_restart() {
 }
 
 #[tokio::test]
-async fn seed_dummy_admins_creates_member1_linked_to_fixture_pool_member() {
+async fn seed_dummy_fixtures_creates_member1_linked_to_fixture_pool_member() {
     // member1 widens the seed matrix beyond admins so manual UI walkthroughs
     // have a member-role login that fronts a real pool participant. Two
     // invariants in one test: the auth row is correct (active, member,
     // must_reset_password=false) and the pool member row carries the
     // user_id back-pointer used by future join-aware queries.
     let (_app, db) = test_app().await;
-    bootstrap::seed_dummy_admins_with_flag(&db, true)
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
         .await
-        .expect("seed_dummy_admins");
+        .expect("seed_dummy_fixtures");
 
     let member_user_rows = count_rows(
         &db,

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2946,6 +2946,7 @@ async fn seed_dummy_fixtures_creates_all_fixtures_with_expected_roles_and_grants
         "admin2@poolpay.test",
         "admin3@poolpay.test",
         "admin4@poolpay.test",
+        "member1@poolpay.test",
     ] {
         let grants = count_rows(
             &db,
@@ -2959,6 +2960,24 @@ async fn seed_dummy_fixtures_creates_all_fixtures_with_expected_roles_and_grants
         .await;
         assert_eq!(grants, 0, "{email} must not receive any fixture grants");
     }
+
+    // member1 — `member` role, linked back to fixture pool member `1`.
+    // The deeper link-resolves-to-the-same-user assertion lives in
+    // `seed_dummy_fixtures_creates_member1_linked_to_fixture_pool_member`;
+    // here we just establish the 5th fixture is part of the sweep so a
+    // regression dropping member1 from `DUMMY_FIXTURE_USERS` is caught.
+    let member1_rows = count_rows(
+        &db,
+        "SELECT count() FROM user \
+         WHERE email_normalised = 'member1@poolpay.test' \
+         AND role = 'member' AND status = 'active' AND must_reset_password = false \
+         GROUP ALL",
+    )
+    .await;
+    assert_eq!(
+        member1_rows, 1,
+        "member1 must be created as an active member-role user"
+    );
 }
 
 #[tokio::test]
@@ -2971,17 +2990,21 @@ async fn seed_dummy_fixtures_is_idempotent_across_restarts() {
         .await
         .expect("second seed (simulated restart)");
 
-    let admins = count_rows(
+    let fixtures = count_rows(
         &db,
         "SELECT count() FROM user \
          WHERE email_normalised IN [\
              'admin1@poolpay.test', 'admin2@poolpay.test', \
-             'admin3@poolpay.test', 'admin4@poolpay.test'\
+             'admin3@poolpay.test', 'admin4@poolpay.test', \
+             'member1@poolpay.test'\
          ] \
          GROUP ALL",
     )
     .await;
-    assert_eq!(admins, 4, "restart must not duplicate fixture admin rows");
+    assert_eq!(
+        fixtures, 5,
+        "restart must not duplicate fixture user rows"
+    );
 
     let grants = count_rows(
         &db,
@@ -2989,6 +3012,32 @@ async fn seed_dummy_fixtures_is_idempotent_across_restarts() {
     )
     .await;
     assert_eq!(grants, 1, "restart must not duplicate fixture grants");
+
+    // Pool member 1 must still carry exactly one user_id back-pointer to
+    // member1 — re-running the seed must not duplicate the link or drift
+    // it onto a different user (e.g. a stale id from a previous boot).
+    let member_links: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE user_id FROM member \
+         WHERE meta::id(id) = '1' AND user_id != NONE",
+    )
+    .await;
+    assert_eq!(
+        member_links.len(),
+        1,
+        "restart must keep the pool member → user_id link intact"
+    );
+    let member1_user_id: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE meta::id(id) FROM user \
+         WHERE email_normalised = 'member1@poolpay.test'",
+    )
+    .await;
+    assert_eq!(
+        member_links[0],
+        *member1_user_id.first().expect("member1 user id"),
+        "restart must not drift the link onto a different user"
+    );
 }
 
 #[tokio::test]
@@ -3000,19 +3049,100 @@ async fn seed_dummy_fixtures_is_noop_without_flag() {
         .await
         .expect("seed_dummy_fixtures noop");
 
-    let admins = count_rows(
+    let fixtures = count_rows(
         &db,
         "SELECT count() FROM user \
          WHERE email_normalised IN [\
              'admin1@poolpay.test', 'admin2@poolpay.test', \
-             'admin3@poolpay.test', 'admin4@poolpay.test'\
+             'admin3@poolpay.test', 'admin4@poolpay.test', \
+             'member1@poolpay.test'\
          ] \
          GROUP ALL",
     )
     .await;
     assert_eq!(
-        admins, 0,
-        "fixture admins must not be seeded without SEED_ON_EMPTY=true"
+        fixtures, 0,
+        "fixture users must not be seeded without SEED_ON_EMPTY=true"
+    );
+
+    // The link side-effect must stay silent too: `db::init_memory()` seeds
+    // pool member `1` without a `user_id`, and a no-op
+    // `seed_dummy_fixtures_with_flag` must leave that field untouched.
+    let member_links: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE user_id FROM member \
+         WHERE meta::id(id) = '1' AND user_id != NONE",
+    )
+    .await;
+    assert!(
+        member_links.is_empty(),
+        "noop seed must not stamp user_id onto pool member 1"
+    );
+}
+
+#[tokio::test]
+async fn seed_dummy_fixtures_restores_missing_member1_link_on_restart() {
+    // Mirror of the admin1 grant restoration contract, but for the
+    // `member.user_id` link: if member1 already exists but the `user_id`
+    // back-pointer on pool member `1` was manually cleared (partial cleanup,
+    // ops intervention, schema-less drift), a subsequent seed must
+    // re-stamp the link rather than silently skip it.
+    let (_app, db) = test_app().await;
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
+        .await
+        .expect("first seed");
+
+    // Capture member1's user id before the cleanup so we can compare against
+    // it after the restore — `ensure_pool_member_link` must reach the same
+    // user, not a stale or freshly-rolled identity.
+    let member1_user_id_before: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE meta::id(id) FROM user \
+         WHERE email_normalised = 'member1@poolpay.test'",
+    )
+    .await;
+    let expected = member1_user_id_before
+        .first()
+        .expect("member1 user id after first seed")
+        .clone();
+
+    // Clear the link on pool member `1` without touching the user row,
+    // simulating a manual cleanup that left member1 intact but stripped
+    // the back-pointer.
+    db.query("UPDATE member:`1` SET user_id = NONE")
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let links_after_wipe: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE user_id FROM member \
+         WHERE meta::id(id) = '1' AND user_id != NONE",
+    )
+    .await;
+    assert!(
+        links_after_wipe.is_empty(),
+        "precondition: pool member 1 user_id wiped"
+    );
+
+    bootstrap::seed_dummy_fixtures_with_flag(&db, true)
+        .await
+        .expect("second seed restores link");
+
+    let links: Vec<String> = query_values(
+        &db,
+        "SELECT VALUE user_id FROM member \
+         WHERE meta::id(id) = '1' AND user_id != NONE",
+    )
+    .await;
+    assert_eq!(
+        links.len(),
+        1,
+        "restart must restore the pool member → user_id link"
+    );
+    assert_eq!(
+        links[0], expected,
+        "restored link must point at the same member1 user, not a stale id"
     );
 }
 

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -3032,8 +3032,8 @@ async fn seed_dummy_fixtures_is_idempotent_across_restarts() {
     )
     .await;
     assert_eq!(
-        member_links[0],
-        *member1_user_id.first().expect("member1 user id"),
+        member_links.first().map(String::as_str),
+        member1_user_id.first().map(String::as_str),
         "restart must not drift the link onto a different user"
     );
 }


### PR DESCRIPTION
## Summary
- Extends fixture seeding with a 5th user (`member1@poolpay.test`, role `member`, password `PoolPayQA2026!`) so manual UI walkthroughs have a member-role login.
- Stamps `user_id` onto fixture pool member `1` (Adaeze Okonkwo) so the seeded auth identity fronts a real pool participant in fixture group `1` — cycles, payments, and member-dashboard queries all resolve.
- Widens fixture role asserts to include `"member"` (matches the DB-level `ASSERT $value IN ['super_admin', 'admin', 'member']` already in `src/db.rs:443`).
- Adds idempotent `ensure_pool_member_link` helper. Captures the UPDATE result so a TOCTOU soft-delete mid-flight doesn't log a false-positive link.
- Refactors the seed loop to `let-else continue` so the grant + pool-member-link branches share the unwrap (no behaviour change).
- Renames the public API (`seed_dummy_fixtures`, `seed_dummy_fixtures_with_flag`) and in-module symbols (`DummyFixtureUser`, `DUMMY_FIXTURE_USERS`, `DUMMY_FIXTURE_PASSWORD`, `ensure_fixture_user`) now that the matrix is no longer admin-only. Test names cascade.
- Adds a `query_values<T>` test helper alongside `count_rows` for `SELECT VALUE` queries.

Obsidian doc `output/2026-05-13-poolpay-logins.md` updated separately in the vault — not part of this PR.

## Gate (unchanged)
Same gate as before: `SEED_ON_EMPTY=true` **and** `APP_ENV ∈ {development, test}`. Production boots fail-closed.

## Test plan
- [x] `cargo test --test auth_integration seed_dummy_fixtures` — 8/8 pass (includes new `restores_missing_member1_link_on_restart`).
- [x] `cargo test` — 405/405 across all binaries.
- [x] `cargo clippy --tests` — clean.
- [ ] Manual: `cargo run`, then sign in at the FE with `member1@poolpay.test` / `PoolPayQA2026!` and confirm the member dashboard renders pool member `1`'s data.

## Coverage notes
The three existing fixture sweeps (`creates_all_fixtures_with_expected_roles_and_grants`, `is_idempotent_across_restarts`, `is_noop_without_flag`) now include `member1` and assert on the pool-member link state. A new `restores_missing_member1_link_on_restart` test mirrors the admin1 grant restoration contract for the `member.user_id` field.

## Commits
1. `[FEAT]` — Member fixture user + pool-member link + helper
2. `[TEST]` — Cover member1 fixture seed + pool-member link
3. `[REFACTOR]` — Rename seed_dummy_admins → seed_dummy_fixtures
4. `[TEST]` — Extract query_values<T> helper
5. `[TEST]` — Cover member1 in fixture sweeps + add link-restoration test