### PR TITLE
[SEC] - Gate GET /api/receipts behind AuthenticatedUser, expand non-admin strip set

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -19,7 +19,7 @@ use crate::api::pagination::{
     header_u32, Pagination, PaginationParams, HEADER_LIMIT, HEADER_OFFSET, HEADER_TOTAL_COUNT,
 };
 use crate::auth::audit::record_auth_event;
-use crate::auth::extractors::{AuthenticatedUser, GroupScopedAdmin, OptionalAuth, SuperAdminUser};
+use crate::auth::extractors::{AuthenticatedUser, GroupScopedAdmin, SuperAdminUser};
 use crate::db::{reseed, DbConn};
 
 // ── Query params ─────────────────────────────────────────────────────────────
@@ -216,7 +216,7 @@ pub async fn get_payments(
 
 pub async fn get_receipts(
     State(db): State<DbConn>,
-    OptionalAuth(auth): OptionalAuth,
+    user: AuthenticatedUser,
     Query(params): Query<ReceiptsQuery>,
 ) -> Result<(HeaderMap, Json<Vec<Receipt>>), AppError> {
     // Validate status filter up-front so an unknown value returns 400
@@ -282,21 +282,29 @@ pub async fn get_receipts(
     let mut resp = q.await?;
     let total = take_count(&mut resp, 0)?;
     let rows: Vec<DbReceipt> = resp.take(1)?;
-    // `GET /api/receipts` is public by default but exposes the admin-review
-    // fields (`raw_image_url`, `rejection_reason`) only to callers presenting
-    // a valid admin-tier Bearer token. `raw_image_url` is the bot-supplied
-    // screenshot URL an admin needs to inspect a pending receipt before
-    // confirming/rejecting; `rejection_reason` is an admin-supplied note.
-    // Without this gating, an admin had no read path to fetch `raw_image_url`
-    // (no separate admin list endpoint exists). Member-role tokens are
-    // treated like anonymous callers here — they get the stripped public
-    // projection. Token verification + status/version checks happen in
-    // `OptionalAuth`, so any failure mode collapses to `None`, which also
-    // keeps the public projection in place.
-    let is_admin = auth
-        .as_ref()
-        .map(|u| matches!(u.role.as_str(), "admin" | "super_admin"))
-        .unwrap_or(false);
+    // The route is gated by `AuthenticatedUser`, so anonymous callers never
+    // reach this body — they get 401 at the extractor. Within authenticated
+    // callers the response shape splits two ways:
+    //
+    // * Admin tier (`admin` / `super_admin`): full payload. Admins need
+    //   `raw_image_url` to inspect the screenshot, `rejection_reason` for
+    //   audit context, and the bot-supplied content fields (`ocr_text`,
+    //   `sender_label`, `bank_label`) plus `sender_phone` to triage the
+    //   pending queue. There is no separate admin list route, so this
+    //   handler is their read path.
+    //
+    // * Member tier: stripped projection. A compromised WhatsApp bot can
+    //   plant attacker-controlled strings into `ocr_text`, `sender_label`,
+    //   `bank_label`, or `raw_image_url`; surfacing them to non-admin
+    //   callers would turn a bot compromise into a public XSS / phishing
+    //   surface. `sender_phone` is PII regardless of bot intent. The
+    //   listing endpoint exposes none of these to members.
+    //
+    // A valid token is not the same as admin authority — the role check
+    // happens on the DB-resolved user (`AuthenticatedUser` re-reads role
+    // from the DB row, not from the JWT claim) so a stale or downgraded
+    // token cannot reach the admin projection by replaying an old claim.
+    let is_admin = matches!(user.role.as_str(), "admin" | "super_admin");
     let receipts: Result<Vec<Receipt>, AppError> = rows
         .into_iter()
         .map(Receipt::try_from)
@@ -305,6 +313,10 @@ pub async fn get_receipts(
                 if !is_admin {
                     receipt.raw_image_url = None;
                     receipt.rejection_reason = None;
+                    receipt.ocr_text = None;
+                    receipt.sender_phone = None;
+                    receipt.sender_label = None;
+                    receipt.bank_label = None;
                 }
                 receipt
             })

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -94,6 +94,12 @@ pub fn router_with_config(
         .route("/api/payments", get(get_payments))
         .route("/api/payments", post(create_payment))
         .route("/api/payments/{member_id}/{cycle_id}", delete(delete_payment))
+        // `/api/receipts` lists receipts for any authenticated user. The
+        // handler gates with `AuthenticatedUser` (anonymous → 401) and
+        // splits the response shape by role: members get a stripped
+        // projection that omits bot-supplied content and PII; admins get
+        // the full payload they need to triage the pending queue. See the
+        // strip rationale in `get_receipts` in `handlers.rs`.
         .route("/api/receipts", get(get_receipts))
         // Admin group endpoints
         .route("/api/admin/groups", post(create_group))

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -488,8 +488,13 @@ pub struct Receipt {
     pub group_id: EntityId,
     #[serde(rename = "chatId")]
     pub chat_id: String,
-    #[serde(rename = "senderPhone")]
-    pub sender_phone: String,
+    /// Bot-supplied sender phone — PII. Modelled as `Option<String>` so the
+    /// non-admin projection of `GET /api/receipts` can strip it (set to
+    /// `None`, skipped in JSON) while admin-tier callers continue to see the
+    /// real value. The DB row always carries a `String`; the conversion in
+    /// `TryFrom<DbReceipt>` wraps it with `Some(..)`.
+    #[serde(rename = "senderPhone", skip_serializing_if = "Option::is_none")]
+    pub sender_phone: Option<String>,
     #[serde(rename = "memberId", skip_serializing_if = "Option::is_none")]
     pub member_id: Option<EntityId>,
     #[serde(rename = "cycleId", skip_serializing_if = "Option::is_none")]
@@ -661,7 +666,7 @@ impl TryFrom<DbReceipt> for Receipt {
             whatsapp_message_id: db.whatsapp_message_id,
             group_id: db.group_id,
             chat_id: db.chat_id,
-            sender_phone: db.sender_phone,
+            sender_phone: Some(db.sender_phone),
             member_id: db.member_id,
             cycle_id: db.cycle_id,
             extracted_amount: db.extracted_amount,

--- a/src/auth/extractors.rs
+++ b/src/auth/extractors.rs
@@ -137,45 +137,6 @@ where
     }
 }
 
-/// Authentication probe that never rejects the request.
-///
-/// Used by endpoints that are public by default but expose extra fields to
-/// callers who present a valid Bearer token (currently: `GET /api/receipts`
-/// returns `raw_image_url` / `rejection_reason` to authenticated admins so
-/// they can review pending receipts, while unauthenticated callers see the
-/// stripped projection). Any failure to extract a valid `AuthenticatedUser`
-/// — missing header, malformed token, expired token, mismatched
-/// `token_version`, inactive/deleted user — collapses to `None` so the
-/// public path is never blocked.
-#[derive(Debug, Clone)]
-pub struct OptionalAuth(pub Option<AuthenticatedUser>);
-
-impl<S> FromRequestParts<S> for OptionalAuth
-where
-    S: Send + Sync,
-    DbConn: FromRef<S>,
-{
-    type Rejection = std::convert::Infallible;
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        // Skip the work entirely when no Authorization header is present —
-        // saves a token verification + DB round-trip on the common
-        // unauthenticated path.
-        if parts
-            .headers
-            .get(axum::http::header::AUTHORIZATION)
-            .is_none()
-        {
-            return Ok(Self(None));
-        }
-        Ok(Self(
-            AuthenticatedUser::from_request_parts(parts, state)
-                .await
-                .ok(),
-        ))
-    }
-}
-
 pub async fn require_group_scope(
     user: &AuthenticatedUser,
     group_id: &str,

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -1820,7 +1820,11 @@ async fn get_receipts_response_shape() {
 #[tokio::test]
 async fn get_receipts_filter_by_group_id() {
     let app = test_app_with_auth().await;
-    let resp = call(app, get_jwt_with("/api/receipts?groupId=1", &admin_bearer())).await;
+    let resp = call(
+        app,
+        get_jwt_with("/api/receipts?groupId=1", &admin_bearer()),
+    )
+    .await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(receipts.iter().all(|r| r["groupId"] == "1"));
 }
@@ -1877,20 +1881,12 @@ async fn get_receipts_excludes_soft_deleted() {
 #[tokio::test]
 async fn reset_restores_receipts_to_fixture_count() {
     let app = test_app_with_auth().await;
-    let before: Vec<serde_json::Value> = json_body(
-        call(
-            app.clone(),
-            get_jwt_with("/api/receipts", &admin_bearer()),
-        )
-        .await,
-    )
-    .await;
+    let before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get_jwt_with("/api/receipts", &admin_bearer())).await).await;
     let baseline = before.len();
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let after: Vec<serde_json::Value> = json_body(
-        call(app, get_jwt_with("/api/receipts", &admin_bearer())).await,
-    )
-    .await;
+    let after: Vec<serde_json::Value> =
+        json_body(call(app, get_jwt_with("/api/receipts", &admin_bearer())).await).await;
     assert_eq!(after.len(), baseline);
 }
 

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -86,9 +86,11 @@ async fn test_app_with_auth_and_db() -> (Router, db::DbConn) {
 const TEST_SUPER_ADMIN_SUB: &str = "test-super-admin";
 const TEST_ADMIN_SUB: &str = "test-admin";
 const TEST_SCOPED_ADMIN_SUB: &str = "test-scoped-admin";
-/// `member`-role fixture user — used to assert that member tokens still
-/// receive the stripped public projection on `GET /api/receipts` (admin
-/// review fields are admin-only).
+/// `member`-role fixture user — used to assert that member tokens are
+/// admitted to `GET /api/receipts` (the route is gated by
+/// `AuthenticatedUser`) but receive the stripped projection that omits
+/// bot-supplied content and sender PII. Admin-review fields are
+/// admin-only.
 const TEST_MEMBER_SUB: &str = "test-member";
 /// Fixture group the scoped admin is granted access to — matches the
 /// single group id produced by `db::init_memory()`.
@@ -233,9 +235,9 @@ fn scoped_admin_bearer() -> String {
 }
 
 /// Bearer for a `member`-role user. Used to verify that handlers which
-/// release admin-only fields when `OptionalAuth` resolves to an admin
-/// (e.g. `GET /api/receipts`) still strip those fields for member
-/// callers — a valid token is not the same as admin authority.
+/// release admin-only fields to admin callers (e.g. `GET /api/receipts`)
+/// still strip those fields for member callers — a valid token is not
+/// the same as admin authority.
 fn member_bearer() -> String {
     format!("Bearer {}", mint_user_jwt(TEST_MEMBER_SUB, "member"))
 }
@@ -1758,20 +1760,32 @@ async fn delete_whatsapp_link_allows_relinking_same_chat_id() {
 
 #[tokio::test]
 async fn get_receipts_returns_200() {
-    let resp = call(test_app().await, get("/api/receipts")).await;
+    let resp = call(
+        test_app_with_auth().await,
+        get_jwt_with("/api/receipts", &admin_bearer()),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
 #[tokio::test]
-async fn get_receipts_no_auth_header_is_public() {
-    // No Authorization header — endpoint must still succeed (public read).
-    let resp = call(test_app().await, get("/api/receipts")).await;
-    assert_eq!(resp.status(), StatusCode::OK);
+async fn get_receipts_no_auth_header_returns_401() {
+    // No Authorization header — endpoint must reject. The listing route is
+    // gated behind `AuthenticatedUser` because the payload contains
+    // bot-supplied content and sender PII that a compromised bot can
+    // poison; anonymous read access turns a bot compromise into a public
+    // phishing / XSS surface.
+    let resp = call(test_app_with_auth().await, get("/api/receipts")).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
 async fn get_receipts_returns_seeded_fixtures() {
-    let resp = call(test_app().await, get("/api/receipts")).await;
+    let resp = call(
+        test_app_with_auth().await,
+        get_jwt_with("/api/receipts", &admin_bearer()),
+    )
+    .await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(
         !receipts.is_empty(),
@@ -1781,7 +1795,11 @@ async fn get_receipts_returns_seeded_fixtures() {
 
 #[tokio::test]
 async fn get_receipts_response_shape() {
-    let resp = call(test_app().await, get("/api/receipts")).await;
+    let resp = call(
+        test_app_with_auth().await,
+        get_jwt_with("/api/receipts", &admin_bearer()),
+    )
+    .await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     let r = &receipts[0];
     for field in [
@@ -1801,40 +1819,52 @@ async fn get_receipts_response_shape() {
 
 #[tokio::test]
 async fn get_receipts_filter_by_group_id() {
-    let app = test_app().await;
-    let resp = call(app, get("/api/receipts?groupId=1")).await;
+    let app = test_app_with_auth().await;
+    let resp = call(app, get_jwt_with("/api/receipts?groupId=1", &admin_bearer())).await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(receipts.iter().all(|r| r["groupId"] == "1"));
 }
 
 #[tokio::test]
 async fn get_receipts_filter_by_group_id_unknown_returns_empty() {
-    let app = test_app().await;
-    let resp = call(app, get("/api/receipts?groupId=does-not-exist")).await;
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        get_jwt_with("/api/receipts?groupId=does-not-exist", &admin_bearer()),
+    )
+    .await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert_eq!(receipts.len(), 0);
 }
 
 #[tokio::test]
 async fn get_receipts_filter_by_status_pending() {
-    let app = test_app().await;
-    let resp = call(app, get("/api/receipts?status=pending")).await;
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        get_jwt_with("/api/receipts?status=pending", &admin_bearer()),
+    )
+    .await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(receipts.iter().all(|r| r["status"] == "pending"));
 }
 
 #[tokio::test]
 async fn get_receipts_invalid_status_returns_400() {
-    let app = test_app().await;
-    let resp = call(app, get("/api/receipts?status=weird")).await;
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        get_jwt_with("/api/receipts?status=weird", &admin_bearer()),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
 async fn get_receipts_excludes_soft_deleted() {
     // At least one fixture receipt has deleted_at set — ensure it's filtered out.
-    let app = test_app().await;
-    let resp = call(app, get("/api/receipts")).await;
+    let app = test_app_with_auth().await;
+    let resp = call(app, get_jwt_with("/api/receipts", &admin_bearer())).await;
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
     assert!(
         receipts
@@ -1846,63 +1876,85 @@ async fn get_receipts_excludes_soft_deleted() {
 
 #[tokio::test]
 async fn reset_restores_receipts_to_fixture_count() {
-    let app = test_app().await;
-    let before: Vec<serde_json::Value> =
-        json_body(call(app.clone(), get("/api/receipts")).await).await;
+    let app = test_app_with_auth().await;
+    let before: Vec<serde_json::Value> = json_body(
+        call(
+            app.clone(),
+            get_jwt_with("/api/receipts", &admin_bearer()),
+        )
+        .await,
+    )
+    .await;
     let baseline = before.len();
     call(app.clone(), post_empty("/api/test/reset")).await;
-    let after: Vec<serde_json::Value> = json_body(call(app, get("/api/receipts")).await).await;
+    let after: Vec<serde_json::Value> = json_body(
+        call(app, get_jwt_with("/api/receipts", &admin_bearer())).await,
+    )
+    .await;
     assert_eq!(after.len(), baseline);
 }
 
-/// Seed admin-review fields on receipt id `1` so the projection tests
-/// can prove which callers see them and which do not. The fixture leaves
-/// both fields `None`, but the serializer skips `None`, so without a
-/// real value present we cannot distinguish "field stripped" from
-/// "field never set" — write a known value here and assert against it.
-async fn seed_admin_review_fields_on_receipt_one(db: &poolpay::db::DbConn) {
+/// Seed the bot-supplied content fields and admin note on receipt id `1`
+/// so the projection tests can prove which callers see them and which do
+/// not. The fixture leaves these fields blank or `None`; the serializer
+/// skips `None`, so without a real value present we cannot distinguish
+/// "field stripped" from "field never set" — write known values here and
+/// assert against them.
+async fn seed_strippable_fields_on_receipt_one(db: &poolpay::db::DbConn) {
     use surrealdb::types::RecordId;
-    db.query("UPDATE $id SET raw_image_url = $url, rejection_reason = $reason")
-        .bind(("id", RecordId::new("receipt", "1".to_string())))
-        .bind(("url", "https://example.invalid/screenshot.png".to_string()))
-        .bind(("reason", "needs manual review".to_string()))
-        .await
-        .expect("seed admin-review fields")
-        .check()
-        .expect("admin-review field update must succeed");
+    db.query(
+        "UPDATE $id SET \
+             raw_image_url = $url, \
+             rejection_reason = $reason, \
+             ocr_text = $ocr, \
+             sender_label = $sender, \
+             bank_label = $bank",
+    )
+    .bind(("id", RecordId::new("receipt", "1".to_string())))
+    .bind(("url", "https://example.invalid/screenshot.png".to_string()))
+    .bind(("reason", "needs manual review".to_string()))
+    .bind(("ocr", "NGN 1,000,000.00\nFrom: Tunde Bakare".to_string()))
+    .bind(("sender", "Tunde Bakare".to_string()))
+    .bind(("bank", "GTBank".to_string()))
+    .await
+    .expect("seed strippable fields")
+    .check()
+    .expect("strippable field update must succeed");
 }
 
-#[tokio::test]
-async fn get_receipts_anonymous_strips_admin_review_fields() {
-    // Anonymous callers must never see `rawImageUrl` or `rejectionReason`,
-    // even when the underlying row has them populated.
-    let (app, db) = test_app_with_auth_and_db().await;
-    seed_admin_review_fields_on_receipt_one(&db).await;
+/// Fields that must NEVER appear in a non-admin projection of the listing.
+/// Bot-supplied content (`rawImageUrl`, `ocrText`, `senderLabel`,
+/// `bankLabel`) is attacker-controllable through a compromised WhatsApp
+/// bot; `senderPhone` is PII; `rejectionReason` is an admin note. Surfacing
+/// any of these to non-admin callers turns a bot compromise or a stolen
+/// member token into a public phishing / data-exfil surface.
+const NON_ADMIN_STRIPPED_FIELDS: &[&str] = &[
+    "rawImageUrl",
+    "rejectionReason",
+    "ocrText",
+    "senderPhone",
+    "senderLabel",
+    "bankLabel",
+];
 
+#[tokio::test]
+async fn get_receipts_anonymous_returns_401() {
+    // Anonymous callers cannot reach the listing at all — the route is
+    // gated behind `AuthenticatedUser`. Token presence is not authority,
+    // but token absence is an outright refusal.
+    let app = test_app_with_auth().await;
     let resp = call(app, get("/api/receipts")).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let receipts: Vec<serde_json::Value> = json_body(resp).await;
-    let r = receipts
-        .iter()
-        .find(|r| r["id"] == "1")
-        .expect("receipt 1 must be in the listing");
-    assert!(
-        r.get("rawImageUrl").is_none(),
-        "anonymous callers must not see rawImageUrl: {r}"
-    );
-    assert!(
-        r.get("rejectionReason").is_none(),
-        "anonymous callers must not see rejectionReason: {r}"
-    );
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
-async fn get_receipts_member_token_strips_admin_review_fields() {
+async fn get_receipts_member_token_strips_sensitive_fields() {
     // A valid token is not the same as admin authority — `member`-role
-    // callers must receive the same stripped public projection as
-    // anonymous callers.
+    // callers receive a stripped projection that omits bot-supplied
+    // content and sender PII even when the underlying row has them
+    // populated.
     let (app, db) = test_app_with_auth_and_db().await;
-    seed_admin_review_fields_on_receipt_one(&db).await;
+    seed_strippable_fields_on_receipt_one(&db).await;
 
     let resp = call(app, get_jwt_with("/api/receipts", &member_bearer())).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -1911,23 +1963,21 @@ async fn get_receipts_member_token_strips_admin_review_fields() {
         .iter()
         .find(|r| r["id"] == "1")
         .expect("receipt 1 must be in the listing");
-    assert!(
-        r.get("rawImageUrl").is_none(),
-        "member-token callers must not see rawImageUrl: {r}"
-    );
-    assert!(
-        r.get("rejectionReason").is_none(),
-        "member-token callers must not see rejectionReason: {r}"
-    );
+    for field in NON_ADMIN_STRIPPED_FIELDS {
+        assert!(
+            r.get(field).is_none(),
+            "member-token callers must not see {field}: {r}"
+        );
+    }
 }
 
 #[tokio::test]
-async fn get_receipts_admin_token_includes_admin_review_fields() {
+async fn get_receipts_admin_token_includes_sensitive_fields() {
     // Admin-tier callers (`admin` or `super_admin`) are the only callers
-    // who get `rawImageUrl` and `rejectionReason` in the listing — they
-    // need them to review pending receipts before confirming/rejecting.
+    // who get the full payload — they need the bot-supplied content to
+    // triage the pending queue and `rejectionReason` for audit context.
     let (app, db) = test_app_with_auth_and_db().await;
-    seed_admin_review_fields_on_receipt_one(&db).await;
+    seed_strippable_fields_on_receipt_one(&db).await;
 
     let resp = call(app, get_jwt_with("/api/receipts", &admin_bearer())).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -1936,22 +1986,25 @@ async fn get_receipts_admin_token_includes_admin_review_fields() {
         .iter()
         .find(|r| r["id"] == "1")
         .expect("receipt 1 must be in the listing");
-    assert_eq!(
-        r["rawImageUrl"], "https://example.invalid/screenshot.png",
-        "admin callers must see rawImageUrl: {r}"
-    );
-    assert_eq!(
-        r["rejectionReason"], "needs manual review",
-        "admin callers must see rejectionReason: {r}"
+    assert_eq!(r["rawImageUrl"], "https://example.invalid/screenshot.png");
+    assert_eq!(r["rejectionReason"], "needs manual review");
+    assert_eq!(r["ocrText"], "NGN 1,000,000.00\nFrom: Tunde Bakare");
+    assert_eq!(r["senderLabel"], "Tunde Bakare");
+    assert_eq!(r["bankLabel"], "GTBank");
+    // `senderPhone` is sourced from the row itself (always present in the
+    // DB, not from the test seed), so just assert it surfaces as a string.
+    assert!(
+        r["senderPhone"].is_string(),
+        "admin callers must see senderPhone: {r}"
     );
 }
 
 #[tokio::test]
-async fn get_receipts_super_admin_token_includes_admin_review_fields() {
+async fn get_receipts_super_admin_token_includes_sensitive_fields() {
     // `super_admin` is strictly more privileged than `admin`; if `admin`
-    // sees the review fields, super-admin must as well.
+    // sees the full payload, super-admin must as well.
     let (app, db) = test_app_with_auth_and_db().await;
-    seed_admin_review_fields_on_receipt_one(&db).await;
+    seed_strippable_fields_on_receipt_one(&db).await;
 
     let resp = call(app, get_jwt_with("/api/receipts", &super_admin_bearer())).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -1962,6 +2015,10 @@ async fn get_receipts_super_admin_token_includes_admin_review_fields() {
         .expect("receipt 1 must be in the listing");
     assert_eq!(r["rawImageUrl"], "https://example.invalid/screenshot.png");
     assert_eq!(r["rejectionReason"], "needs manual review");
+    assert_eq!(r["ocrText"], "NGN 1,000,000.00\nFrom: Tunde Bakare");
+    assert_eq!(r["senderLabel"], "Tunde Bakare");
+    assert_eq!(r["bankLabel"], "GTBank");
+    assert!(r["senderPhone"].is_string());
 }
 
 // ── POST /api/admin/receipts/{id}/confirm ────────────────────────────────────
@@ -2583,7 +2640,11 @@ async fn pagination_excludes_soft_deleted_receipts_from_total_count() {
     // The receipts fixture seeds two rows — one active, one
     // soft-deleted. After filtering, the count + body should both
     // surface only the active row.
-    let resp = call(test_app().await, get("/api/receipts?limit=200")).await;
+    let resp = call(
+        test_app_with_auth().await,
+        get_jwt_with("/api/receipts?limit=200", &admin_bearer()),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
     let total = total_count_header(&resp);
     let receipts: Vec<serde_json::Value> = json_body(resp).await;
@@ -3099,7 +3160,11 @@ async fn inbox_count_gates_admin_landing_when_zero() {
     // after every pending fixture row is acted on, the queue drains.
     let app = test_app_with_auth().await;
 
-    let before = call(app.clone(), get("/api/receipts?status=pending&limit=200")).await;
+    let before = call(
+        app.clone(),
+        get_jwt_with("/api/receipts?status=pending&limit=200", &admin_bearer()),
+    )
+    .await;
     let pre: Vec<serde_json::Value> = json_body(before).await;
     assert!(
         !pre.is_empty(),
@@ -3119,7 +3184,11 @@ async fn inbox_count_gates_admin_landing_when_zero() {
         assert_eq!(resp.status(), StatusCode::OK, "reject {id}");
     }
 
-    let after = call(app, get("/api/receipts?status=pending&limit=200")).await;
+    let after = call(
+        app,
+        get_jwt_with("/api/receipts?status=pending&limit=200", &admin_bearer()),
+    )
+    .await;
     let post: Vec<serde_json::Value> = json_body(after).await;
     assert!(
         post.is_empty(),
@@ -3227,7 +3296,11 @@ async fn admin_receipt_queue_orders_by_ingested_at_not_received_at() {
     )
     .await;
 
-    let resp = call(app, get("/api/receipts?limit=200")).await;
+    let resp = call(
+        app,
+        get_jwt_with("/api/receipts?limit=200", &admin_bearer()),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK);
     let rows: Vec<serde_json::Value> = json_body(resp).await;
 

--- a/tests/webhook_integration.rs
+++ b/tests/webhook_integration.rs
@@ -55,8 +55,15 @@ async fn webhook_app() -> Router {
     init_env();
     let conn = db::init_memory().await.expect("init test DB");
     seed_link(&conn).await;
+    seed_admin_user(&conn).await;
     api::router(conn)
 }
+
+/// Test fixture: an `admin`-role user that backs the admin Bearer used to
+/// list receipts through `/api/receipts`. The listing route is gated by
+/// `AuthenticatedUser`, and the role is re-read from the DB row on every
+/// request, so a real `user` record (not just a signed JWT) is required.
+const TEST_WEBHOOK_ADMIN_SUB: &str = "webhook-test-admin";
 
 /// Seed a `group_link` for the fixture group so the matcher resolves
 /// `LINKED_CHAT_ID` → group `1` (and therefore can find the seeded members).
@@ -76,6 +83,56 @@ async fn seed_link(db: &poolpay::db::DbConn) {
         .content(content)
         .await
         .expect("seed group_link");
+}
+
+/// Seed the `admin` fixture user the listing assertions authenticate as.
+/// Mirrors the shape produced by `tests/api_integration.rs` so the role
+/// re-read inside `AuthenticatedUser` resolves to `admin` and the full
+/// payload is returned.
+async fn seed_admin_user(db: &poolpay::db::DbConn) {
+    use poolpay::api::models::{now_iso, DbUser, UserContent};
+    let now = now_iso();
+    let content = UserContent {
+        email: format!("{TEST_WEBHOOK_ADMIN_SUB}@test.local"),
+        email_normalised: format!("{TEST_WEBHOOK_ADMIN_SUB}@test.local"),
+        password_hash: None,
+        role: "admin".into(),
+        status: "active".into(),
+        token_version: 0,
+        must_reset_password: false,
+        version: 1,
+        created_at: now.clone(),
+        updated_at: now,
+        deleted_at: None,
+    };
+    let _: Option<DbUser> = db
+        .upsert(("user", TEST_WEBHOOK_ADMIN_SUB))
+        .content(content)
+        .await
+        .expect("seed webhook admin user");
+}
+
+/// Mint a Bearer for `TEST_WEBHOOK_ADMIN_SUB` signed by the process-shared
+/// verifier so `AuthenticatedUser` accepts it. The verifier is the same
+/// instance the router uses to verify, so a freshly-minted token round-trips.
+fn admin_bearer() -> String {
+    let token = poolpay::api::shared_verifier()
+        .mint_access(TEST_WEBHOOK_ADMIN_SUB, "admin", 0)
+        .expect("shared verifier must mint");
+    format!("Bearer {token}")
+}
+
+/// Build an authenticated GET for the listing — every webhook test that
+/// reads `/api/receipts` is verifying that the ingest path actually
+/// persisted, so it needs to bypass the public auth gate that the listing
+/// otherwise enforces.
+fn authed_get(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("authorization", admin_bearer())
+        .body(Body::empty())
+        .unwrap()
 }
 
 fn now_ts() -> i64 {
@@ -360,15 +417,7 @@ async fn webhook_concurrent_duplicate_deliveries_persist_single_row() {
 
     // And exactly one row must persist for the message id — the whole point
     // of the unique index is that the second insert never lands.
-    let list = call(
-        app,
-        Request::builder()
-            .method(Method::GET)
-            .uri("/api/receipts?limit=200")
-            .body(Body::empty())
-            .unwrap(),
-    )
-    .await;
+    let list = call(app, authed_get("/api/receipts?limit=200")).await;
     assert_eq!(list.status(), StatusCode::OK);
     let receipts: Vec<serde_json::Value> = json_body(list).await;
     let persisted: Vec<_> = receipts
@@ -537,18 +586,11 @@ async fn webhook_trims_whitespace_padded_fields_and_routes() {
         .to_string();
 
     // Confirm the row persisted with canonical (trimmed) identifier
-    // values. `/api/receipts` exposes `chatId`, `senderPhone`, and
-    // `whatsappMessageId` to anonymous callers; `rawImageUrl` is admin-
-    // gated and exercised in unit coverage of the trim path itself.
-    let list = call(
-        app,
-        Request::builder()
-            .method(Method::GET)
-            .uri("/api/receipts?limit=200")
-            .body(Body::empty())
-            .unwrap(),
-    )
-    .await;
+    // values. The listing strips bot-supplied content + sender PII for
+    // non-admin callers, so we authenticate as the seeded admin to read
+    // back the full payload — the trim assertions then exercise
+    // `whatsappMessageId`, `chatId`, and `senderPhone` end-to-end.
+    let list = call(app, authed_get("/api/receipts?limit=200")).await;
     assert_eq!(list.status(), StatusCode::OK);
     let receipts: Vec<serde_json::Value> = json_body(list).await;
     let row = receipts
@@ -575,10 +617,11 @@ async fn webhook_persists_receipt_row_visible_to_admin_list() {
     // up in `GET /api/receipts`. Confirms the receipt row materialises
     // through the same listing the FE admin queue consumes.
     //
-    // `GET /api/receipts` is a public read endpoint, so it deliberately
-    // strips bot-supplied (`rawImageUrl`) and admin-supplied
-    // (`rejectionReason`) fields — we assert the row appears and carries
-    // the public identifiers, and that the sensitive fields are absent.
+    // The listing is gated by `AuthenticatedUser` and returns the full
+    // payload (including `rawImageUrl` and `rejectionReason`) to admin
+    // callers — so we authenticate as the seeded admin and assert that
+    // the ingested row appears in the admin projection. The strip
+    // behaviour for non-admin callers is covered in `api_integration.rs`.
     let app = webhook_app().await;
     let body = payload_matching_member("WAMSG-PERSIST");
 
@@ -590,15 +633,7 @@ async fn webhook_persists_receipt_row_visible_to_admin_list() {
         .expect("ingested response must carry receiptId")
         .to_string();
 
-    let list = call(
-        app,
-        Request::builder()
-            .method(Method::GET)
-            .uri("/api/receipts?limit=200")
-            .body(Body::empty())
-            .unwrap(),
-    )
-    .await;
+    let list = call(app, authed_get("/api/receipts?limit=200")).await;
     assert_eq!(list.status(), StatusCode::OK);
     let receipts: Vec<serde_json::Value> = json_body(list).await;
     let row = receipts
@@ -606,12 +641,8 @@ async fn webhook_persists_receipt_row_visible_to_admin_list() {
         .find(|r| r["id"] == receipt_id)
         .expect("ingested receipt must appear in /api/receipts");
     assert_eq!(row["whatsappMessageId"], "WAMSG-PERSIST");
-    assert!(
-        row.get("rawImageUrl").is_none(),
-        "public /api/receipts must not expose bot-supplied rawImageUrl"
-    );
-    assert!(
-        row.get("rejectionReason").is_none(),
-        "public /api/receipts must not expose admin-supplied rejectionReason"
-    );
+    // `payload_matching_member` ships `rawImageUrl` and the ingest path
+    // persists it verbatim, so an admin caller must read it back from the
+    // listing — this is the read path admins use to triage the queue.
+    assert_eq!(row["rawImageUrl"], "https://example.com/receipt.jpg");
 }


### PR DESCRIPTION
## Summary

Closes #50.

Three commits, each atomic:

1. **[REFACTOR]** Flip `Receipt.sender_phone` to `Option<String>` so it can be stripped. Pure-internal change — the public JSON is unchanged until commit 2 stomps it for non-admins.
2. **[SEC]** Gate `GET /api/receipts` behind `AuthenticatedUser`. Anonymous → 401. Members get a stripped projection. Admins see the full payload (they need it to triage the queue).
3. **[REMOVE]** Drop the now-unused `OptionalAuth` extractor.

## Threat closed

A compromised WhatsApp bot can plant attacker-controlled strings into the bot-supplied content fields (`ocrText`, `senderLabel`, `bankLabel`, `rawImageUrl`). Before this change those fields, plus `senderPhone` (PII), were reachable from an unauthenticated `GET /api/receipts` — turning a bot compromise into a public phishing / XSS / PII-scrape surface.

`AuthenticatedUser` re-reads the user role from the DB on every request (not from the JWT claim), so a stale or downgraded token cannot reach the admin projection by replaying an old claim.

## Strip set (members → admins)

| Field | Members | Admins | Reason for stripping |
|---|---|---|---|
| `rawImageUrl` | stripped | full | Bot-supplied URL (attacker-controllable) |
| `rejectionReason` | stripped | full | Admin-supplied note |
| `ocrText` | stripped | full | Bot-supplied OCR body |
| `senderPhone` | stripped | full | PII |
| `senderLabel` | stripped | full | Bot-parsed sender name |
| `bankLabel` | stripped | full | Bot-parsed bank name |

`whatsappMessageId`, `chatId`, `receivedAt`, amounts, and timestamps remain in both projections — routing identifiers and derived values that don't carry the same threat.

## Why gate over field-filter alone

The previous implementation chose field-filter on a public route — the same pattern OWASP API Top 10 #3 calls out as brittle (every new field needs to be remembered in the strip list, and slice 5 demonstrated the failure mode by adding four new bot fields and stripping only two). Default-deny on the route is the industry posture for endpoints surfacing user / bot-supplied content. The split-by-route option (#3 in the issue) is overkill today because there is no genuine anonymous consumer of this listing.

## Test plan

- [x] `cargo build --tests` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 405 tests pass
- [x] Anonymous `GET /api/receipts` → 401 (`get_receipts_no_auth_header_returns_401`, `get_receipts_anonymous_returns_401`)
- [x] Member token → 200 with stripped projection (`get_receipts_member_token_strips_sensitive_fields`)
- [x] Admin token → 200 with full payload (`get_receipts_admin_token_includes_sensitive_fields`)
- [x] Super-admin token → 200 with full payload (`get_receipts_super_admin_token_includes_sensitive_fields`)
- [x] All existing receipt-listing tests updated to authenticate
- [x] Webhook persistence tests authenticate as a seeded admin (new `seed_admin_user` + `authed_get` helpers in `webhook_integration.rs`)