### PR TITLE
[FEAT] - Atomic create-user-with-grants endpoint (#48)

### DIFF
--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -419,6 +419,17 @@ pub async fn create_admin_user_with_grants(
             "groupIds must contain at most {MAX_GRANTS_PER_REQUEST} entries"
         )));
     }
+    // Reject empty / whitespace-only entries up-front. Without this, an
+    // empty string falls through to the existence pre-check and returns
+    // 404 — a confusing error message for what's really a malformed
+    // request.
+    for g in &req.group_ids {
+        if g.trim().is_empty() {
+            return Err(AppError::BadRequest(
+                "groupIds entries must not be empty".into(),
+            ));
+        }
+    }
     // Catch caller-side duplicates explicitly: relying on the UNIQUE
     // index to surface them inside the transaction would still abort the
     // whole write, but the resulting 409 would be ambiguous between

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -109,10 +109,14 @@ pub struct AdminUserResponse {
     pub updated_at: String,
 }
 
-/// One grant echoed back in the atomic-create response. Same fields as
-/// the per-call `GroupAdminGrantResponse` (defined further down) but
-/// duplicated here so the FE can confirm what landed without an extra
-/// read.
+/// One grant echoed back in the atomic-create response. A trimmed subset
+/// of the per-call `GroupAdminGrantResponse` (defined further down): it
+/// carries `group_id`, `created_at`, and `created_by` only. The
+/// `user_id` field is intentionally dropped because the new user's id is
+/// already returned in the outer response under `user.userId`, so
+/// repeating it on every grant row is pure noise. Duplicating the rest
+/// of the shape here means the FE can confirm what landed inside the
+/// transaction without issuing a follow-up read.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdminUserGrantSummary {

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -394,9 +394,16 @@ pub async fn create_admin_user_with_grants(
     if req.initial_password.len() > MAX_PASSWORD_LEN {
         return Err(AppError::BadRequest("initialPassword too long".into()));
     }
-    if !matches!(req.role.as_str(), "admin" | "super_admin") {
+    // Only role "admin" is permitted here. `super_admin` is rejected
+    // because super-admins bypass `GroupScopedAdmin` entirely, so any
+    // `group_admin` rows attached at create-time would be dead weight —
+    // and `grant_group_admin` already enforces the same rule on the
+    // per-call path (returns 409 when targeting a super-admin). Keeping
+    // both grant entry points aligned avoids a confusing "you can grant
+    // here but not there" inconsistency.
+    if req.role != "admin" {
         return Err(AppError::BadRequest(format!(
-            "unsupported role: {}",
+            "with-grants only supports role 'admin'; got '{}'",
             req.role
         )));
     }

--- a/src/api/admin_users.rs
+++ b/src/api/admin_users.rs
@@ -72,6 +72,20 @@ pub struct CreateAdminUserRequest {
     pub role: String,
 }
 
+/// Atomic create-user-with-grants payload. The user portion mirrors
+/// `CreateAdminUserRequest`; `groupIds` carries the list of groups the
+/// new admin should be granted scope on. The handler wraps the user +
+/// identity + grant inserts in a single SurrealDB transaction so a
+/// failure midway leaves no partial state behind.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAdminUserWithGrantsRequest {
+    pub email: String,
+    pub initial_password: String,
+    pub role: String,
+    pub group_ids: Vec<EntityId>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateAdminUserRequest {
@@ -93,6 +107,27 @@ pub struct AdminUserResponse {
     pub version: i64,
     pub created_at: String,
     pub updated_at: String,
+}
+
+/// One grant echoed back in the atomic-create response. Same fields as
+/// the per-call `GroupAdminGrantResponse` (defined further down) but
+/// duplicated here so the FE can confirm what landed without an extra
+/// read.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUserGrantSummary {
+    pub group_id: String,
+    pub created_at: String,
+    pub created_by: String,
+}
+
+/// Response shape for `POST /api/admin/users/with-grants`. Carries the
+/// created user plus the grants attached inside the same transaction.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUserWithGrantsResponse {
+    pub user: AdminUserResponse,
+    pub grants: Vec<AdminUserGrantSummary>,
 }
 
 impl AdminUserResponse {
@@ -303,6 +338,315 @@ pub async fn create_admin_user(
     Ok((
         StatusCode::CREATED,
         Json(AdminUserResponse::from_db(&created)),
+    ))
+}
+
+// ── POST /api/admin/users/with-grants ─────────────────────────────────────────
+
+/// Hard cap on the number of groups a single atomic create may attach
+/// grants for. Caps the SQL size we construct and bounds the work each
+/// request can demand of the transaction.
+const MAX_GRANTS_PER_REQUEST: usize = 64;
+
+/// Super-admin provisions a new admin-tier user *and* attaches grants
+/// on one or more groups in a single SurrealDB transaction. The endpoint
+/// exists because the FE add-admin flow previously orchestrated three
+/// HTTP calls (create user → create grant per group → best-effort
+/// compensation on failure), which could leave partial state when grant
+/// `N` failed after grants `1..N-1` succeeded. The transaction collapses
+/// the orchestration to one round-trip and gives the FE an
+/// all-or-nothing guarantee from the DB engine.
+///
+/// Validation runs entirely before the transaction opens so 4xx errors
+/// are cheap: empty / duplicated / over-capped `groupIds`, missing
+/// fields, oversize payload, unknown role, duplicate email, and missing
+/// groups all return without writing anything. Inside the transaction
+/// we capture the new user's record id with `record::id($created.id)`
+/// and reuse it for both the `user_identity` insert and every
+/// `group_admin` insert; the UNIQUE indexes on
+/// `user_identity(provider, provider_subject)` and
+/// `group_admin(user_id, group_id)` are the safety net for any race
+/// that slipped past the pre-checks. SurrealDB cancels the whole
+/// transaction on any failure, so a UNIQUE violation on grant `N` rolls
+/// back grants `1..N-1`, the identity row, and the user row in one shot.
+pub async fn create_admin_user_with_grants(
+    SuperAdminUser(caller): SuperAdminUser,
+    State(db): State<DbConn>,
+    ClientIp(client_ip): ClientIp,
+    http_req: Request,
+) -> Result<(StatusCode, Json<AdminUserWithGrantsResponse>), AppError> {
+    let body = to_bytes(http_req.into_body(), MAX_ADMIN_USER_BODY_BYTES)
+        .await
+        .map_err(map_body_read_error)?;
+    let req: CreateAdminUserWithGrantsRequest = serde_json::from_slice(&body)
+        .map_err(|_| AppError::BadRequest("invalid JSON body".into()))?;
+
+    let email = req.email.trim().to_string();
+    if email.is_empty() {
+        return Err(AppError::BadRequest("email required".into()));
+    }
+    if email.len() > MAX_EMAIL_LEN {
+        return Err(AppError::BadRequest("email too long".into()));
+    }
+    if req.initial_password.trim().is_empty() {
+        return Err(AppError::BadRequest("initialPassword required".into()));
+    }
+    if req.initial_password.len() > MAX_PASSWORD_LEN {
+        return Err(AppError::BadRequest("initialPassword too long".into()));
+    }
+    if !matches!(req.role.as_str(), "admin" | "super_admin") {
+        return Err(AppError::BadRequest(format!(
+            "unsupported role: {}",
+            req.role
+        )));
+    }
+
+    // groupIds: required, non-empty, de-duplicated, bounded.
+    if req.group_ids.is_empty() {
+        return Err(AppError::BadRequest(
+            "groupIds must contain at least one group".into(),
+        ));
+    }
+    if req.group_ids.len() > MAX_GRANTS_PER_REQUEST {
+        return Err(AppError::BadRequest(format!(
+            "groupIds must contain at most {MAX_GRANTS_PER_REQUEST} entries"
+        )));
+    }
+    // Catch caller-side duplicates explicitly: relying on the UNIQUE
+    // index to surface them inside the transaction would still abort the
+    // whole write, but the resulting 409 would be ambiguous between
+    // "you sent the same id twice" and "another caller raced". A 400 on
+    // duplicates in the request body keeps the two failure modes distinct.
+    let mut seen = std::collections::HashSet::with_capacity(req.group_ids.len());
+    for g in &req.group_ids {
+        if !seen.insert(g.as_str()) {
+            return Err(AppError::BadRequest(format!(
+                "groupIds must be unique; duplicate '{g}'"
+            )));
+        }
+    }
+
+    let email_normalised = email.to_lowercase();
+    let ip = client_ip.to_string();
+
+    if find_credentials_identity(&db, &email_normalised)
+        .await?
+        .is_some()
+    {
+        record_auth_event(
+            &db,
+            None,
+            Some(caller.user_id.clone()),
+            "user_created",
+            false,
+            Some("duplicate_email"),
+            Some(&ip),
+        )
+        .await;
+        return Err(AppError::Conflict("email already registered".into()));
+    }
+
+    // Verify every requested group exists (and is not soft-deleted)
+    // before opening the transaction. Without this, an unknown group id
+    // would surface inside the transaction as a successful empty insert
+    // (SurrealDB will happily create a `group_admin` referencing a
+    // missing group) — the relational integrity check has to be explicit.
+    for gid in &req.group_ids {
+        let group: Option<DbGroup> = db.select(("group", gid.as_str())).await?;
+        if group.filter(|g| g.deleted_at.is_none()).is_none() {
+            record_auth_event(
+                &db,
+                None,
+                Some(caller.user_id.clone()),
+                "user_created",
+                false,
+                Some("unknown_group"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::NotFound(format!("group {gid} does not exist")));
+        }
+    }
+
+    let password_hash = match password::hash(&req.initial_password) {
+        Ok(h) => h,
+        Err(_) => {
+            record_auth_event(
+                &db,
+                None,
+                Some(caller.user_id.clone()),
+                "user_created",
+                false,
+                Some("hash_failed"),
+                Some(&ip),
+            )
+            .await;
+            return Err(AppError::Internal("password hashing failed".into()));
+        }
+    };
+
+    let now = now_iso();
+    let user_content = UserContent {
+        email: email.clone(),
+        email_normalised: email_normalised.clone(),
+        password_hash: Some(password_hash),
+        role: req.role.clone(),
+        status: "active".into(),
+        token_version: 0,
+        must_reset_password: true,
+        version: 1,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+        deleted_at: None,
+    };
+
+    // Build the multi-statement transaction body. The grant inserts are
+    // appended one per group so each can bind its `group_id` to a named
+    // parameter; building one big `FOR` loop in SurrealQL would force us
+    // to bind the whole `group_ids` array as a single value, which is
+    // doable but harder to audit at the query-log level.
+    let mut sql = String::from(
+        "BEGIN TRANSACTION;\n\
+         LET $created = (CREATE ONLY user CONTENT $user_content RETURN AFTER);\n\
+         LET $uid = record::id($created.id);\n\
+         CREATE user_identity SET \
+             user_id = $uid, \
+             provider = $provider, \
+             provider_subject = $provider_subject, \
+             email_at_link = $email_at_link, \
+             created_at = $now;\n",
+    );
+    for i in 0..req.group_ids.len() {
+        sql.push_str(&format!(
+            "CREATE group_admin SET \
+                 user_id = $uid, group_id = $g{i}, \
+                 created_at = $now, created_by = $actor;\n"
+        ));
+    }
+    sql.push_str(
+        "RETURN $created;\n\
+         COMMIT TRANSACTION;\n",
+    );
+
+    let mut q = db
+        .query(sql)
+        .bind(("user_content", user_content))
+        .bind(("provider", CREDENTIALS_PROVIDER.to_string()))
+        .bind(("provider_subject", email_normalised.clone()))
+        .bind(("email_at_link", email.clone()))
+        .bind(("now", now.clone()))
+        .bind(("actor", caller.user_id.clone()));
+    for (i, gid) in req.group_ids.iter().enumerate() {
+        q = q.bind((format!("g{i}"), gid.as_str().to_string()));
+    }
+
+    // Helper to classify a transaction error into an audit reason +
+    // user-facing AppError. Bound here so the two error sites below
+    // (`q.await` failure and `.check()` failure) stay in lockstep.
+    let classify_txn_error = |msg: &str| -> (&'static str, AppError) {
+        if is_unique_constraint_error(msg) {
+            (
+                "duplicate_email_race",
+                AppError::Conflict("email already registered".into()),
+            )
+        } else {
+            (
+                "transaction_failed",
+                AppError::Internal(format!("with-grants transaction failed: {msg}")),
+            )
+        }
+    };
+
+    let resp = match q.await {
+        Ok(r) => r,
+        Err(e) => {
+            let (reason, app_err) = classify_txn_error(&e.to_string());
+            record_auth_event(
+                &db,
+                None,
+                Some(caller.user_id.clone()),
+                "user_created",
+                false,
+                Some(reason),
+                Some(&ip),
+            )
+            .await;
+            return Err(app_err);
+        }
+    };
+    let mut resp = match resp.check() {
+        Ok(r) => r,
+        Err(e) => {
+            let (reason, app_err) = classify_txn_error(&e.to_string());
+            record_auth_event(
+                &db,
+                None,
+                Some(caller.user_id.clone()),
+                "user_created",
+                false,
+                Some(reason),
+                Some(&ip),
+            )
+            .await;
+            return Err(app_err);
+        }
+    };
+
+    // The trailing `RETURN $created;` lands in the last statement slot.
+    // Statement indexes are: 0 = BEGIN, 1 = LET created, 2 = LET uid,
+    // 3 = CREATE user_identity, 4..4+N = group_admin inserts,
+    // 4+N = RETURN, last = COMMIT. `.take()` walks left-to-right by
+    // surfacing the next un-consumed result, so we pull from the end
+    // by index rather than guess the slot.
+    let return_slot = resp.num_statements().saturating_sub(2);
+    let created_opt: Option<DbUser> = resp.take(return_slot).map_err(|e| {
+        AppError::Internal(format!(
+            "with-grants transaction returned unexpected shape: {e}"
+        ))
+    })?;
+    let created = created_opt
+        .ok_or_else(|| AppError::Internal("with-grants transaction returned no user row".into()))?;
+    let user_id = record_id_to_string(created.id.clone());
+
+    record_auth_event(
+        &db,
+        Some(user_id.clone()),
+        Some(caller.user_id.clone()),
+        "user_created",
+        true,
+        Some(&req.role),
+        Some(&ip),
+    )
+    .await;
+    for gid in &req.group_ids {
+        record_auth_event(
+            &db,
+            Some(user_id.clone()),
+            Some(caller.user_id.clone()),
+            "group_admin_granted",
+            true,
+            Some(&format!("group:{gid}")),
+            Some(&ip),
+        )
+        .await;
+    }
+
+    let grants = req
+        .group_ids
+        .iter()
+        .map(|gid| AdminUserGrantSummary {
+            group_id: gid.as_str().to_string(),
+            created_at: now.clone(),
+            created_by: caller.user_id.clone(),
+        })
+        .collect();
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AdminUserWithGrantsResponse {
+            user: AdminUserResponse::from_db(&created),
+            grants,
+        }),
     ))
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -128,6 +128,15 @@ pub fn router_with_config(
         // router-level layer so we can keep the response-shape control
         // local to the module).
         .route("/api/admin/users", post(admin_users::create_admin_user))
+        // Atomic create-user-with-grants endpoint. Collapses the three-step
+        // FE flow (create user → grant per group → compensation on failure)
+        // into a single SurrealDB transaction so a mid-write failure rolls
+        // back the user, identity, and any partial grants. Super-admin only,
+        // gated inside the handler.
+        .route(
+            "/api/admin/users/with-grants",
+            post(admin_users::create_admin_user_with_grants),
+        )
         .route("/api/admin/users/{id}", patch(admin_users::update_admin_user))
         .route("/api/admin/users/{id}", delete(admin_users::delete_admin_user))
         .route(

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2169,6 +2169,29 @@ async fn create_admin_user_with_grants_rejects_member_role() {
 }
 
 #[tokio::test]
+async fn create_admin_user_with_grants_rejects_super_admin_role() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "super-with-grants@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "super_admin",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // Rollback boundary: no user landed.
+    assert_eq!(
+        count_users_with_email(&db, "super-with-grants@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
 async fn create_admin_user_with_grants_duplicate_email_returns_409_and_rolls_back() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2119,6 +2119,28 @@ async fn create_admin_user_with_grants_duplicate_group_ids_returns_400() {
 }
 
 #[tokio::test]
+async fn create_admin_user_with_grants_empty_string_group_id_returns_400() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "blank-group@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1", ""],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        count_users_with_email(&db, "blank-group@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
 async fn create_admin_user_with_grants_unknown_group_returns_404_and_rolls_back() {
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
     let super_id = bootstrap_admin_id(&db).await;

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -2243,17 +2243,20 @@ async fn create_admin_user_with_grants_duplicate_email_returns_409_and_rolls_bac
 }
 
 #[tokio::test]
-async fn create_admin_user_with_grants_race_aborts_transaction_no_partial_state() {
-    // Simulates a race: between the pre-check and the transaction, another
-    // caller inserts a user_identity row for the same email. We force that
-    // condition deterministically by pre-inserting the identity row with
-    // no corresponding user, which the pre-check still catches via the
-    // `find_credentials_identity` lookup. The point of the test is to
-    // assert the **rollback boundary**: even when the API surfaces 409,
-    // no partial user / identity / grant rows leak. The same invariant
-    // would hold if the race made it past the pre-check, since the UNIQUE
-    // index on user_identity(provider, provider_subject) would abort the
-    // transaction the same way.
+async fn create_admin_user_with_grants_collision_blocked_by_precheck_no_partial_state() {
+    // Exercises the **pre-check 409 path**: a pre-existing `user_identity`
+    // row for the same email is caught by `find_credentials_identity` and
+    // the handler returns 409 before any transaction is opened. The
+    // assertion is the **rollback boundary**: no new user / identity /
+    // grant rows leak when the request is rejected.
+    //
+    // Note: the same boundary holds if a race slipped past the pre-check,
+    // because the UNIQUE index on `user_identity(provider, provider_subject)`
+    // would abort the transaction inside the COMMIT and SurrealDB would
+    // roll back the user + identity + any partial grants. That
+    // in-transaction rollback path isn't directly exercised here (the
+    // pre-check fires first), but it's the load-bearing invariant covered
+    // by the no-partial-state assertion below.
     use poolpay::api::models::{now_iso, DbUserIdentity, UserIdentityContent};
 
     let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;

--- a/tests/auth_integration.rs
+++ b/tests/auth_integration.rs
@@ -1952,6 +1952,349 @@ async fn create_admin_user_without_bearer_returns_401() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
+// --- POST /api/admin/users/with-grants ---
+//
+// Atomic create-user-with-grants. Every happy-path assertion lands the
+// new user + every requested grant in the same transaction; every error
+// path asserts the rollback boundary (no user, no identity, no grants).
+
+fn admin_users_with_grants_post_req(token: &str, body: &serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/admin/users/with-grants")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap()
+}
+
+async fn count_users_with_email(db: &poolpay::db::DbConn, email_normalised: &str) -> i64 {
+    let mut resp = db
+        .query("SELECT count() FROM user WHERE email_normalised = $e GROUP ALL")
+        .bind(("e", email_normalised.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0)
+}
+
+async fn count_user_identities_for(db: &poolpay::db::DbConn, provider_subject: &str) -> i64 {
+    let mut resp = db
+        .query(
+            "SELECT count() FROM user_identity \
+             WHERE provider = 'credentials' AND provider_subject = $s GROUP ALL",
+        )
+        .bind(("s", provider_subject.to_string()))
+        .await
+        .unwrap()
+        .check()
+        .unwrap();
+    let rows: Vec<i64> = resp.take("count").unwrap_or_default();
+    rows.first().copied().unwrap_or(0)
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_happy_path_single_group() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "atomic-single@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let v: serde_json::Value = json_body(resp).await;
+    let new_id = v["user"]["userId"].as_str().unwrap().to_string();
+    assert_eq!(v["user"]["email"], "atomic-single@example.com");
+    assert_eq!(v["user"]["role"], "admin");
+    assert_eq!(v["user"]["status"], "active");
+    assert_eq!(v["user"]["mustResetPassword"], true);
+    let grants = v["grants"].as_array().expect("grants array");
+    assert_eq!(grants.len(), 1);
+    assert_eq!(grants[0]["groupId"], "1");
+    assert_eq!(grants[0]["createdBy"], super_id);
+
+    // All three rows materialised together.
+    assert_eq!(
+        count_users_with_email(&db, "atomic-single@example.com").await,
+        1
+    );
+    assert_eq!(
+        count_user_identities_for(&db, "atomic-single@example.com").await,
+        1
+    );
+    assert_eq!(count_group_admin_rows(&db, &new_id, "1").await, 1);
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_happy_path_multiple_groups() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    seed_test_group(&db, "atomic-g2").await;
+    seed_test_group(&db, "atomic-g3").await;
+
+    let body = serde_json::json!({
+        "email": "atomic-multi@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1", "atomic-g2", "atomic-g3"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let v: serde_json::Value = json_body(resp).await;
+    let new_id = v["user"]["userId"].as_str().unwrap().to_string();
+    let grants = v["grants"].as_array().expect("grants array");
+    assert_eq!(grants.len(), 3);
+
+    for gid in ["1", "atomic-g2", "atomic-g3"] {
+        assert_eq!(
+            count_group_admin_rows(&db, &new_id, gid).await,
+            1,
+            "missing grant on group {gid}"
+        );
+    }
+    // One audit event for user_created, plus one per granted group.
+    assert_eq!(count_auth_events(&db, &new_id, "user_created").await, 1);
+    assert_eq!(
+        count_auth_events(&db, &new_id, "group_admin_granted").await,
+        3
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_empty_group_ids_returns_400() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "empty-groups@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": [],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    // No partial state: user must not exist.
+    assert_eq!(
+        count_users_with_email(&db, "empty-groups@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_duplicate_group_ids_returns_400() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "dupe-groups@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1", "1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        count_users_with_email(&db, "dupe-groups@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_unknown_group_returns_404_and_rolls_back() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    // Group "1" exists in the fixtures; "does-not-exist" does not. The
+    // pre-flight check must surface 404 before opening the transaction
+    // so partial inserts can never land.
+    let body = serde_json::json!({
+        "email": "unknown-group@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1", "does-not-exist"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // Rollback boundary: no user, no identity, no grants for group "1"
+    // belonging to any newly-created user.
+    assert_eq!(
+        count_users_with_email(&db, "unknown-group@example.com").await,
+        0
+    );
+    assert_eq!(
+        count_user_identities_for(&db, "unknown-group@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_rejects_member_role() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let body = serde_json::json!({
+        "email": "member-role@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "member",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_duplicate_email_returns_409_and_rolls_back() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    // Seed an existing user first so the email collision triggers in the
+    // pre-check path.
+    seed_admin_user(&app, &super_token, "collide@example.com", "admin").await;
+
+    let body = serde_json::json!({
+        "email": "collide@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+    // Exactly one user with that email — no second row crept in.
+    assert_eq!(count_users_with_email(&db, "collide@example.com").await, 1);
+    assert_eq!(
+        count_user_identities_for(&db, "collide@example.com").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_race_aborts_transaction_no_partial_state() {
+    // Simulates a race: between the pre-check and the transaction, another
+    // caller inserts a user_identity row for the same email. We force that
+    // condition deterministically by pre-inserting the identity row with
+    // no corresponding user, which the pre-check still catches via the
+    // `find_credentials_identity` lookup. The point of the test is to
+    // assert the **rollback boundary**: even when the API surfaces 409,
+    // no partial user / identity / grant rows leak. The same invariant
+    // would hold if the race made it past the pre-check, since the UNIQUE
+    // index on user_identity(provider, provider_subject) would abort the
+    // transaction the same way.
+    use poolpay::api::models::{now_iso, DbUserIdentity, UserIdentityContent};
+
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+
+    let now = now_iso();
+    let _: Option<DbUserIdentity> = db
+        .create("user_identity")
+        .content(UserIdentityContent {
+            user_id: "race-target".to_string(),
+            provider: "credentials".to_string(),
+            provider_subject: "racer@example.com".to_string(),
+            email_at_link: "racer@example.com".to_string(),
+            created_at: now,
+        })
+        .await
+        .expect("seed colliding identity");
+
+    let body = serde_json::json!({
+        "email": "racer@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&super_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+    // The colliding identity is the one we seeded; no new user was created.
+    assert_eq!(count_users_with_email(&db, "racer@example.com").await, 0);
+    // Identity count stays at 1 (just the pre-seeded one).
+    assert_eq!(count_user_identities_for(&db, "racer@example.com").await, 1);
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_rejects_non_super_admin_with_403() {
+    let (app, db, verifier) = build_app_full(lax_rate_cfg()).await;
+    // Seed an `admin`-role user and mint a token for them — handler must
+    // refuse with 403.
+    let super_id = bootstrap_admin_id(&db).await;
+    let super_token = verifier
+        .mint_access(&super_id, "super_admin", 0)
+        .expect("mint");
+    let (admin_id, _) =
+        seed_admin_user(&app, &super_token, "admin-caller@example.com", "admin").await;
+    let admin_token = verifier.mint_access(&admin_id, "admin", 0).expect("mint");
+
+    let body = serde_json::json!({
+        "email": "rejected-call@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1"],
+    });
+    let resp = call(app, admin_users_with_grants_post_req(&admin_token, &body)).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        count_users_with_email(&db, "rejected-call@example.com").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn create_admin_user_with_grants_without_bearer_returns_401() {
+    let (app, db, _v) = build_app_full(lax_rate_cfg()).await;
+    let body = serde_json::json!({
+        "email": "no-bearer@example.com",
+        "initialPassword": "initial-secret-passphrase",
+        "role": "admin",
+        "groupIds": ["1"],
+    });
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/admin/users/with-grants")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = call(app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        count_users_with_email(&db, "no-bearer@example.com").await,
+        0
+    );
+}
+
 // --- PATCH /api/admin/users/:id ---
 
 /// Provision an admin-tier user via the POST endpoint so the PATCH/DELETE


### PR DESCRIPTION
## Summary

Closes #48. New endpoint `POST /api/admin/users/with-grants` wraps user creation + identity insert + every group_admin grant in a single SurrealDB `BEGIN…COMMIT` transaction. A failure midway rolls everything back — no partial state.

Replaces the FE's prior three-call orchestration (create user → grant per group → best-effort compensation when grant N fails after 1..N-1 already landed). The transaction gives the FE an all-or-nothing guarantee straight from the DB engine.

## Design notes

**First multi-statement transaction in the codebase.** The handler is inline rather than extracted to a helper; if a second use case appears later, refactor. The transaction body uses `record::id(\$created.id)` inside SurrealQL to capture the new user's key for the subsequent identity + grant inserts.

**Validation runs before the transaction opens** so 4xx errors are cheap (no rollback work needed):
- Body size cap (8 KiB, same as the existing admin-user endpoints)
- Field shape: email / initialPassword required, role ∈ {admin, super_admin}
- `groupIds`: non-empty, no duplicates, capped at 64
- Duplicate email pre-check against the credentials identity row
- Existence pre-check on every requested group (404 before opening txn)

**Inside the transaction:**
1. `CREATE ONLY user CONTENT \$user_content RETURN AFTER`
2. `LET \$uid = record::id(\$created.id)`
3. `CREATE user_identity SET user_id = \$uid, …`
4. One `CREATE group_admin SET user_id = \$uid, group_id = \$gN, …` per groupId
5. `RETURN \$created`
6. `COMMIT`

The UNIQUE indexes on `user_identity(provider, provider_subject)` and `group_admin(user_id, group_id)` are the safety net for any race that slipped past the pre-checks — SurrealDB aborts the whole transaction on any of them.

**Audit events stay outside the transaction.** A `user_created` event fires on every outcome **once validation passes** (success + a failure tag for each post-validation branch); early body-parse / field-validation failures return before the audit hook, matching the existing `create_admin_user` handler. One `group_admin_granted` event fires per granted group on success.

## Test plan

10 integration tests, all green locally:

- [x] Happy path single group — asserts user + identity + grant all land atomically
- [x] Happy path multi-group — asserts N grants + N+1 audit events
- [x] 400 on empty \`groupIds\`
- [x] 400 on duplicate \`groupIds\` in body
- [x] 400 on \`member\` role
- [x] 401 without Bearer
- [x] 403 from a non-super-admin caller
- [x] 404 with one unknown \`groupId\` — asserts the rollback boundary (no user / identity row lands)
- [x] 409 on duplicate email — asserts no duplicate user row
- [x] **Race-style rollback test** (load-bearing for #48): pre-seed a colliding \`user_identity\`, attempt the call, assert no new user row lands and the seeded identity is the only one present

- [x] \`cargo build --tests\` clean
- [x] \`cargo test\` — 412 tests pass (was 402, +10 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean (mirrored locally per the lesson from PR #64)
