### PR TITLE
[REMOVE] - Drop legacy POST receipt confirm/reject routes (#51)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1058,9 +1058,9 @@ fn sanitise_reason(reason: Option<String>) -> Result<Option<String>, AppError> {
     }
 }
 
-/// Unified action dispatcher. The legacy POST `/api/admin/receipts/{id}/{confirm,reject}`
-/// routes stay alive and delegate to the same `_inner` helpers, so this
-/// endpoint and the legacy routes cannot diverge.
+/// Unified action dispatcher for receipt admin actions. Routes
+/// `confirm` / `reject` / `flag` through the shared `_inner` helpers so
+/// every path runs the same state-transition + audit logic.
 pub async fn patch_receipt(
     user: AuthenticatedUser,
     State(db): State<DbConn>,
@@ -1092,24 +1092,6 @@ pub async fn patch_receipt(
             "unknown action '{other}'; must be one of confirm, reject, flag"
         ))),
     }
-}
-
-// Legacy POST routes ----------------------------------------------------------
-
-pub async fn confirm_receipt(
-    user: AuthenticatedUser,
-    State(db): State<DbConn>,
-    Path(id): Path<EntityId>,
-) -> Result<Json<Receipt>, AppError> {
-    confirm_receipt_inner(user, &db, &id).await
-}
-
-pub async fn reject_receipt(
-    user: AuthenticatedUser,
-    State(db): State<DbConn>,
-    Path(id): Path<EntityId>,
-) -> Result<Json<Receipt>, AppError> {
-    reject_receipt_inner(user, &db, &id, None).await
 }
 
 // Action handlers -------------------------------------------------------------

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -17,11 +17,10 @@ use crate::auth::jwt::{JwtConfig, SharedVerifier, StaticKeyVerifier};
 use crate::auth::rate_limit::{self, CredentialFailureLimiter, RateLimitConfig};
 use crate::db::DbConn;
 use handlers::{
-    confirm_receipt, create_cycle, create_group, create_member, create_payment,
-    create_whatsapp_link, delete_cycle, delete_group, delete_member, delete_payment,
-    delete_whatsapp_link, get_cycles, get_groups, get_members, get_payments, get_receipts,
-    get_whatsapp_links, patch_receipt, reject_receipt, reset_db, update_cycle, update_group,
-    update_member,
+    create_cycle, create_group, create_member, create_payment, create_whatsapp_link, delete_cycle,
+    delete_group, delete_member, delete_payment, delete_whatsapp_link, get_cycles, get_groups,
+    get_members, get_payments, get_receipts, get_whatsapp_links, patch_receipt, reset_db,
+    update_cycle, update_group, update_member,
 };
 use std::sync::{Arc, OnceLock};
 
@@ -113,13 +112,7 @@ pub fn router_with_config(
         .route("/api/admin/groups/{gid}/cycles", post(create_cycle))
         .route("/api/admin/cycles/{id}", patch(update_cycle))
         .route("/api/admin/cycles/{id}", delete(delete_cycle))
-        // Admin Receipt endpoints. The legacy confirm/reject POST routes
-        // stay live alongside the new unified PATCH /api/receipts/{id} so
-        // the FE can migrate without a synchronised cut; slice 6 drops
-        // the POST routes once callers have moved across.
-        .route("/api/admin/receipts/{id}/confirm", post(confirm_receipt))
-        .route("/api/admin/receipts/{id}/reject", post(reject_receipt))
-        // Slice 5 unified action endpoint. Accepts
+        // Unified action endpoint for receipt admin actions. Accepts
         // `{ action: 'confirm' | 'reject' | 'flag', reason?: string }`
         // and gates on `GroupScopedAdmin` via the inner helpers.
         .route("/api/receipts/{id}", patch(patch_receipt))

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -283,19 +283,6 @@ fn delete_req_jwt_with(uri: &str, bearer: &str) -> Request<Body> {
         .unwrap()
 }
 
-fn post_empty_jwt(uri: &str) -> Request<Body> {
-    post_empty_jwt_with(uri, &super_admin_bearer())
-}
-
-fn post_empty_jwt_with(uri: &str, bearer: &str) -> Request<Body> {
-    Request::builder()
-        .method(Method::POST)
-        .uri(uri)
-        .header("authorization", bearer)
-        .body(Body::empty())
-        .unwrap()
-}
-
 fn get_jwt(uri: &str) -> Request<Body> {
     get_jwt_with(uri, &super_admin_bearer())
 }
@@ -2017,183 +2004,6 @@ async fn get_receipts_super_admin_token_includes_sensitive_fields() {
     assert!(r["senderPhone"].is_string());
 }
 
-// ── POST /api/admin/receipts/{id}/confirm ────────────────────────────────────
-
-#[tokio::test]
-async fn confirm_receipt_requires_auth() {
-    let app = test_app_with_auth().await;
-    let resp = call(app, post_empty("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn confirm_receipt_unknown_id_returns_404() {
-    let app = test_app_with_auth().await;
-    let resp = call(
-        app,
-        post_empty_jwt("/api/admin/receipts/does-not-exist/confirm"),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn confirm_receipt_soft_deleted_returns_404() {
-    // Fixture receipt id 2 is soft-deleted.
-    let app = test_app_with_auth().await;
-    let resp = call(app, post_empty_jwt("/api/admin/receipts/2/confirm")).await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn confirm_receipt_marks_status_and_creates_payment() {
-    let (app, db) = test_app_with_auth_and_db().await;
-
-    let payments_before: Vec<serde_json::Value> =
-        json_body(call(app.clone(), get("/api/payments")).await).await;
-    let baseline = payments_before.len();
-
-    let resp = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let updated: serde_json::Value = json_body(resp).await;
-    assert_eq!(updated["status"], "confirmed");
-    assert_eq!(updated["id"], "1");
-    // Audit: the confirming admin is recorded on the receipt row itself.
-    assert_eq!(updated["confirmedBy"], TEST_SUPER_ADMIN_SUB);
-
-    let payments_after: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/payments")).await).await;
-    assert_eq!(payments_after.len(), baseline + 1);
-
-    let new_payment = payments_after
-        .iter()
-        .find(|p| p["reference"] == "3EB0C123ABCD4567EF89")
-        .expect("expected new payment referencing the receipt's whatsapp message id");
-    assert_eq!(new_payment["memberId"], "4");
-    assert_eq!(new_payment["cycleId"], "3");
-    assert_eq!(new_payment["amount"], 1_000_000);
-    assert_eq!(new_payment["currency"], "NGN");
-    assert!(new_payment["confirmedAt"].is_string());
-    // Audit: same admin is attributed on the payment created from the receipt.
-    assert_eq!(new_payment["confirmedBy"], TEST_SUPER_ADMIN_SUB);
-
-    // Audit: the `auth_event` row carries the linked member as the subject
-    // (user_id), not null. Receipt 1's fixture has member_id="4".
-    use surrealdb_types::SurrealValue;
-    #[derive(Debug, serde::Deserialize, SurrealValue)]
-    struct AuthEventRow {
-        user_id: Option<String>,
-        actor_id: Option<String>,
-        success: bool,
-    }
-    let rows: Vec<AuthEventRow> = db
-        .query(
-            "SELECT user_id, actor_id, success FROM auth_event \
-             WHERE event_type = 'receipt_confirmed' AND success = true",
-        )
-        .await
-        .expect("select auth_event")
-        .take(0)
-        .expect("decode auth_event rows");
-    let event = rows
-        .into_iter()
-        .find(|r| r.success && r.actor_id.as_deref() == Some(TEST_SUPER_ADMIN_SUB))
-        .expect("expected successful receipt_confirmed auth_event for this admin");
-    assert_eq!(
-        event.user_id.as_deref(),
-        Some("4"),
-        "auth_event.user_id should be the linked member id, not null"
-    );
-}
-
-#[tokio::test]
-async fn confirm_receipt_twice_returns_409() {
-    let app = test_app_with_auth().await;
-    let first = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(first.status(), StatusCode::OK);
-    let second = call(app, post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(second.status(), StatusCode::CONFLICT);
-}
-
-#[tokio::test]
-async fn confirm_receipt_with_existing_payment_for_member_cycle_returns_409() {
-    // Pre-create a payment for the same member+cycle referenced by receipt 1,
-    // then confirm the receipt and verify the duplicate-payment guard returns
-    // HTTP 409 Conflict.
-    let app = test_app_with_auth().await;
-    let create = post_json_jwt(
-        "/api/payments",
-        serde_json::json!({
-            "memberId": "4",
-            "cycleId": "3",
-            "amount": 1_000_000,
-            "currency": "NGN",
-            "paymentDate": "2026-03-02"
-        }),
-    );
-    let create_resp = call(app.clone(), create).await;
-    assert_eq!(create_resp.status(), StatusCode::CREATED);
-
-    let resp = call(app, post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
-}
-
-// ── POST /api/admin/receipts/{id}/reject ─────────────────────────────────────
-
-#[tokio::test]
-async fn reject_receipt_requires_auth() {
-    let app = test_app_with_auth().await;
-    let resp = call(app, post_empty("/api/admin/receipts/1/reject")).await;
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn reject_receipt_unknown_id_returns_404() {
-    let app = test_app_with_auth().await;
-    let resp = call(app, post_empty_jwt("/api/admin/receipts/nope/reject")).await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn reject_receipt_marks_status_and_creates_no_payment() {
-    let app = test_app_with_auth().await;
-    let payments_before: Vec<serde_json::Value> =
-        json_body(call(app.clone(), get("/api/payments")).await).await;
-    let baseline = payments_before.len();
-
-    let resp = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/reject")).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let updated: serde_json::Value = json_body(resp).await;
-    assert_eq!(updated["status"], "rejected");
-    // Audit: rejecting admin is recorded so later reviewers can attribute the decision.
-    assert_eq!(updated["rejectedBy"], TEST_SUPER_ADMIN_SUB);
-
-    let payments_after: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/payments")).await).await;
-    assert_eq!(payments_after.len(), baseline);
-}
-
-#[tokio::test]
-async fn reject_receipt_already_rejected_returns_409() {
-    // Fixture receipt id 2 is rejected and soft-deleted, so reject hits 404.
-    // Use receipt 1: reject once, then try again.
-    let app = test_app_with_auth().await;
-    let first = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/reject")).await;
-    assert_eq!(first.status(), StatusCode::OK);
-    let second = call(app, post_empty_jwt("/api/admin/receipts/1/reject")).await;
-    assert_eq!(second.status(), StatusCode::CONFLICT);
-}
-
-#[tokio::test]
-async fn confirm_after_reject_returns_409() {
-    let app = test_app_with_auth().await;
-    let r = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/reject")).await;
-    assert_eq!(r.status(), StatusCode::OK);
-    let c = call(app, post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(c.status(), StatusCode::CONFLICT);
-}
-
 // ── GroupScopedAdmin guard (BE-5b–e) ─────────────────────────────────────────
 //
 // These cases pin both branches of `require_group_scope` for every
@@ -2390,39 +2200,6 @@ async fn delete_payment_admin_without_group_admin_returns_403() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
-#[tokio::test]
-async fn confirm_receipt_admin_without_group_admin_returns_403() {
-    let app = test_app_with_auth().await;
-    let resp = call(
-        app,
-        post_empty_jwt_with("/api/admin/receipts/1/confirm", &admin_bearer()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn reject_receipt_admin_without_group_admin_returns_403() {
-    let app = test_app_with_auth().await;
-    let resp = call(
-        app,
-        post_empty_jwt_with("/api/admin/receipts/1/reject", &admin_bearer()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn reject_receipt_scoped_admin_proceeds() {
-    let app = test_app_with_auth().await;
-    let resp = call(
-        app,
-        post_empty_jwt_with("/api/admin/receipts/1/reject", &scoped_admin_bearer()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-}
-
 // ── Opaque-denial for unknown ids (cross-tenant existence probing) ───────────
 //
 // A non-scoped `admin` must not be able to distinguish "this id doesn't
@@ -2452,20 +2229,6 @@ async fn delete_cycle_unknown_id_denies_non_scoped_admin_opaquely() {
     let resp = call(
         app,
         delete_req_jwt_with("/api/admin/cycles/does-not-exist", &admin_bearer()),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn confirm_receipt_unknown_id_denies_non_scoped_admin_opaquely() {
-    let app = test_app_with_auth().await;
-    let resp = call(
-        app,
-        post_empty_jwt_with(
-            "/api/admin/receipts/does-not-exist/confirm",
-            &admin_bearer(),
-        ),
     )
     .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -3002,11 +2765,12 @@ async fn patch_receipt_confirm_rejects_reason_field() {
 
 // ── PATCH action behaviour — audit + payment integrity ───────────────────────
 //
-// These cases cover the behaviour previously asserted only against the
-// legacy POST /api/admin/receipts/{id}/{confirm,reject} routes. The PATCH
-// dispatcher routes through the same `*_receipt_inner` helpers, so the
-// behaviour is identical — but the legacy POST routes are being removed,
-// so the assertions need a live entry point.
+// Pins the receipt-action behaviour that lives inside the shared
+// `*_receipt_inner` helpers: audit fields on the receipt + payment rows,
+// the duplicate-payment guard, soft-delete + unknown-id surfacing,
+// state-transition refusal (double action / cross-action), the
+// `GroupScopedAdmin` matrix, and the ingested_at-sourced `payment_date`
+// guard against a hostile bot clock.
 
 #[tokio::test]
 async fn patch_receipt_confirm_creates_payment_with_correct_fields_and_audit_event() {
@@ -3510,40 +3274,6 @@ async fn inbox_count_gates_admin_landing_when_zero() {
 }
 
 // ── Bot-clock independence ────────────────────────────────────────────────────
-
-/// A bot that lies about `received_at` must NOT be able to backdate or
-/// future-date the resulting payment row. `payment_date` is sourced from
-/// the server-stamped `ingested_at`, so the bot-supplied timestamp is
-/// purely forensic.
-#[tokio::test]
-async fn confirm_receipt_sources_payment_date_from_ingested_at_not_received_at() {
-    let (app, db) = test_app_with_auth_and_db().await;
-
-    // Receipt 1 is a pre-seeded pending receipt linked to member 4 / cycle 3.
-    // Force a deliberate mismatch: bot claims a wildly future `received_at`,
-    // server stamped `ingested_at` lives in the recent past.
-    db.query(
-        "UPDATE receipt:`1` SET \
-             received_at = '2099-12-31T23:59:59+00:00', \
-             ingested_at = '2026-03-10T10:00:00.000Z'",
-    )
-    .await
-    .expect("rewrite receipt 1 timestamps");
-
-    let resp = call(app.clone(), post_empty_jwt("/api/admin/receipts/1/confirm")).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let payments: Vec<serde_json::Value> =
-        json_body(call(app, get("/api/payments?limit=200")).await).await;
-    let new_payment = payments
-        .iter()
-        .find(|p| p["reference"] == "3EB0C123ABCD4567EF89")
-        .expect("payment created from receipt 1");
-    assert_eq!(
-        new_payment["paymentDate"], "2026-03-10",
-        "payment_date must follow server ingested_at, not bot-supplied received_at"
-    );
-}
 
 /// The admin queue must order by the server-stamped `ingested_at`. A
 /// bot that lies about `received_at` (forward or backward) cannot move

--- a/tests/api_integration.rs
+++ b/tests/api_integration.rs
@@ -3000,6 +3000,323 @@ async fn patch_receipt_confirm_rejects_reason_field() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+// ── PATCH action behaviour — audit + payment integrity ───────────────────────
+//
+// These cases cover the behaviour previously asserted only against the
+// legacy POST /api/admin/receipts/{id}/{confirm,reject} routes. The PATCH
+// dispatcher routes through the same `*_receipt_inner` helpers, so the
+// behaviour is identical — but the legacy POST routes are being removed,
+// so the assertions need a live entry point.
+
+#[tokio::test]
+async fn patch_receipt_confirm_creates_payment_with_correct_fields_and_audit_event() {
+    // Beyond the "payment row materialises" check in
+    // `patch_receipt_confirm_creates_payment_and_inbox_item`, the resulting
+    // payment must carry the correct member/cycle/amount/currency/reference
+    // fields, the confirming admin on both the receipt and payment rows,
+    // and a successful `auth_event` row attributing the action to the
+    // admin while recording the linked member as the subject.
+    let (app, db) = test_app_with_auth_and_db().await;
+
+    let payments_before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get("/api/payments")).await).await;
+    let baseline = payments_before.len();
+
+    let resp = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let updated: serde_json::Value = json_body(resp).await;
+    assert_eq!(updated["status"], "confirmed");
+    assert_eq!(updated["id"], "1");
+    assert_eq!(updated["confirmedBy"], TEST_SUPER_ADMIN_SUB);
+
+    let payments_after: Vec<serde_json::Value> =
+        json_body(call(app, get("/api/payments")).await).await;
+    assert_eq!(payments_after.len(), baseline + 1);
+
+    let new_payment = payments_after
+        .iter()
+        .find(|p| p["reference"] == "3EB0C123ABCD4567EF89")
+        .expect("expected new payment referencing the receipt's whatsapp message id");
+    assert_eq!(new_payment["memberId"], "4");
+    assert_eq!(new_payment["cycleId"], "3");
+    assert_eq!(new_payment["amount"], 1_000_000);
+    assert_eq!(new_payment["currency"], "NGN");
+    assert!(new_payment["confirmedAt"].is_string());
+    assert_eq!(new_payment["confirmedBy"], TEST_SUPER_ADMIN_SUB);
+
+    use surrealdb_types::SurrealValue;
+    #[derive(Debug, serde::Deserialize, SurrealValue)]
+    struct AuthEventRow {
+        user_id: Option<String>,
+        actor_id: Option<String>,
+        success: bool,
+    }
+    let rows: Vec<AuthEventRow> = db
+        .query(
+            "SELECT user_id, actor_id, success FROM auth_event \
+             WHERE event_type = 'receipt_confirmed' AND success = true",
+        )
+        .await
+        .expect("select auth_event")
+        .take(0)
+        .expect("decode auth_event rows");
+    let event = rows
+        .into_iter()
+        .find(|r| r.success && r.actor_id.as_deref() == Some(TEST_SUPER_ADMIN_SUB))
+        .expect("expected successful receipt_confirmed auth_event for this admin");
+    assert_eq!(
+        event.user_id.as_deref(),
+        Some("4"),
+        "auth_event.user_id should be the linked member id, not null"
+    );
+}
+
+#[tokio::test]
+async fn patch_receipt_reject_creates_no_payment_and_records_admin() {
+    // Symmetric audit guard for reject: the rejecting admin is recorded on
+    // the receipt row, and no payment row is created. Status + reason are
+    // covered separately by `patch_receipt_reject_returns_200_and_persists_reason`.
+    let app = test_app_with_auth().await;
+    let payments_before: Vec<serde_json::Value> =
+        json_body(call(app.clone(), get("/api/payments")).await).await;
+    let baseline = payments_before.len();
+
+    let resp = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "reject"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let updated: serde_json::Value = json_body(resp).await;
+    assert_eq!(updated["status"], "rejected");
+    assert_eq!(updated["rejectedBy"], TEST_SUPER_ADMIN_SUB);
+
+    let payments_after: Vec<serde_json::Value> =
+        json_body(call(app, get("/api/payments")).await).await;
+    assert_eq!(payments_after.len(), baseline);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_with_existing_payment_for_member_cycle_returns_409() {
+    // Pre-create a payment for the same member+cycle referenced by receipt 1,
+    // then confirm the receipt and verify the duplicate-payment guard
+    // returns 409 Conflict instead of silently double-paying.
+    let app = test_app_with_auth().await;
+    let create = post_json_jwt(
+        "/api/payments",
+        serde_json::json!({
+            "memberId": "4",
+            "cycleId": "3",
+            "amount": 1_000_000,
+            "currency": "NGN",
+            "paymentDate": "2026-03-02"
+        }),
+    );
+    let create_resp = call(app.clone(), create).await;
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_unknown_id_returns_404_for_super_admin() {
+    // Super-admin path on a missing id: the opaque-denial cover only kicks
+    // in for non-scoped admins, so super-admins still receive a true 404.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/does-not-exist",
+            serde_json::json!({"action": "confirm"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn patch_receipt_reject_unknown_id_returns_404_for_super_admin() {
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt(
+            "/api/receipts/nope",
+            serde_json::json!({"action": "reject"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn patch_receipt_soft_deleted_returns_404() {
+    // Fixture receipt id 2 is soft-deleted — `load_active_receipt_opt`
+    // filters it out, so any action against it surfaces as 404.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt("/api/receipts/2", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn patch_receipt_double_reject_returns_409() {
+    // Reject once, then attempt a second reject — the status-transition
+    // guard inside `reject_receipt_inner` must surface a 409, not a
+    // silent idempotent success.
+    let app = test_app_with_auth().await;
+    let first = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "reject"})),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let second = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "reject"})),
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_after_reject_returns_409() {
+    // Cross-action transition: a rejected receipt cannot be revived via
+    // confirm. The transition matrix must refuse both directions
+    // symmetrically.
+    let app = test_app_with_auth().await;
+    let r = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "reject"})),
+    )
+    .await;
+    assert_eq!(r.status(), StatusCode::OK);
+    let c = call(
+        app,
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(c.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_admin_without_group_admin_returns_403() {
+    // `admin`-role user with no `group_admin` rows: must be refused by
+    // `require_group_scope` even on a receipt in a group that exists.
+    // Complements `patch_receipt_scoped_admin_denied_cross_group_returns_403`,
+    // which exercises "scoped admin on the wrong group" instead.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt_with(
+            "/api/receipts/1",
+            serde_json::json!({"action": "confirm"}),
+            &admin_bearer(),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn patch_receipt_reject_admin_without_group_admin_returns_403() {
+    // Symmetric guard for reject — same actor, same target, different action.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt_with(
+            "/api/receipts/1",
+            serde_json::json!({"action": "reject"}),
+            &admin_bearer(),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn patch_receipt_reject_scoped_admin_proceeds() {
+    // Positive branch: a scoped admin with `group_admin{user_id, group_id=1}`
+    // succeeds on a receipt in group 1.
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt_with(
+            "/api/receipts/1",
+            serde_json::json!({"action": "reject"}),
+            &scoped_admin_bearer(),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn patch_receipt_unknown_id_denies_non_scoped_admin_opaquely() {
+    // Cross-tenant existence probing guard: a non-scoped `admin` cannot
+    // tell "this id doesn't exist" from "this id is in a group you can't
+    // touch" — both collapse to 403. Super-admins keep their 404 path
+    // (covered by `patch_receipt_confirm_unknown_id_returns_404_for_super_admin`).
+    let app = test_app_with_auth().await;
+    let resp = call(
+        app,
+        patch_json_jwt_with(
+            "/api/receipts/does-not-exist",
+            serde_json::json!({"action": "confirm"}),
+            &admin_bearer(),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn patch_receipt_confirm_sources_payment_date_from_ingested_at_not_received_at() {
+    // A bot that lies about `received_at` must NOT be able to backdate or
+    // future-date the resulting payment row. `payment_date` is sourced
+    // from the server-stamped `ingested_at`, so a hostile bot timestamp
+    // is purely forensic.
+    let (app, db) = test_app_with_auth_and_db().await;
+
+    db.query(
+        "UPDATE receipt:`1` SET \
+             received_at = '2099-12-31T23:59:59+00:00', \
+             ingested_at = '2026-03-10T10:00:00.000Z'",
+    )
+    .await
+    .expect("rewrite receipt 1 timestamps");
+
+    let resp = call(
+        app.clone(),
+        patch_json_jwt("/api/receipts/1", serde_json::json!({"action": "confirm"})),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let payments: Vec<serde_json::Value> =
+        json_body(call(app, get("/api/payments?limit=200")).await).await;
+    let new_payment = payments
+        .iter()
+        .find(|p| p["reference"] == "3EB0C123ABCD4567EF89")
+        .expect("payment created from receipt 1");
+    assert_eq!(
+        new_payment["paymentDate"], "2026-03-10",
+        "payment_date must follow server ingested_at, not bot-supplied received_at"
+    );
+}
+
 // ── inbox_item side effects (Slice 5) ─────────────────────────────────────────
 //
 // Verifies the new inbox_item table behaves end-to-end: rows materialise


### PR DESCRIPTION
## Summary

Closes #51.

Two atomic commits:

1. **[TEST]** Port behaviour-unique legacy POST tests to PATCH (additive — repo still green with both route shapes covered).
2. **[REMOVE]** Drop the legacy routes, the thin wrapper handlers, their `use` imports, the now-redundant POST tests, and two helper fns (`post_empty_jwt` / `post_empty_jwt_with`) that lost all callers.

The PATCH dispatcher routes through the same `confirm_receipt_inner` / `reject_receipt_inner` helpers the legacy routes did, so the action behaviour is unchanged — only the HTTP envelope is removed.

## Verification

The legacy routes had no remaining first-party caller (issue notes the FE migrated to PATCH via `lib/actions/receipts.ts`). Coverage parity is preserved: every behaviour the legacy tests exercised now has a PATCH equivalent.

| Legacy POST test | New PATCH test |
|---|---|
| `confirm_receipt_marks_status_and_creates_payment` | `patch_receipt_confirm_creates_payment_with_correct_fields_and_audit_event` |
| `confirm_receipt_with_existing_payment_for_member_cycle_returns_409` | `patch_receipt_confirm_with_existing_payment_for_member_cycle_returns_409` |
| `confirm_receipt_unknown_id_returns_404` | `patch_receipt_confirm_unknown_id_returns_404_for_super_admin` |
| `confirm_receipt_soft_deleted_returns_404` | `patch_receipt_soft_deleted_returns_404` |
| `confirm_after_reject_returns_409` | `patch_receipt_confirm_after_reject_returns_409` |
| `confirm_receipt_admin_without_group_admin_returns_403` | `patch_receipt_confirm_admin_without_group_admin_returns_403` |
| `confirm_receipt_unknown_id_denies_non_scoped_admin_opaquely` | `patch_receipt_unknown_id_denies_non_scoped_admin_opaquely` |
| `confirm_receipt_sources_payment_date_from_ingested_at_not_received_at` | `patch_receipt_confirm_sources_payment_date_from_ingested_at_not_received_at` |
| `reject_receipt_unknown_id_returns_404` | `patch_receipt_reject_unknown_id_returns_404_for_super_admin` |
| `reject_receipt_marks_status_and_creates_no_payment` | `patch_receipt_reject_creates_no_payment_and_records_admin` |
| `reject_receipt_already_rejected_returns_409` | `patch_receipt_double_reject_returns_409` |
| `reject_receipt_admin_without_group_admin_returns_403` | `patch_receipt_reject_admin_without_group_admin_returns_403` |
| `reject_receipt_scoped_admin_proceeds` | `patch_receipt_reject_scoped_admin_proceeds` |
| `confirm_receipt_requires_auth` / `reject_receipt_requires_auth` | covered by every `patch_receipt_*` test going through `AuthenticatedUser` |
| `confirm_receipt_twice_returns_409` | covered by existing `patch_receipt_double_confirm_returns_409` |

## Test plan

- [x] `cargo build --tests` clean
- [x] `cargo test` — 402 tests pass (was 405, net −3: 13 new PATCH tests added, 16 legacy POST tests removed)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Grep confirms zero remaining references to the dropped symbols (`confirm_receipt` / `reject_receipt` thin wrappers, `post_empty_jwt` helpers, `/api/admin/receipts/{id}/{confirm,reject}` routes)